### PR TITLE
[PoC] Use golomb-rice filters for mempool

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -83,6 +83,23 @@ public class BlockchainController : ControllerBase
 	}
 
 	/// <summary>
+	/// Gets mempool compact filter.
+	/// </summary>
+	[HttpGet("mempool-filter")]
+	[ResponseCache(Duration = 5)]
+	public async Task<IActionResult> GetMempoolCompactFilterAsync(CancellationToken cancellationToken = default)
+	{
+		var txIds = await Global.RpcClient.GetRawMempoolAsync(cancellationToken).ConfigureAwait(false);
+		var filter = new GolombRiceFilterBuilder()
+			.SetP(20)
+			.SetM(1 << 20)
+			.SetKey(uint256.Zero)
+			.AddEntries(txIds.Select(x => x.ToBytes()))
+			.Build();
+		return Ok(filter);
+	}
+
+	/// <summary>
 	/// Gets mempool hashes.
 	/// </summary>
 	/// <param name="compactness">Can strip the last x characters from the hashes.</param>

--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -65,26 +65,6 @@ public class LiveServerTests : IAsyncLifetime
 
 	[Theory]
 	[MemberData(nameof(GetNetworks))]
-	public async Task GetTransactionsAsync(Network network)
-	{
-		using CancellationTokenSource ctsTimeout = new(TimeSpan.FromMinutes(2));
-
-		WasabiClient client = MakeWasabiClient(network);
-		IEnumerable<uint256> randomTxIds = Enumerable.Range(0, 20).Select(_ => RandomUtils.GetUInt256());
-
-		// We don't really expect that the random strings represent some actual transactions.
-		IEnumerable<Transaction> retrievedTxs = await client.GetTransactionsAsync(network, randomTxIds.Take(4), ctsTimeout.Token);
-		Assert.Empty(retrievedTxs);
-
-		var mempoolTxIds = await client.GetMempoolHashesAsync(ctsTimeout.Token);
-		randomTxIds = Enumerable.Range(0, 5).Select(_ => mempoolTxIds.RandomElement(InsecureRandom.Instance)!).Distinct().ToArray();
-		var txs = await client.GetTransactionsAsync(network, randomTxIds, ctsTimeout.Token);
-		var returnedTxIds = txs.Select(tx => tx.GetHash());
-		Assert.Equal(returnedTxIds.OrderBy(x => x).ToArray(), randomTxIds.OrderBy(x => x).ToArray());
-	}
-
-	[Theory]
-	[MemberData(nameof(GetNetworks))]
 	public async Task GetVersionsTestsAsync(Network network)
 	{
 		using CancellationTokenSource ctsTimeout = new(TimeSpan.FromMinutes(2));

--- a/WalletWasabi/Blockchain/Mempool/MempoolService.cs
+++ b/WalletWasabi/Blockchain/Mempool/MempoolService.cs
@@ -100,14 +100,15 @@ public class MempoolService
 
 			Logger.LogInfo("Start cleaning out mempool...");
 			{
-				var compactness = 10;
-				var allMempoolHashes = await httpClientFactory.SharedWasabiClient.GetMempoolHashesAsync(compactness).ConfigureAwait(false);
+				var mempoolFilter = await httpClientFactory.SharedWasabiClient.GetMempoolFilterAsync().ConfigureAwait(false);
+				var zero = uint256.Zero.ToBytes();
+				var key = zero[..16];
 
 				int removedTxCount;
 
 				lock (ProcessedLock)
 				{
-					removedTxCount = ProcessedTransactionHashes.RemoveWhere(x => !allMempoolHashes.Contains(x.ToString()[..compactness]));
+					removedTxCount = ProcessedTransactionHashes.RemoveWhere(x => !mempoolFilter.Match(x.ToBytes(), key));
 				}
 
 				Logger.LogInfo($"{removedTxCount} transactions were removed from mempool.");

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -428,15 +428,14 @@ public class Wallet : BackgroundService, IWallet
 			try
 			{
 				var client = Synchronizer.HttpClientFactory.SharedWasabiClient;
-				var compactness = 10;
 
-				var mempoolHashes = await client.GetMempoolHashesAsync(compactness).ConfigureAwait(false);
-
+				var mempoolFilter = await client.GetMempoolFilterAsync().ConfigureAwait(false);
+				var filterKey = uint256.Zero.ToBytes();
 				var txsToProcess = new List<SmartTransaction>();
 				foreach (var tx in BitcoinStore.TransactionStore.MempoolStore.GetTransactions())
 				{
 					uint256 hash = tx.GetHash();
-					if (mempoolHashes.Contains(hash.ToString()[..compactness]))
+					if (mempoolFilter.Match(hash.ToBytes(), filterKey[..16]))
 					{
 						txsToProcess.Add(tx);
 						Logger.LogInfo($"'{WalletName}': Transaction was successfully tested against the backend's mempool hashes: {hash}.");

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -158,11 +158,11 @@ public class WasabiClient
 		await BroadcastAsync(transaction.Transaction).ConfigureAwait(false);
 	}
 
-	public async Task<IEnumerable<uint256>> GetMempoolHashesAsync(CancellationToken cancel = default)
+	public async Task<GolombRiceFilter> GetMempoolFilterAsync(CancellationToken cancel = default)
 	{
 		using HttpResponseMessage response = await HttpClient.SendAsync(
 			HttpMethod.Get,
-			$"api/v{ApiVersion}/btc/blockchain/mempool-hashes",
+			$"api/v{ApiVersion}/btc/blockchain/mempool-filter",
 			cancellationToken: cancel).ConfigureAwait(false);
 
 		if (response.StatusCode != HttpStatusCode.OK)
@@ -171,32 +171,8 @@ public class WasabiClient
 		}
 
 		using HttpContent content = response.Content;
-		var strings = await content.ReadAsJsonAsync<IEnumerable<string>>().ConfigureAwait(false);
-		var ret = strings.Select(x => new uint256(x));
-
-		return ret;
-	}
-
-	/// <summary>
-	/// Gets mempool hashes, but strips the last x characters of each hash.
-	/// </summary>
-	/// <param name="compactness">1 to 64</param>
-	public async Task<ISet<string>> GetMempoolHashesAsync(int compactness, CancellationToken cancel = default)
-	{
-		using HttpResponseMessage response = await HttpClient.SendAsync(
-			HttpMethod.Get,
-			$"api/v{ApiVersion}/btc/blockchain/mempool-hashes?compactness={compactness}",
-			cancellationToken: cancel).ConfigureAwait(false);
-
-		if (response.StatusCode != HttpStatusCode.OK)
-		{
-			await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
-		}
-
-		using HttpContent content = response.Content;
-		var strings = await content.ReadAsJsonAsync<ISet<string>>().ConfigureAwait(false);
-
-		return strings;
+		var filter = await content.ReadAsJsonAsync<GolombRiceFilter>().ConfigureAwait(false);
+		return filter;
 	}
 
 	#endregion blockchain


### PR DESCRIPTION
This PR allows Wasabi to download a compact filter (a compressed structure) to check whether or not a given transaction is in the backend's mempool or not. 