### PR TITLE
Use `<` instead of `<=` for versions check in `UpdateManager`

### DIFF
--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -52,7 +52,7 @@ public class UpdateManager : PeriodicRunner
 		{
 			var result = await GetLatestReleaseFromGithubAsync(cancellationToken).ConfigureAwait(false);
 
-			bool updateAvailable = Helpers.Constants.ClientVersion <= result.LatestClientVersion;
+			bool updateAvailable = Helpers.Constants.ClientVersion < result.LatestClientVersion;
 
 			if (!updateAvailable)
 			{


### PR DESCRIPTION
Tested and found no way where it can cause any problem, in fact it seems to me that it correctly 

Using super power merging again because I really want to make the PR to master today, but @Szpoti or @molnard please scream if it is incorrect.