### PR TITLE
[FOSS Port] Remove `SkipSynchronization`

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletLoadWorkflow.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletLoadWorkflow.cs
@@ -37,7 +37,7 @@ public partial class WalletLoadWorkflow
 			Observable.FromEventPattern<WalletState>(_wallet, nameof(Wallet.StateChanged))
 					.ObserveOn(RxApp.MainThreadScheduler)
 					.Select(x => x.EventArgs)
-					.Where(x => x == WalletState.Started || (x == WalletState.Starting && wallet.KeyManager.SkipSynchronization))
+					.Where(x => x == WalletState.Started)
 					.ToSignal();
 	}
 

--- a/WalletWasabi.Fluent/Views/Wallets/LoadingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/LoadingView.axaml
@@ -31,7 +31,7 @@
             TextAlignment="Center" TextWrapping="Wrap" Opacity="0.6" />
 
           <TextBlock
-            Text="This process may take some time depending on the size of your wallet."
+            Text="This process will be longer on first launch, with larger wallets, or after long gaps between synchronizations."
             TextAlignment="Center" TextWrapping="Wrap" Opacity="0.6" />
 
           <ProgressBar Value="{Binding Percent}" IsIndeterminate="{Binding !Percent}" Margin="0 20 0 0" />

--- a/WalletWasabi.Tests/Helpers/ServiceFactory.cs
+++ b/WalletWasabi.Tests/Helpers/ServiceFactory.cs
@@ -79,7 +79,7 @@ public static class ServiceFactory
 			taprootExtPubKey = extKey.Derive(taprootAccountKeyPath).Neuter();
 		}
 
-		return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, segwitExtPubKey, taprootExtPubKey, skipSynchronization: true, 21, blockchainState, null, segwitAccountKeyPath, null);
+		return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, segwitExtPubKey, taprootExtPubKey, 21, blockchainState, null, segwitAccountKeyPath, null);
 	}
 
 	public static KeyManager CreateWatchOnlyKeyManager()

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -42,7 +42,7 @@ public class KeyManagementTests
 		Assert.NotNull(manager3.SegwitExtPubKey);
 		Assert.NotNull(manager3.TaprootExtPubKey);
 
-		var sameManager = new KeyManager(manager.EncryptedSecret, manager.ChainCode, manager.MasterFingerprint, manager.SegwitExtPubKey, manager.TaprootExtPubKey, true, null, new BlockchainState(Network.Main));
+		var sameManager = new KeyManager(manager.EncryptedSecret, manager.ChainCode, manager.MasterFingerprint, manager.SegwitExtPubKey, manager.TaprootExtPubKey, null, new BlockchainState(Network.Main));
 		var sameManager2 = new KeyManager(manager.EncryptedSecret, manager.ChainCode, password, Network.Main);
 		Logger.TurnOff();
 		Assert.Throws<SecurityException>(() => new KeyManager(manager.EncryptedSecret, manager.ChainCode, "differentPassword", Network.Main));

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -43,7 +43,7 @@ public class KeyManager
 	};
 
 	[JsonConstructor]
-	public KeyManager(BitcoinEncryptedSecretNoEC? encryptedSecret, byte[]? chainCode, HDFingerprint? masterFingerprint, ExtPubKey extPubKey, ExtPubKey? taprootExtPubKey, bool skipSynchronization, int? minGapLimit, BlockchainState blockchainState, string? filePath = null, KeyPath? segwitAccountKeyPath = null, KeyPath? taprootAccountKeyPath = null)
+	public KeyManager(BitcoinEncryptedSecretNoEC? encryptedSecret, byte[]? chainCode, HDFingerprint? masterFingerprint, ExtPubKey extPubKey, ExtPubKey? taprootExtPubKey, int? minGapLimit, BlockchainState blockchainState, string? filePath = null, KeyPath? segwitAccountKeyPath = null, KeyPath? taprootAccountKeyPath = null)
 	{
 		EncryptedSecret = encryptedSecret;
 		ChainCode = chainCode;
@@ -51,7 +51,6 @@ public class KeyManager
 		SegwitExtPubKey = Guard.NotNull(nameof(extPubKey), extPubKey);
 		TaprootExtPubKey = taprootExtPubKey;
 
-		SkipSynchronization = skipSynchronization;
 		MinGapLimit = Math.Max(AbsoluteMinGapLimit, minGapLimit ?? 0);
 
 		BlockchainState = blockchainState;
@@ -158,9 +157,6 @@ public class KeyManager
 	[JsonProperty(PropertyName = "TaprootExtPubKey")]
 	public ExtPubKey? TaprootExtPubKey { get; private set; }
 
-	[JsonProperty(PropertyName = "SkipSynchronization")]
-	public bool SkipSynchronization { get; private set; } = false;
-
 	[JsonProperty(PropertyName = "UseTurboSync")]
 	public bool UseTurboSync { get; private set; } = true;
 
@@ -258,17 +254,17 @@ public class KeyManager
 		KeyPath taprootAccountKeyPath = GetAccountKeyPath(network, ScriptPubKeyType.TaprootBIP86);
 		ExtPubKey taprootExtPubKey = extKey.Derive(taprootAccountKeyPath).Neuter();
 
-		return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, segwitExtPubKey, taprootExtPubKey, skipSynchronization: true, AbsoluteMinGapLimit, blockchainState, filePath, segwitAccountKeyPath, taprootAccountKeyPath);
+		return new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, segwitExtPubKey, taprootExtPubKey, AbsoluteMinGapLimit, blockchainState, filePath, segwitAccountKeyPath, taprootAccountKeyPath);
 	}
 
 	public static KeyManager CreateNewWatchOnly(ExtPubKey segwitExtPubKey, ExtPubKey taprootExtPubKey, string? filePath = null, int? minGapLimit = null)
 	{
-		return new KeyManager(null, null, null, segwitExtPubKey, taprootExtPubKey, skipSynchronization: false, minGapLimit ?? AbsoluteMinGapLimit, new BlockchainState(), filePath);
+		return new KeyManager(null, null, null, segwitExtPubKey, taprootExtPubKey, minGapLimit ?? AbsoluteMinGapLimit, new BlockchainState(), filePath);
 	}
 
 	public static KeyManager CreateNewHardwareWalletWatchOnly(HDFingerprint masterFingerprint, ExtPubKey segwitExtPubKey, ExtPubKey? taprootExtPubKey, Network network, string? filePath = null)
 	{
-		return new KeyManager(null, null, masterFingerprint, segwitExtPubKey, taprootExtPubKey, skipSynchronization: false, AbsoluteMinGapLimit, new BlockchainState(network), filePath);
+		return new KeyManager(null, null, masterFingerprint, segwitExtPubKey, taprootExtPubKey, AbsoluteMinGapLimit, new BlockchainState(network), filePath);
 	}
 
 	public static KeyManager Recover(Mnemonic mnemonic, string password, Network network, KeyPath swAccountKeyPath, KeyPath? trAccountKeyPath = null, string? filePath = null, int minGapLimit = AbsoluteMinGapLimit)
@@ -286,7 +282,7 @@ public class KeyManager
 		KeyPath taprootAccountKeyPath = trAccountKeyPath ?? GetAccountKeyPath(network, ScriptPubKeyType.TaprootBIP86);
 		ExtPubKey taprootExtPubKey = extKey.Derive(taprootAccountKeyPath).Neuter();
 
-		var km = new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, segwitExtPubKey, taprootExtPubKey, skipSynchronization: false, minGapLimit, new BlockchainState(network), filePath, segwitAccountKeyPath, taprootAccountKeyPath);
+		var km = new KeyManager(encryptedSecret, extKey.ChainCode, masterFingerprint, segwitExtPubKey, taprootExtPubKey, minGapLimit, new BlockchainState(network), filePath, segwitAccountKeyPath, taprootAccountKeyPath);
 		km.AssertCleanKeysIndexed();
 		return km;
 	}
@@ -349,7 +345,6 @@ public class KeyManager
 			};
 
 			newKey.SetLabel(labels);
-			SkipSynchronization = false;
 
 			ToFile();
 			return newKey;


### PR DESCRIPTION
Fixes #13111 

It also includes a slight change of the text during sync to emphasize that it will be longer on first launch.
This loading screen really doesn't make the job but well... out of scope.

Note that this PR is not aimed at `master` but at `Downsize+FOSS`, it is seeking for cACK or cNACK, I would accept either but take in mind that this feature creates maintenance burden

Ps: I noticed that the filters are longer to download than in the past