### PR TITLE
Banned coin check feature

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
@@ -38,7 +38,8 @@ public class AliceTimeoutTests
 		KeyChain keyChain = new(km, new Kitchen(ingredients: ""));
 
 		using CancellationTokenSource registrationCts = new();
-		Task<AliceClient> task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, smartCoin, keyChain, roundStateUpdater, registrationCts.Token, registrationCts.Token, confirmationCancellationToken: testDeadlineCts.Token);
+		using CancellationTokenSource coinBanCheckMode = new();
+		Task<AliceClient> task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, smartCoin, keyChain, roundStateUpdater, registrationCts.Token, registrationCts.Token, confirmationCancellationToken: testDeadlineCts.Token, coinBanCheckMode.Token);
 
 		while (round.Alices.Count == 0)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -210,6 +210,8 @@ public class StepOutputRegistrationTests
 	{
 		using CancellationTokenSource cancellationTokenSource = new(TestTimeout);
 		var token = cancellationTokenSource.Token;
+		using CancellationTokenSource coinBanCheckMode = new();
+		var coinBanCheckModeToken = coinBanCheckMode.Token;
 
 		// Get the round.
 		await arena.TriggerAndWaitRoundAsync(token);
@@ -221,8 +223,8 @@ public class StepOutputRegistrationTests
 
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
 		await roundStateUpdater.StartAsync(token);
-		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, token, token, token);
-		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, token, token, token);
+		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, token, token, token, coinBanCheckModeToken);
+		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, token, token, token, coinBanCheckModeToken);
 
 		while (Phase.ConnectionConfirmation != round.Phase)
 		{
@@ -252,6 +254,8 @@ public class StepOutputRegistrationTests
 	{
 		using CancellationTokenSource cancellationTokenSource = new(TestTimeout);
 		var token = cancellationTokenSource.Token;
+		using CancellationTokenSource coinBanCheckMode = new();
+		var coinBanCheckModeToken = coinBanCheckMode.Token;
 
 		WabiSabiConfig cfg = new()
 		{
@@ -282,8 +286,8 @@ public class StepOutputRegistrationTests
 
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
 		await roundStateUpdater.StartAsync(token);
-		var task1a = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round1), arenaClient1, coin1a, keyChain1, roundStateUpdater, token, token, token);
-		var task1b = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round1), arenaClient1, coin1b, keyChain1, roundStateUpdater, token, token, token);
+		var task1a = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round1), arenaClient1, coin1a, keyChain1, roundStateUpdater, token, token, token, coinBanCheckModeToken);
+		var task1b = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round1), arenaClient1, coin1b, keyChain1, roundStateUpdater, token, token, token, coinBanCheckModeToken);
 
 		while (Phase.ConnectionConfirmation != round1.Phase)
 		{
@@ -298,8 +302,8 @@ public class StepOutputRegistrationTests
 
 		var arenaClient2 = WabiSabiFactory.CreateArenaClient(arena, round2);
 
-		var task2a = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round2), arenaClient2, coin2a, keyChain2, roundStateUpdater, token, token, token);
-		var task2b = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round2), arenaClient2, coin2b, keyChain2, roundStateUpdater, token, token, token);
+		var task2a = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round2), arenaClient2, coin2a, keyChain2, roundStateUpdater, token, token, token, coinBanCheckModeToken);
+		var task2b = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round2), arenaClient2, coin2b, keyChain2, roundStateUpdater, token, token, token, coinBanCheckModeToken);
 
 		while (Phase.ConnectionConfirmation != round2.Phase)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -274,6 +274,8 @@ public class StepTransactionSigningTests
 	{
 		using CancellationTokenSource cancellationTokenSource = new(TestTimeout);
 		var token = cancellationTokenSource.Token;
+		using CancellationTokenSource coinBanCheckMode = new();
+		var coinBanCheckModeToken = coinBanCheckMode.Token;
 
 		// Create the round.
 		await arena.TriggerAndWaitRoundAsync(token);
@@ -285,8 +287,8 @@ public class StepTransactionSigningTests
 		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), arena);
 		await roundStateUpdater.StartAsync(token);
 
-		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, token, token, token);
-		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, token, token, token);
+		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, token, token, token, coinBanCheckModeToken);
+		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, token, token, token, coinBanCheckModeToken);
 
 		while (Phase.OutputRegistration != round.Phase)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -37,6 +37,8 @@ public class BobClientTests
 	{
 		using CancellationTokenSource cancellationTokenSource = new(TestTimeout);
 		var token = cancellationTokenSource.Token;
+		using CancellationTokenSource coinBanCheckMode = new();
+		var coinBanCheckModeToken = coinBanCheckMode.Token;
 
 		var config = new WabiSabiConfig { MaxInputCountByRound = 1 };
 		var round = WabiSabiFactory.CreateRound(config);
@@ -75,7 +77,7 @@ public class BobClientTests
 		await roundStateUpdater.StartAsync(token);
 
 		var keyChain = new KeyChain(km, new Kitchen(""));
-		var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), aliceArenaClient, coin1, keyChain, roundStateUpdater, token, token, token);
+		var task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), aliceArenaClient, coin1, keyChain, roundStateUpdater, token, token, token, coinBanCheckModeToken);
 
 		do
 		{

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Channels;
+using WabiSabi.Crypto.Randomness;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
@@ -80,7 +81,8 @@ public class Prison
 
 			var maxOffense = offenderHistory.Count == 0
 				? 1
-				: offenderHistory.Max( x => x switch {
+				: offenderHistory.Max(x => x switch
+				{
 					{ Method: RoundDisruptionMethod.DidNotConfirm } => configuration.PenaltyFactorForDisruptingConfirmation,
 					{ Method: RoundDisruptionMethod.DidNotSign } => configuration.PenaltyFactorForDisruptingSigning,
 					{ Method: RoundDisruptionMethod.DoubleSpent } => configuration.PenaltyFactorForDisruptingByDoubleSpending,
@@ -130,6 +132,11 @@ public class Prison
 			{ Offense: Inherited { Ancestors: { } ancestors } } => CalculatePunishmentInheritance(ancestors),
 			_ => throw new NotSupportedException("Unknown offense type.")
 		});
+
+		if (DateTimeOffset.UtcNow - banningTime.StartTime < TimeSpan.FromHours(1) && banningTime.Duration < TimeSpan.FromMinutes(30))
+		{
+			banningTime = new TimeFrame(banningTime.StartTime, TimeSpan.FromMinutes(30 + SecureRandom.Instance.GetInt(0, 30)));
+		}
 
 		lock (Lock)
 		{

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -133,7 +133,7 @@ public class Prison
 			_ => throw new NotSupportedException("Unknown offense type.")
 		});
 
-		if (DateTimeOffset.UtcNow - banningTime.StartTime < TimeSpan.FromHours(1) && banningTime.Duration < TimeSpan.FromMinutes(30))
+		if (DateTimeOffset.UtcNow < banningTime.StartTime + TimeSpan.FromHours(1) && banningTime.Duration < TimeSpan.FromMinutes(30))
 		{
 			banningTime = new TimeFrame(banningTime.StartTime, TimeSpan.FromMinutes(30 + SecureRandom.Instance.GetInt(0, 30)));
 		}

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -2,7 +2,6 @@ using NBitcoin;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Channels;
-using WabiSabi.Crypto.Randomness;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Rounds.CoinJoinStorage;
@@ -132,11 +131,6 @@ public class Prison
 			{ Offense: Inherited { Ancestors: { } ancestors } } => CalculatePunishmentInheritance(ancestors),
 			_ => throw new NotSupportedException("Unknown offense type.")
 		});
-
-		if (DateTimeOffset.UtcNow < banningTime.StartTime + TimeSpan.FromHours(1) && banningTime.Duration < TimeSpan.FromMinutes(30))
-		{
-			banningTime = new TimeFrame(banningTime.StartTime, TimeSpan.FromMinutes(30 + SecureRandom.Instance.GetInt(0, 30)));
-		}
 
 		lock (Lock)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -483,6 +483,10 @@ public class CoinJoinClient
 							Logger.LogError($"{nameof(InputBannedExceptionData)} is missing.");
 						}
 						var bannedUntil = inputBannedExData?.BannedUntil ?? DateTimeOffset.UtcNow + TimeSpan.FromDays(1);
+						if (bannedUntil < DateTimeOffset.UtcNow + TimeSpan.FromMinutes(30))
+						{
+							bannedUntil = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(30 + SecureRandom.Instance.GetInt(0, 30));
+						}
 						CoinJoinClientProgress.SafeInvoke(this, new CoinBanned(coin, bannedUntil));
 						roundState.LogInfo($"{coin.Coin.Outpoint} is banned until {bannedUntil}.");
 						if (!coinBanCheckMode.IsCancellationRequested)

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/StatusChangedEvents/StatusChangedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/StatusChangedEvents/StatusChangedEventArgs.cs
@@ -29,7 +29,8 @@ public enum CoinjoinError
 	OnlyImmatureCoinsAvailable,
 	OnlyExcludedCoinsAvailable,
 	UneconomicalRound,
-	RandomlySkippedRound
+	RandomlySkippedRound,
+	BannedCoinCheckFinished,
 }
 
 public class StatusChangedEventArgs : EventArgs


### PR DESCRIPTION
If the client has a banned coin then it does not finish the coin connection confirmation. It won't participate in the next phase, but checks the coins whether they are banned or not.

Fixes https://github.com/zkSNACKs/WalletWasabi/issues/12790