### PR TITLE
Don't log that we couldn't connect to a node if endpoint is default

### DIFF
--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -53,27 +53,27 @@ public class Config : ConfigBase
 
 	[JsonProperty(PropertyName = "MainNetBitcoinP2pEndPoint")]
 	[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBitcoinP2pPort)]
-	public EndPoint MainNetBitcoinP2pEndPoint { get; internal set; } = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBitcoinP2pPort);
+	public EndPoint MainNetBitcoinP2pEndPoint { get; internal set; } = Constants.DefaultMainNetBitcoinP2PEndPoint;
 
 	[JsonProperty(PropertyName = "TestNetBitcoinP2pEndPoint")]
 	[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBitcoinP2pPort)]
-	public EndPoint TestNetBitcoinP2pEndPoint { get; internal set; } = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBitcoinP2pPort);
+	public EndPoint TestNetBitcoinP2pEndPoint { get; internal set; } = Constants.DefaultTestNetBitcoinP2PEndPoint;
 
 	[JsonProperty(PropertyName = "RegTestBitcoinP2pEndPoint")]
 	[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBitcoinP2pPort)]
-	public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; } = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBitcoinP2pPort);
+	public EndPoint RegTestBitcoinP2pEndPoint { get; internal set; } = Constants.DefaultRegTestBitcoinP2PEndPoint;
 
 	[JsonProperty(PropertyName = "MainNetBitcoinCoreRpcEndPoint")]
 	[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBitcoinCoreRpcPort)]
-	public EndPoint MainNetBitcoinCoreRpcEndPoint { get; internal set; } = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBitcoinCoreRpcPort);
+	public EndPoint MainNetBitcoinCoreRpcEndPoint { get; internal set; } = Constants.DefaultMainNetBitcoinCoreRpcEndPoint;
 
 	[JsonProperty(PropertyName = "TestNetBitcoinCoreRpcEndPoint")]
 	[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBitcoinCoreRpcPort)]
-	public EndPoint TestNetBitcoinCoreRpcEndPoint { get; internal set; } = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBitcoinCoreRpcPort);
+	public EndPoint TestNetBitcoinCoreRpcEndPoint { get; internal set; } = Constants.DefaultTestNetBitcoinCoreRpcEndPoint;
 
 	[JsonProperty(PropertyName = "RegTestBitcoinCoreRpcEndPoint")]
 	[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBitcoinCoreRpcPort)]
-	public EndPoint RegTestBitcoinCoreRpcEndPoint { get; internal set; } = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBitcoinCoreRpcPort);
+	public EndPoint RegTestBitcoinCoreRpcEndPoint { get; internal set; } = Constants.DefaultRegTestBitcoinCoreRpcEndPoint;
 
 	public EndPoint GetBitcoinP2pEndPoint()
 	{

--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -78,15 +78,15 @@ public record PersistentConfig : IConfigNg
 
 	[JsonPropertyName("MainNetBitcoinP2pEndPoint")]
 	[JsonConverter(typeof(MainNetBitcoinP2pEndPointConverterNg))]
-	public EndPoint MainNetBitcoinP2pEndPoint { get; init; } = new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBitcoinP2pPort);
+	public EndPoint MainNetBitcoinP2pEndPoint { get; init; } = Constants.DefaultMainNetBitcoinP2PEndPoint;
 
 	[JsonPropertyName("TestNetBitcoinP2pEndPoint")]
 	[JsonConverter(typeof(TestNetBitcoinP2pEndPointConverterNg))]
-	public EndPoint TestNetBitcoinP2pEndPoint { get; init; } = new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBitcoinP2pPort);
+	public EndPoint TestNetBitcoinP2pEndPoint { get; init; } = Constants.DefaultTestNetBitcoinP2PEndPoint;
 
 	[JsonPropertyName("RegTestBitcoinP2pEndPoint")]
 	[JsonConverter(typeof(RegTestBitcoinP2pEndPointConverterNg))]
-	public EndPoint RegTestBitcoinP2pEndPoint { get; init; } = new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBitcoinP2pPort);
+	public EndPoint RegTestBitcoinP2pEndPoint { get; init; } = Constants.DefaultRegTestBitcoinP2PEndPoint;
 
 	[DefaultValue(false)]
 	[JsonPropertyName("JsonRpcServerEnabled")]

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using NBitcoin;
 using NBitcoin.Protocol;
 
@@ -81,6 +82,14 @@ public static class Constants
 	public const string BuiltinBitcoinNodeName = "Bitcoin Knots";
 
 	public const string FallbackAffiliationMessageSignerKey = "30770201010420686710a86f0cdf425e3bc9781f51e45b9440aec1215002402d5cdee713066623a00a06082a8648ce3d030107a14403420004f267804052bd863a1644233b8bfb5b8652ab99bcbfa0fb9c36113a571eb5c0cb7c733dbcf1777c2745c782f96e218bb71d67d15da1a77d37fa3cb96f423e53ba";
+
+	public static readonly EndPoint DefaultMainNetBitcoinP2PEndPoint = new IPEndPoint(IPAddress.Loopback, DefaultMainNetBitcoinP2pPort);
+	public static readonly EndPoint DefaultTestNetBitcoinP2PEndPoint = new IPEndPoint(IPAddress.Loopback, DefaultTestNetBitcoinP2pPort);
+	public static readonly EndPoint DefaultRegTestBitcoinP2PEndPoint = new IPEndPoint(IPAddress.Loopback, DefaultRegTestBitcoinP2pPort);
+
+	public static readonly EndPoint DefaultMainNetBitcoinCoreRpcEndPoint = new IPEndPoint(IPAddress.Loopback, DefaultMainNetBitcoinCoreRpcPort);
+	public static readonly EndPoint DefaultTestNetBitcoinCoreRpcEndPoint = new IPEndPoint(IPAddress.Loopback, DefaultTestNetBitcoinCoreRpcPort);
+	public static readonly EndPoint DefaultRegTestBitcoinCoreRpcEndPoint = new IPEndPoint(IPAddress.Loopback, DefaultRegTestBitcoinCoreRpcPort);
 
 	public static readonly Money MaximumNumberOfBitcoinsMoney = Money.Coins(MaximumNumberOfBitcoins);
 

--- a/WalletWasabi/Wallets/SpecificNodeBlockProvider.cs
+++ b/WalletWasabi/Wallets/SpecificNodeBlockProvider.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Exceptions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
@@ -129,13 +130,13 @@ public class SpecificNodeBlockProvider : IBlockProvider, IAsyncDisposable
 							                  """;
 
 							Logger.LogWarning(message);
+							logWarningOnConnectionEx = false;
 						}
-						else
+						else if(!(ex is SocketException && IsDefaultP2pEndpoint(BitcoinCoreEndPoint, Network)))
 						{
 							Logger.LogWarning($"Failed to establish a connection to the node '{BitcoinCoreEndPoint}'. Exception: {ex}");
+							logWarningOnConnectionEx = false;
 						}
-
-						logWarningOnConnectionEx = false;
 					}
 
 					// Failing to connect leads to exponential slowdown.
@@ -203,6 +204,17 @@ public class SpecificNodeBlockProvider : IBlockProvider, IAsyncDisposable
 		}
 
 		return new ConnectedNode(node);
+	}
+
+	private static bool IsDefaultP2pEndpoint(EndPoint endpoint, Network network)
+	{
+		return network switch
+		{
+			{ } n when n == Network.Main => Equals(endpoint, new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBitcoinP2pPort)),
+			{ } n when n == Network.TestNet => Equals(endpoint, new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBitcoinP2pPort)),
+			{ } n when n == Network.RegTest => Equals(endpoint, new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBitcoinP2pPort)),
+			_ => throw new NotSupportedNetworkException(network)
+		};
 	}
 
 	/// <inheritdoc/>

--- a/WalletWasabi/Wallets/SpecificNodeBlockProvider.cs
+++ b/WalletWasabi/Wallets/SpecificNodeBlockProvider.cs
@@ -210,9 +210,9 @@ public class SpecificNodeBlockProvider : IBlockProvider, IAsyncDisposable
 	{
 		return network switch
 		{
-			{ } n when n == Network.Main => Equals(endpoint, new IPEndPoint(IPAddress.Loopback, Constants.DefaultMainNetBitcoinP2pPort)),
-			{ } n when n == Network.TestNet => Equals(endpoint, new IPEndPoint(IPAddress.Loopback, Constants.DefaultTestNetBitcoinP2pPort)),
-			{ } n when n == Network.RegTest => Equals(endpoint, new IPEndPoint(IPAddress.Loopback, Constants.DefaultRegTestBitcoinP2pPort)),
+			{ } n when n == Network.Main => Equals(endpoint, Constants.DefaultMainNetBitcoinP2PEndPoint),
+			{ } n when n == Network.TestNet => Equals(endpoint, Constants.DefaultTestNetBitcoinP2PEndPoint),
+			{ } n when n == Network.RegTest => Equals(endpoint, Constants.DefaultRegTestBitcoinP2PEndPoint),
 			_ => throw new NotSupportedNetworkException(network)
 		};
 	}


### PR DESCRIPTION
Fixed a problem that I introduced recently where it `LogWarning` at every launch because there is no `SpecificNode` to connect to.

This PR doesn't log if the endpoint specified is default, so that it avoids logging for nothing in the standard case, but still logs if user specified a custom endpoint.

The downside is that there will not be any log if a node is expected by user on default endpoint but is not available. However, there is no perfect solution here and I believe this PR is the best tradeoff

@kiminuo If you can think of a better place for `IsDefaultP2pEndpoint` please move it!
