### PR TITLE
Save creation time of message in `ChatMessage`

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/AssistantMessageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/AssistantMessageViewModel.cs
@@ -6,27 +6,5 @@ public partial class AssistantMessageViewModel : MessageViewModel
 {
 	public AssistantMessageViewModel(ChatMessage message) : base(message)
 	{
-		string uiMessage = ParseRawMessage(message);
-		UiMessage = uiMessage;
-	}
-
-	private string ParseRawMessage(ChatMessage message)
-	{
-		string raw = message.Text;
-
-		// Check if the string starts with '@'
-		if (raw.StartsWith('@'))
-		{
-			// Find the index of the second '@'
-			int secondAt = raw.IndexOf('@', 1);
-
-			if (secondAt != -1 && long.TryParse(raw[1..secondAt], out _))
-			{
-				// Take the substring starting after the second '@'
-				raw = raw[(secondAt + 1)..];
-			}
-		}
-
-		return raw;
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/MessageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/MessageViewModel.cs
@@ -15,6 +15,28 @@ public abstract partial class MessageViewModel : ReactiveObject
 		_message = message;
 		IsUnread = message.IsUnread;
 		OriginalText = message.Text;
+		string uiMessage = ParseRawMessage(message);
+		UiMessage = uiMessage;
+	}
+
+	public string ParseRawMessage(ChatMessage message)
+	{
+		string raw = message.Text;
+
+		// Check if the string starts with '@'
+		if (raw.StartsWith('@'))
+		{
+			// Find the index of the second '@'
+			int secondAt = raw.IndexOf('@', 1);
+
+			if (secondAt != -1 && long.TryParse(raw[1..secondAt], out _))
+			{
+				// Take the substring starting after the second '@'
+				raw = raw[(secondAt + 1)..];
+			}
+		}
+
+		return raw;
 	}
 
 	public string? OriginalText { get; set; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/MessageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/MessageViewModel.cs
@@ -15,8 +15,7 @@ public abstract partial class MessageViewModel : ReactiveObject
 		_message = message;
 		IsUnread = message.IsUnread;
 		OriginalText = message.Text;
-		string uiMessage = ParseRawMessage(message);
-		UiMessage = uiMessage;
+		UiMessage = ParseRawMessage(message);
 	}
 
 	public string? OriginalText { get; set; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/MessageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/MessageViewModel.cs
@@ -19,6 +19,8 @@ public abstract partial class MessageViewModel : ReactiveObject
 		UiMessage = uiMessage;
 	}
 
+	public string? OriginalText { get; set; }
+
 	public string ParseRawMessage(ChatMessage message)
 	{
 		string raw = message.Text;
@@ -38,6 +40,4 @@ public abstract partial class MessageViewModel : ReactiveObject
 
 		return raw;
 	}
-
-	public string? OriginalText { get; set; }
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/PayNowAssistantMessageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/PayNowAssistantMessageViewModel.cs
@@ -39,7 +39,6 @@ public partial class PayNowAssistantMessageViewModel : AssistantMessageViewModel
 		IsPaid = invoice.IsPaid;
 		PaymentUrl = invoice.Bip21Link;
 		PayButtonText = IsPaid ? "Paid" : "Pay";
-		UiMessage = message.Text;
 
 		UiContext = uiContext;
 		_wallet = wallet;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/UserMessageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Messages/UserMessageViewModel.cs
@@ -46,7 +46,7 @@ public partial class UserMessageViewModel : MessageViewModel
 		Message = newMessage;
 		IsUnread = newMessage.IsUnread;
 		OriginalText = newMessage.Text;
-		UiMessage = newMessage.Text;
+		UiMessage = ParseRawMessage(newMessage);
 
 		Workflow.CurrentStep = currentStep;
 		Workflow.Conversation = editor.Conversation;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -185,7 +185,6 @@ public partial class OrderViewModel : ViewModelBase
 		{
 			return new UserMessageViewModel(Workflow, message)
 			{
-				UiMessage = message.Text,
 				OriginalText = message.Text,
 				IsUnread = message.IsUnread
 			};

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/WorkflowStep.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/Workflows/WorkflowStep.cs
@@ -168,7 +168,9 @@ public abstract partial class WorkflowStep<TValue> : ReactiveObject, IWorkflowSt
 
 			if (StringValue(value) is { } userMessage)
 			{
-				newMessage = newMessage with { Text = userMessage };
+				var timestamp = GetTimestampFromMessage(chatMessage);
+
+				newMessage = newMessage with { Text = timestamp + userMessage };
 				updatedConversation = updatedConversation.ReplaceMessage(chatMessage, newMessage);
 			}
 
@@ -176,6 +178,21 @@ public abstract partial class WorkflowStep<TValue> : ReactiveObject, IWorkflowSt
 		}
 
 		return newMessage;
+	}
+
+	private string GetTimestampFromMessage(ChatMessage message)
+	{
+		var text = message.Text;
+		if (text.StartsWith('@'))
+		{
+			int secondAt = text.IndexOf('@', 1);
+
+			if (secondAt != -1)
+			{
+				return text[0..(secondAt + 1)];
+			}
+		}
+		return "";
 	}
 
 	/// <summary>

--- a/WalletWasabi/BuyAnything/ChatMessage.cs
+++ b/WalletWasabi/BuyAnything/ChatMessage.cs
@@ -37,7 +37,7 @@ public record ChatMessage
 		IsUnread = isUnread;
 		StepName = stepName;
 		Data = data;
-		DateTime = ReadUnixTimestamp();
+		CreatedAt = ReadUnixTimestamp();
 	}
 
 	private DateTimeOffset ReadUnixTimestamp()
@@ -68,5 +68,5 @@ public record ChatMessage
 	public bool IsUnread { get; set; }
 	public string? StepName { get; }
 	public DataCarrier? Data { get; set; }
-	public DateTimeOffset DateTime { get; }
+	public DateTimeOffset CreatedAt { get; }
 }

--- a/WalletWasabi/BuyAnything/ChatMessage.cs
+++ b/WalletWasabi/BuyAnything/ChatMessage.cs
@@ -38,7 +38,6 @@ public record ChatMessage
 		IsUnread = isUnread;
 		StepName = stepName;
 		Data = data;
-
 		CreatedAt = ReadUnixTimestamp();
 	}
 

--- a/WalletWasabi/BuyAnything/ChatMessage.cs
+++ b/WalletWasabi/BuyAnything/ChatMessage.cs
@@ -40,6 +40,14 @@ public record ChatMessage
 		CreatedAt = ReadUnixTimestamp();
 	}
 
+	public bool IsMyMessage => Source == MessageSource.User;
+	public MessageSource Source { get; }
+	public string Text { get; set; }
+	public bool IsUnread { get; set; }
+	public string? StepName { get; }
+	public DataCarrier? Data { get; set; }
+	public DateTimeOffset CreatedAt { get; }
+
 	private DateTimeOffset ReadUnixTimestamp()
 	{
 		if (Text.StartsWith('@'))
@@ -60,13 +68,4 @@ public record ChatMessage
 
 		return now;
 	}
-
-	public bool IsMyMessage => Source == MessageSource.User;
-
-	public MessageSource Source { get; }
-	public string Text { get; set; }
-	public bool IsUnread { get; set; }
-	public string? StepName { get; }
-	public DataCarrier? Data { get; set; }
-	public DateTimeOffset CreatedAt { get; }
 }

--- a/WalletWasabi/BuyAnything/ConversationExtensions.cs
+++ b/WalletWasabi/BuyAnything/ConversationExtensions.cs
@@ -19,18 +19,18 @@ public static class ConversationExtensions
 		ConversationStatus newStatus) =>
 		conversation with
 		{
-			ChatMessages = new(conversation.ChatMessages.Append(new ChatMessage(MessageSource.Bot, message, IsUnread: true, null, data))),
+			ChatMessages = new(conversation.ChatMessages.Append(new ChatMessage(MessageSource.Bot, message, isUnread: true, null, data))),
 			ConversationStatus = newStatus
 		};
 
 	public static Conversation AddUserMessage(this Conversation conversation, string msg, string? stepName = null) =>
-		conversation with { ChatMessages = new(conversation.ChatMessages.Append(new ChatMessage(MessageSource.User, msg, IsUnread: false, stepName))) };
+		conversation with { ChatMessages = new(conversation.ChatMessages.Append(new ChatMessage(MessageSource.User, msg, isUnread: false, stepName))) };
 
 	public static Conversation AddBotMessage(this Conversation conversation, string msg, string? stepName = null, bool isUnread = true) =>
-		conversation with { ChatMessages = new(conversation.ChatMessages.Append(new ChatMessage(MessageSource.Bot, msg, IsUnread: isUnread, stepName))) };
+		conversation with { ChatMessages = new(conversation.ChatMessages.Append(new ChatMessage(MessageSource.Bot, msg, isUnread: isUnread, stepName))) };
 
 	public static Conversation AddAgentMessage(this Conversation conversation, string msg) =>
-		conversation with { ChatMessages = new(conversation.ChatMessages.Append(new ChatMessage(MessageSource.Agent, msg, IsUnread: true, null))) };
+		conversation with { ChatMessages = new(conversation.ChatMessages.Append(new ChatMessage(MessageSource.Agent, msg, isUnread: true, null))) };
 
 	public static Conversation UpdateMetadata(this Conversation conversation, Func<ConversationMetaData, ConversationMetaData> updateMetadata)
 	{


### PR DESCRIPTION
Partially fixes https://github.com/zkSNACKs/WalletWasabi/issues/12429

This is only business code. The time of creation now gets saved in the ChatMessage object, for both user and agent messages, but it's not visible anywhere, that will be a UI task. @zkSNACKs/ui-team 

What happened:
- Moved `ParseRawMessage` from `AssistantViewModel` and moved it to the base, `MessageViewModel`.
- This saves us from code duplication and will solve removing the ugly timestamp from every message.
- From some places I removed the setting of `UiMessage`, as now it's handled in the base class.
- Only exception is the `OfferMessageViewModel`, where it has to be overwritten.
- Added a small logic in `WorkflowStep.EditMessageAsync` so the timestamp from the raw text doesn't disappear.
- Expanded the `ChatMessage` record, so it reads `DateTime` from the Unix timestamp of the message. 