### PR TITLE
Point to the correct repository in UpdateManager

### DIFF
--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -19,7 +19,7 @@ namespace WalletWasabi.Services;
 
 public class UpdateManager
 {
-	private const string ReleaseURL = "https://api.github.com/repos/zkSNACKs/WalletWasabi/releases/latest";
+	private const string ReleaseURL = "https://api.github.com/repos/WalletWasabi/WalletWasabi/releases/latest";
 
 	public UpdateManager(string dataDir, bool downloadNewVersion, IHttpClient githubHttpClient, WasabiClient sharedWasabiClient)
 	{


### PR DESCRIPTION
This PR is useless because it doesn't change anything except avoiding a redirection.
Yet it's better to point to the correct place I guess.

There is a much bigger PR to make to replace links everywhere, but this PR is part of an effort to finalize UpdateManager on the `Downsize+FOSS` branch so we can port it to `master` for the release.

I'm super power merging