### PR TITLE
Introduce `MaxAllowedCoordinationFeeRate` setting

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -127,6 +127,9 @@ public class Config
 			[ nameof(CoordinatorIdentifier)] = (
 				"-",
 				GetStringValue("CoordinatorIdentifier", PersistentConfig.CoordinatorIdentifier, cliArgs)),
+			[ nameof(MaxAllowedCoordinationFeeRate)] = (
+				"Max coordination fee rate the client is willing to accept to participate into a round",
+				GetDecimalValue("MaxAllowedCoordinationFeeRate", PersistentConfig.MaxAllowedCoordinationFeeRate, cliArgs)),
 		};
 
 		// Check if any config value is overridden (either by an environment value, or by a CLI argument).
@@ -184,6 +187,7 @@ public class Config
 
 	public bool EnableGpu => GetEffectiveValue<BoolValue, bool>(nameof(EnableGpu));
 	public string CoordinatorIdentifier => GetEffectiveValue<StringValue, string>(nameof(CoordinatorIdentifier));
+	public decimal MaxAllowedCoordinationFeeRate => GetEffectiveValue<DecimalValue, decimal>(nameof(MaxAllowedCoordinationFeeRate));
 	public ServiceConfiguration ServiceConfiguration { get; }
 
 	public static string DataDir { get; } = GetStringValue(
@@ -308,6 +312,21 @@ public class Config
 		}
 
 		return new BoolValue(value, value, ValueSource.Disk);
+	}
+
+	private DecimalValue GetDecimalValue(string key, decimal value, string[] cliArgs)
+	{
+		if (GetOverrideValue(key, cliArgs, out string? overrideValue, out ValueSource? valueSource))
+		{
+			if (!int.TryParse(overrideValue, out int argsLongValue))
+			{
+				throw new ArgumentException("must be a decimal number.", key);
+			}
+
+			return new DecimalValue(value, argsLongValue, valueSource.Value);
+		}
+
+		return new DecimalValue(value, value, ValueSource.Disk);
 	}
 
 	private IntValue GetLongValue(string key, int value, string[] cliArgs)
@@ -511,6 +530,7 @@ public class Config
 
 	private record BoolValue(bool Value, bool EffectiveValue, ValueSource ValueSource) : ITypedValue<bool>;
 	private record IntValue(int Value, int EffectiveValue, ValueSource ValueSource) : ITypedValue<int>;
+	private record DecimalValue(decimal Value, decimal EffectiveValue, ValueSource ValueSource) : ITypedValue<decimal>;
 	private record StringValue(string Value, string EffectiveValue, ValueSource ValueSource) : ITypedValue<string>;
 	private record NullableStringValue(string? Value, string? EffectiveValue, ValueSource ValueSource) : ITypedValue<string?>;
 	private record StringArrayValue(string[] Value, string[] EffectiveValue, ValueSource ValueSource) : ITypedValue<string[]>;

--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -127,9 +127,9 @@ public class Config
 			[ nameof(CoordinatorIdentifier)] = (
 				"-",
 				GetStringValue("CoordinatorIdentifier", PersistentConfig.CoordinatorIdentifier, cliArgs)),
-			[ nameof(MaxAllowedCoordinationFeeRate)] = (
+			[ nameof(MaxCoordinationFeeRate)] = (
 				"Max coordination fee rate the client is willing to accept to participate into a round",
-				GetDecimalValue("MaxAllowedCoordinationFeeRate", PersistentConfig.MaxAllowedCoordinationFeeRate, cliArgs)),
+				GetDecimalValue("MaxCoordinationFeeRate", PersistentConfig.MaxCoordinationFeeRate, cliArgs)),
 		};
 
 		// Check if any config value is overridden (either by an environment value, or by a CLI argument).
@@ -187,7 +187,7 @@ public class Config
 
 	public bool EnableGpu => GetEffectiveValue<BoolValue, bool>(nameof(EnableGpu));
 	public string CoordinatorIdentifier => GetEffectiveValue<StringValue, string>(nameof(CoordinatorIdentifier));
-	public decimal MaxAllowedCoordinationFeeRate => GetEffectiveValue<DecimalValue, decimal>(nameof(MaxAllowedCoordinationFeeRate));
+	public decimal MaxCoordinationFeeRate => GetEffectiveValue<DecimalValue, decimal>(nameof(MaxCoordinationFeeRate));
 	public ServiceConfiguration ServiceConfiguration { get; }
 
 	public static string DataDir { get; } = GetStringValue(

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -399,7 +399,7 @@ public class Global
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = CoordinatorHttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, HostedServices.Get<WasabiSynchronizer>(), Config.CoordinatorIdentifier, CoinPrison), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, HostedServices.Get<WasabiSynchronizer>(), Config.CoordinatorIdentifier, Config.MaxAllowedCoordinationFeeRate, CoinPrison), "CoinJoin Manager");
 	}
 
 	private void WalletManager_WalletStateChanged(object? sender, WalletState e)

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -399,7 +399,7 @@ public class Global
 	{
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = CoordinatorHttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, HostedServices.Get<WasabiSynchronizer>(), Config.CoordinatorIdentifier, Config.MaxAllowedCoordinationFeeRate, CoinPrison), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, HostedServices.Get<WasabiSynchronizer>(), Config.CoordinatorIdentifier, Config.MaxCoordinationFeeRate, CoinPrison), "CoinJoin Manager");
 	}
 
 	private void WalletManager_WalletStateChanged(object? sender, WalletState e)

--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -16,7 +16,7 @@ public record PersistentConfig : IConfigNg
 {
 	public const int DefaultJsonRpcServerPort = 37128;
 	public static readonly Money DefaultDustThreshold = Money.Coins(Constants.DefaultDustThreshold);
-	public static readonly decimal DefaultMaxAllowedCoordinationFeeRate = Constants.DefaultMaxAllowedCoordinationFeeRate;
+	public static readonly decimal DefaultMaxCoordinationFeeRate = Constants.DefaultMaxCoordinationFeeRate;
 
 	[JsonPropertyName("Network")]
 	[JsonConverter(typeof(NetworkJsonConverterNg))]
@@ -119,8 +119,8 @@ public record PersistentConfig : IConfigNg
 	[JsonPropertyName("CoordinatorIdentifier")]
 	public string CoordinatorIdentifier { get; init; } = "CoinJoinCoordinatorIdentifier";
 
-	[JsonPropertyName("MaxAllowedCoordinationFeeRate")]
-	public decimal MaxAllowedCoordinationFeeRate { get; init; } = DefaultMaxAllowedCoordinationFeeRate;
+	[JsonPropertyName("MaxCoordinationFeeRate")]
+	public decimal MaxCoordinationFeeRate { get; init; } = DefaultMaxCoordinationFeeRate;
 
 	public bool DeepEquals(PersistentConfig other)
 	{
@@ -150,7 +150,7 @@ public record PersistentConfig : IConfigNg
 			DustThreshold == other.DustThreshold &&
 			EnableGpu == other.EnableGpu &&
 			CoordinatorIdentifier == other.CoordinatorIdentifier &&
-			MaxAllowedCoordinationFeeRate == other.MaxAllowedCoordinationFeeRate;
+			MaxCoordinationFeeRate == other.MaxCoordinationFeeRate;
 	}
 
 	public EndPoint GetBitcoinP2pEndPoint()

--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -16,6 +16,7 @@ public record PersistentConfig : IConfigNg
 {
 	public const int DefaultJsonRpcServerPort = 37128;
 	public static readonly Money DefaultDustThreshold = Money.Coins(Constants.DefaultDustThreshold);
+	public static readonly decimal DefaultMaxAllowedCoordinationFeeRate = Constants.DefaultMaxAllowedCoordinationFeeRate;
 
 	[JsonPropertyName("Network")]
 	[JsonConverter(typeof(NetworkJsonConverterNg))]
@@ -118,6 +119,9 @@ public record PersistentConfig : IConfigNg
 	[JsonPropertyName("CoordinatorIdentifier")]
 	public string CoordinatorIdentifier { get; init; } = "CoinJoinCoordinatorIdentifier";
 
+	[JsonPropertyName("MaxAllowedCoordinationFeeRate")]
+	public decimal MaxAllowedCoordinationFeeRate { get; init; } = DefaultMaxAllowedCoordinationFeeRate;
+
 	public bool DeepEquals(PersistentConfig other)
 	{
 		bool useTorIsEqual = Config.ObjectToTorMode(UseTor) == Config.ObjectToTorMode(other.UseTor);
@@ -145,7 +149,8 @@ public record PersistentConfig : IConfigNg
 			JsonRpcServerPrefixes.SequenceEqual(other.JsonRpcServerPrefixes) &&
 			DustThreshold == other.DustThreshold &&
 			EnableGpu == other.EnableGpu &&
-			CoordinatorIdentifier == other.CoordinatorIdentifier;
+			CoordinatorIdentifier == other.CoordinatorIdentifier &&
+			MaxAllowedCoordinationFeeRate == other.MaxAllowedCoordinationFeeRate;
 	}
 
 	public EndPoint GetBitcoinP2pEndPoint()

--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -43,7 +43,7 @@ public partial class ApplicationSettings : ReactiveObject
 	[AutoNotify] private bool _stopLocalBitcoinCoreOnShutdown;
 	[AutoNotify] private string _bitcoinP2PEndPoint;
 	[AutoNotify] private string _coordinatorUri;
-	[AutoNotify] private string _maxAllowedCoordinationFeeRate;
+	[AutoNotify] private string _maxCoordinationFeeRate;
 	[AutoNotify] private string _dustThreshold;
 
 	// General
@@ -87,7 +87,7 @@ public partial class ApplicationSettings : ReactiveObject
 		_stopLocalBitcoinCoreOnShutdown = _startupConfig.StopLocalBitcoinCoreOnShutdown;
 		_bitcoinP2PEndPoint = _startupConfig.GetBitcoinP2pEndPoint().ToString(defaultPort: -1);
 		_coordinatorUri = _startupConfig.GetCoordinatorUri();
-		_maxAllowedCoordinationFeeRate = _startupConfig.MaxAllowedCoordinationFeeRate.ToString(CultureInfo.InvariantCulture);
+		_maxCoordinationFeeRate = _startupConfig.MaxCoordinationFeeRate.ToString(CultureInfo.InvariantCulture);
 		_dustThreshold = _startupConfig.DustThreshold.ToString();
 
 		// General
@@ -121,7 +121,7 @@ public partial class ApplicationSettings : ReactiveObject
 			x => x.StopLocalBitcoinCoreOnShutdown,
 			x => x.BitcoinP2PEndPoint,
 			x => x.CoordinatorUri,
-			x => x.MaxAllowedCoordinationFeeRate,
+			x => x.MaxCoordinationFeeRate,
 			x => x.DustThreshold,
 			x => x.UseTor,
 			x => x.TerminateTorOnExit,
@@ -258,9 +258,9 @@ public partial class ApplicationSettings : ReactiveObject
 				DustThreshold = decimal.TryParse(DustThreshold, out var threshold) ?
 					Money.Coins(threshold) :
 					PersistentConfig.DefaultDustThreshold,
-				MaxAllowedCoordinationFeeRate = decimal.TryParse(MaxAllowedCoordinationFeeRate, out var maxAllowedCoordinationFeeRate) ?
-					maxAllowedCoordinationFeeRate :
-					PersistentConfig.DefaultMaxAllowedCoordinationFeeRate
+				MaxCoordinationFeeRate = decimal.TryParse(MaxCoordinationFeeRate, out var maxCoordinationFeeRate) ?
+					maxCoordinationFeeRate :
+					PersistentConfig.DefaultMaxCoordinationFeeRate
 			};
 		}
 		else

--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Avalonia.Controls;
 using NBitcoin;
 using ReactiveUI;
@@ -42,6 +43,7 @@ public partial class ApplicationSettings : ReactiveObject
 	[AutoNotify] private bool _stopLocalBitcoinCoreOnShutdown;
 	[AutoNotify] private string _bitcoinP2PEndPoint;
 	[AutoNotify] private string _coordinatorUri;
+	[AutoNotify] private string _maxAllowedCoordinationFeeRate;
 	[AutoNotify] private string _dustThreshold;
 
 	// General
@@ -85,6 +87,7 @@ public partial class ApplicationSettings : ReactiveObject
 		_stopLocalBitcoinCoreOnShutdown = _startupConfig.StopLocalBitcoinCoreOnShutdown;
 		_bitcoinP2PEndPoint = _startupConfig.GetBitcoinP2pEndPoint().ToString(defaultPort: -1);
 		_coordinatorUri = _startupConfig.GetCoordinatorUri();
+		_maxAllowedCoordinationFeeRate = _startupConfig.MaxAllowedCoordinationFeeRate.ToString(CultureInfo.InvariantCulture);
 		_dustThreshold = _startupConfig.DustThreshold.ToString();
 
 		// General
@@ -118,11 +121,12 @@ public partial class ApplicationSettings : ReactiveObject
 			x => x.StopLocalBitcoinCoreOnShutdown,
 			x => x.BitcoinP2PEndPoint,
 			x => x.CoordinatorUri,
+			x => x.MaxAllowedCoordinationFeeRate,
 			x => x.DustThreshold,
 			x => x.UseTor,
 			x => x.TerminateTorOnExit,
 			x => x.DownloadNewVersion,
-			(_, _, _, _, _, _, _, _, _, _, _) => Unit.Default)
+			(_, _, _, _, _, _, _, _, _, _, _, _) => Unit.Default)
 			.Skip(1)
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Throttle(TimeSpan.FromMilliseconds(ThrottleTime))
@@ -251,9 +255,12 @@ public partial class ApplicationSettings : ReactiveObject
 				StartLocalBitcoinCoreOnStartup = StartLocalBitcoinCoreOnStartup,
 				StopLocalBitcoinCoreOnShutdown = StopLocalBitcoinCoreOnShutdown,
 				LocalBitcoinCoreDataDir = Guard.Correct(LocalBitcoinCoreDataDir),
-				DustThreshold = decimal.TryParse(DustThreshold, out var threshold)
-					? Money.Coins(threshold)
-					: PersistentConfig.DefaultDustThreshold,
+				DustThreshold = decimal.TryParse(DustThreshold, out var threshold) ?
+					Money.Coins(threshold) :
+					PersistentConfig.DefaultDustThreshold,
+				MaxAllowedCoordinationFeeRate = decimal.TryParse(MaxAllowedCoordinationFeeRate, out var maxAllowedCoordinationFeeRate) ?
+					maxAllowedCoordinationFeeRate :
+					PersistentConfig.DefaultMaxAllowedCoordinationFeeRate
 			};
 		}
 		else

--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -28,7 +28,7 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 {
 	[AutoNotify] private string _bitcoinP2PEndPoint;
 	[AutoNotify] private string _coordinatorUri;
-	[AutoNotify] private string _maxAllowedCoordinationFeeRate;
+	[AutoNotify] private string _maxCoordinationFeeRate;
 	[AutoNotify] private string _dustThreshold;
 
 	[AutoNotify] private bool _focusCoordinatorUri;
@@ -39,12 +39,12 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 
 		this.ValidateProperty(x => x.BitcoinP2PEndPoint, ValidateBitcoinP2PEndPoint);
 		this.ValidateProperty(x => x.CoordinatorUri, ValidateCoordinatorUri);
-		this.ValidateProperty(x => x.MaxAllowedCoordinationFeeRate, ValidateMaxAllowedCoordinationFeeRate);
+		this.ValidateProperty(x => x.MaxCoordinationFeeRate, ValidateMaxCoordinationFeeRate);
 		this.ValidateProperty(x => x.DustThreshold, ValidateDustThreshold);
 
 		_bitcoinP2PEndPoint = settings.BitcoinP2PEndPoint;
 		_coordinatorUri = settings.CoordinatorUri;
-		_maxAllowedCoordinationFeeRate = settings.MaxAllowedCoordinationFeeRate;
+		_maxCoordinationFeeRate = settings.MaxCoordinationFeeRate;
 		_dustThreshold = settings.DustThreshold;
 
 		this.WhenAnyValue(x => x.Settings.BitcoinP2PEndPoint)
@@ -95,28 +95,28 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 		Settings.CoordinatorUri = coordinatorUri;
 	}
 
-	private void ValidateMaxAllowedCoordinationFeeRate(IValidationErrors errors)
+	private void ValidateMaxCoordinationFeeRate(IValidationErrors errors)
 	{
-		var maxAllowedCoordinationFeeRate = MaxAllowedCoordinationFeeRate;
+		var maxCoordinationFeeRate = MaxCoordinationFeeRate;
 
-		if (string.IsNullOrEmpty(maxAllowedCoordinationFeeRate))
+		if (string.IsNullOrEmpty(maxCoordinationFeeRate))
 		{
 			return;
 		}
 
-		if (!decimal.TryParse(maxAllowedCoordinationFeeRate, out var maxAllowedCoordinationFeeRateDecimal))
+		if (!decimal.TryParse(maxCoordinationFeeRate, out var maxCoordinationFeeRateDecimal))
 		{
 			errors.Add(ErrorSeverity.Error, "Invalid number.");
 			return;
 		}
 
-		if (maxAllowedCoordinationFeeRateDecimal > 1)
+		if (maxCoordinationFeeRateDecimal > 1)
 		{
 			errors.Add(ErrorSeverity.Error, "Absolute maximum allowed coordination fee rate is 1%");
 			return;
 		}
 
-		Settings.MaxAllowedCoordinationFeeRate = maxAllowedCoordinationFeeRateDecimal.ToString(CultureInfo.InvariantCulture);
+		Settings.MaxCoordinationFeeRate = maxCoordinationFeeRateDecimal.ToString(CultureInfo.InvariantCulture);
 	}
 
 	private void ValidateDustThreshold(IValidationErrors errors)

--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -118,7 +118,7 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 
 		if (maxCoordinationFeeRateDecimal > 1)
 		{
-			errors.Add(ErrorSeverity.Error, "Absolute maximum allowed coordination fee rate is 1%");
+			errors.Add(ErrorSeverity.Error, "Absolute maximum coordination fee rate is 1%");
 			return;
 		}
 

--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Fluent.Infrastructure;
@@ -17,16 +18,17 @@ namespace WalletWasabi.Fluent.ViewModels.Settings;
 	Caption = "Manage Bitcoin settings",
 	Order = 1,
 	Category = "Settings",
-	Keywords = new[]
-	{
-			"Settings", "Bitcoin", "Network", "Main", "TestNet", "RegTest", "Run", "Node", "Core", "Knots", "Version", "Startup",
-			"P2P", "Endpoint", "Dust", "Threshold", "BTC"
-	},
+	Keywords =
+	[
+		"Settings", "Bitcoin", "Network", "Main", "TestNet", "RegTest", "Run", "Node", "Core", "Knots", "Version", "Startup",
+			"P2P", "Endpoint", "Dust", "Threshold", "BTC", "Coordinator", "Coordination", "Fee"
+	],
 	IconName = "settings_bitcoin_regular")]
 public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 {
 	[AutoNotify] private string _bitcoinP2PEndPoint;
 	[AutoNotify] private string _coordinatorUri;
+	[AutoNotify] private string _maxAllowedCoordinationFeeRate;
 	[AutoNotify] private string _dustThreshold;
 
 	[AutoNotify] private bool _focusCoordinatorUri;
@@ -37,10 +39,12 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 
 		this.ValidateProperty(x => x.BitcoinP2PEndPoint, ValidateBitcoinP2PEndPoint);
 		this.ValidateProperty(x => x.CoordinatorUri, ValidateCoordinatorUri);
+		this.ValidateProperty(x => x.MaxAllowedCoordinationFeeRate, ValidateMaxAllowedCoordinationFeeRate);
 		this.ValidateProperty(x => x.DustThreshold, ValidateDustThreshold);
 
 		_bitcoinP2PEndPoint = settings.BitcoinP2PEndPoint;
 		_coordinatorUri = settings.CoordinatorUri;
+		_maxAllowedCoordinationFeeRate = settings.MaxAllowedCoordinationFeeRate;
 		_dustThreshold = settings.DustThreshold;
 
 		this.WhenAnyValue(x => x.Settings.BitcoinP2PEndPoint)
@@ -89,6 +93,30 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 		}
 
 		Settings.CoordinatorUri = coordinatorUri;
+	}
+
+	private void ValidateMaxAllowedCoordinationFeeRate(IValidationErrors errors)
+	{
+		var maxAllowedCoordinationFeeRate = MaxAllowedCoordinationFeeRate;
+
+		if (string.IsNullOrEmpty(maxAllowedCoordinationFeeRate))
+		{
+			return;
+		}
+
+		if (!decimal.TryParse(maxAllowedCoordinationFeeRate, out var maxAllowedCoordinationFeeRateDecimal))
+		{
+			errors.Add(ErrorSeverity.Error, "Invalid number.");
+			return;
+		}
+
+		if (maxAllowedCoordinationFeeRateDecimal > 1)
+		{
+			errors.Add(ErrorSeverity.Error, "Absolute maximum allowed coordination fee rate is 1%");
+			return;
+		}
+
+		Settings.MaxAllowedCoordinationFeeRate = maxAllowedCoordinationFeeRateDecimal.ToString(CultureInfo.InvariantCulture);
 	}
 
 	private void ValidateDustThreshold(IValidationErrors errors)

--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -110,6 +110,12 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 			return;
 		}
 
+		if (maxCoordinationFeeRateDecimal < 0)
+		{
+			errors.Add(ErrorSeverity.Error, "Cannot be lower than 0.0%");
+			return;
+		}
+
 		if (maxCoordinationFeeRateDecimal > 1)
 		{
 			errors.Add(ErrorSeverity.Error, "Absolute maximum allowed coordination fee rate is 1%");

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -22,6 +22,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private const string WaitingMessage = "Awaiting coinjoin";
 	private const string UneconomicalRoundMessage = "Awaiting cheaper coinjoins";
 	private const string RandomlySkippedRoundMessage = "Skipping a round for better privacy";
+	private const string CoordinationFeeRateTooHighMessage = "Coordination fee rate was too high";
 	private const string PauseMessage = "Coinjoin is paused";
 	private const string StoppedMessage = "Coinjoin has stopped";
 	private const string PressPlayToStartMessage = "Press Play to start";
@@ -382,6 +383,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 					CoinjoinError.OnlyExcludedCoinsAvailable => OnlyExcludedCoinsAvailableMessage,
 					CoinjoinError.UneconomicalRound => UneconomicalRoundMessage,
 					CoinjoinError.RandomlySkippedRound => RandomlySkippedRoundMessage,
+					CoinjoinError.CoordinationFeeRateTooHigh => CoordinationFeeRateTooHighMessage,
 					_ => GeneralErrorMessage
 				};
 

--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -48,6 +48,14 @@
       </PrivacyContentControl>
     </StackPanel>
 
+    <StackPanel ToolTip.Tip="Coins received from others to already used addresses won't appear below this amount. To prevent potential dust attacks.">
+      <TextBlock Text="Dust Threshold" />
+      <CurrencyEntryBox Classes="standalone" Text="{Binding DustThreshold}" CurrencyCode="BTC" />
+    </StackPanel>
+
+    <Separator />
+
+    <!-- Coordination related settings !-->
     <StackPanel ToolTip.Tip="The client will connect to this coordinator that will manage coinjoins.">
       <TextBlock Text="Coordinator URI" />
       <TextBox Name="CoordinatorTextBox" Text="{Binding CoordinatorUri}">
@@ -59,10 +67,9 @@
         </Interaction.Behaviors>
       </TextBox>
     </StackPanel>
-
-    <StackPanel ToolTip.Tip="Coins received from others to already used addresses won't appear below this amount. To prevent potential dust attacks.">
-      <TextBlock Text="Dust Threshold" />
-      <CurrencyEntryBox Classes="standalone" Text="{Binding DustThreshold}" CurrencyCode="BTC" />
+    <StackPanel ToolTip.Tip="The client will refuse to participate in rounds charging a coordinaton fee rate (percentage) higher than the value indicated here.">
+      <TextBlock Text="Max Coordination Fee Rate" />
+      <CurrencyEntryBox Classes="standalone" Name="CoordinationFeeRateTextBox" Text="{Binding MaxAllowedCoordinationFeeRate}" CurrencyCode="%"/>
     </StackPanel>
   </StackPanel>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -67,8 +67,8 @@
         </Interaction.Behaviors>
       </TextBox>
     </StackPanel>
-    <StackPanel ToolTip.Tip="The client will refuse to participate in rounds charging a coordinaton fee rate (percentage) higher than the value indicated here.">
-      <TextBlock Text="Max Coordination Fee Rate" />
+    <StackPanel ToolTip.Tip="The client will refuse to participate in rounds charging a coordination fee rate (percentage) higher than the value indicated here.">
+      <TextBlock Text="Max Coordination Fee (percent)" />
       <CurrencyEntryBox Classes="standalone" Name="CoordinationFeeRateTextBox" Text="{Binding MaxAllowedCoordinationFeeRate}" CurrencyCode="%"/>
     </StackPanel>
   </StackPanel>

--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -69,7 +69,7 @@
     </StackPanel>
     <StackPanel ToolTip.Tip="The client will refuse to participate in rounds charging a coordination fee rate (percentage) higher than the value indicated here.">
       <TextBlock Text="Max Coordination Fee (percent)" />
-      <CurrencyEntryBox Classes="standalone" Name="CoordinationFeeRateTextBox" Text="{Binding MaxAllowedCoordinationFeeRate}" CurrencyCode="%"/>
+      <CurrencyEntryBox Classes="standalone" Name="CoordinationFeeRateTextBox" Text="{Binding MaxCoordinationFeeRate}" CurrencyCode="%"/>
     </StackPanel>
   </StackPanel>
 </UserControl>

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -344,6 +344,7 @@ public static class WabiSabiFactory
 			"CoinJoinCoordinatorIdentifier",
 			coinSelector,
 			new LiquidityClueProvider(),
+			0.3m,
 			TimeSpan.Zero,
 			TimeSpan.Zero,
 			null);

--- a/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullApplicationSettings.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullApplicationSettings.cs
@@ -18,7 +18,7 @@ public class NullApplicationSettings : IApplicationSettings
 	public string LocalBitcoinCoreDataDir { get; set; } = "";
 	public bool StopLocalBitcoinCoreOnShutdown { get; set; }
 	public string BitcoinP2PEndPoint { get; set; } = "";
-	public string MaxAllowedCoordinationFeeRate { get; set; } = "";
+	public string MaxCoordinationFeeRate { get; set; } = "";
 	public string CoordinatorUri { get; set; } = "";
 	public string DustThreshold { get; set; } = "";
 	public bool DarkModeEnabled { get; set; }

--- a/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullApplicationSettings.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullApplicationSettings.cs
@@ -18,6 +18,7 @@ public class NullApplicationSettings : IApplicationSettings
 	public string LocalBitcoinCoreDataDir { get; set; } = "";
 	public bool StopLocalBitcoinCoreOnShutdown { get; set; }
 	public string BitcoinP2PEndPoint { get; set; } = "";
+	public string MaxAllowedCoordinationFeeRate { get; set; } = "";
 	public string CoordinatorUri { get; set; } = "";
 	public string DustThreshold { get; set; } = "";
 	public bool DarkModeEnabled { get; set; }

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -65,7 +65,7 @@ public static class Constants
 	public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
 
 	public const decimal DefaultDustThreshold = 0.00005m;
-	public const decimal DefaultMaxAllowedCoordinationFeeRate = 0.0m;
+	public const decimal DefaultMaxCoordinationFeeRate = 0.0m;
 
 	public const string AlphaNumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 	public const string CapitalAlphaNumericCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -65,6 +65,7 @@ public static class Constants
 	public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
 
 	public const decimal DefaultDustThreshold = 0.00005m;
+	public const decimal DefaultMaxAllowedCoordinationFeeRate = 0.0m;
 
 	public const string AlphaNumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 	public const string CapitalAlphaNumericCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -157,7 +157,7 @@ public class CoinJoinClient
 				}
 				if (roundParameters.CoordinationFeeRate.Rate * 100 > MaxAllowedCoordinationFeeRate)
 				{
-					string roundSkippedMessage = "Coordination fee rate was too high.";
+					string roundSkippedMessage = $"Coordination fee rate was {roundParameters.CoordinationFeeRate.Rate * 100} but max allowed is {MaxAllowedCoordinationFeeRate}.";
 					currentRoundState.LogInfo(roundSkippedMessage);
 					throw new CoinJoinClientException(CoinjoinError.CoordinationFeeRateTooHigh, roundSkippedMessage);
 				}

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -44,6 +44,7 @@ public class CoinJoinClient
 		string coordinatorIdentifier,
 		CoinJoinCoinSelector coinJoinCoinSelector,
 		LiquidityClueProvider liquidityClueProvider,
+		decimal maxAllowedCoordinationFeeRate,
 		TimeSpan feeRateMedianTimeFrame = default,
 		TimeSpan doNotRegisterInLastMinuteTimeLimit = default,
 		CoinjoinSkipFactors? skipFactors = null)
@@ -55,6 +56,7 @@ public class CoinJoinClient
 		CoordinatorIdentifier = coordinatorIdentifier;
 		LiquidityClueProvider = liquidityClueProvider;
 		CoinJoinCoinSelector = coinJoinCoinSelector;
+		MaxAllowedCoordinationFeeRate = maxAllowedCoordinationFeeRate;
 		FeeRateMedianTimeFrame = feeRateMedianTimeFrame;
 		SkipFactors = skipFactors ?? CoinjoinSkipFactors.NoSkip;
 		SecureRandom = new SecureRandom();
@@ -71,6 +73,7 @@ public class CoinJoinClient
 	private OutputProvider OutputProvider { get; }
 	private RoundStateUpdater RoundStatusUpdater { get; }
 	private string CoordinatorIdentifier { get; }
+	private decimal MaxAllowedCoordinationFeeRate { get; }
 	private LiquidityClueProvider LiquidityClueProvider { get; }
 	private CoinJoinCoinSelector CoinJoinCoinSelector { get; }
 	private TimeSpan DoNotRegisterInLastMinuteTimeLimit { get; }
@@ -151,6 +154,12 @@ public class CoinJoinClient
 					string roundSkippedMessage = "Uneconomical round skipped.";
 					currentRoundState.LogInfo(roundSkippedMessage);
 					throw new CoinJoinClientException(CoinjoinError.UneconomicalRound, roundSkippedMessage);
+				}
+				if (roundParameters.CoordinationFeeRate.Rate * 100 > MaxAllowedCoordinationFeeRate)
+				{
+					string roundSkippedMessage = "Coordination fee rate was too high.";
+					currentRoundState.LogInfo(roundSkippedMessage);
+					throw new CoinJoinClientException(CoinjoinError.CoordinationFeeRateTooHigh, roundSkippedMessage);
 				}
 				if (SkipFactors.ShouldSkipRoundRandomly(SecureRandom, roundParameters.MiningFeeRate, RoundStatusUpdater.CoinJoinFeeRateMedians, currentRoundState.Id))
 				{

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -44,7 +44,7 @@ public class CoinJoinClient
 		string coordinatorIdentifier,
 		CoinJoinCoinSelector coinJoinCoinSelector,
 		LiquidityClueProvider liquidityClueProvider,
-		decimal maxAllowedCoordinationFeeRate,
+		decimal maxCoordinationFeeRate,
 		TimeSpan feeRateMedianTimeFrame = default,
 		TimeSpan doNotRegisterInLastMinuteTimeLimit = default,
 		CoinjoinSkipFactors? skipFactors = null)
@@ -56,7 +56,7 @@ public class CoinJoinClient
 		CoordinatorIdentifier = coordinatorIdentifier;
 		LiquidityClueProvider = liquidityClueProvider;
 		CoinJoinCoinSelector = coinJoinCoinSelector;
-		MaxAllowedCoordinationFeeRate = maxAllowedCoordinationFeeRate;
+		MaxCoordinationFeeRate = maxCoordinationFeeRate;
 		FeeRateMedianTimeFrame = feeRateMedianTimeFrame;
 		SkipFactors = skipFactors ?? CoinjoinSkipFactors.NoSkip;
 		SecureRandom = new SecureRandom();
@@ -73,7 +73,7 @@ public class CoinJoinClient
 	private OutputProvider OutputProvider { get; }
 	private RoundStateUpdater RoundStatusUpdater { get; }
 	private string CoordinatorIdentifier { get; }
-	private decimal MaxAllowedCoordinationFeeRate { get; }
+	private decimal MaxCoordinationFeeRate { get; }
 	private LiquidityClueProvider LiquidityClueProvider { get; }
 	private CoinJoinCoinSelector CoinJoinCoinSelector { get; }
 	private TimeSpan DoNotRegisterInLastMinuteTimeLimit { get; }
@@ -155,9 +155,9 @@ public class CoinJoinClient
 					currentRoundState.LogInfo(roundSkippedMessage);
 					throw new CoinJoinClientException(CoinjoinError.UneconomicalRound, roundSkippedMessage);
 				}
-				if (roundParameters.CoordinationFeeRate.Rate * 100 > MaxAllowedCoordinationFeeRate)
+				if (roundParameters.CoordinationFeeRate.Rate * 100 > MaxCoordinationFeeRate)
 				{
-					string roundSkippedMessage = $"Coordination fee rate was {roundParameters.CoordinationFeeRate.Rate * 100} but max allowed is {MaxAllowedCoordinationFeeRate}.";
+					string roundSkippedMessage = $"Coordination fee rate was {roundParameters.CoordinationFeeRate.Rate * 100} but max allowed is {MaxCoordinationFeeRate}.";
 					currentRoundState.LogInfo(roundSkippedMessage);
 					throw new CoinJoinClientException(CoinjoinError.CoordinationFeeRateTooHigh, roundSkippedMessage);
 				}

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -26,14 +26,14 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinManager : BackgroundService
 {
-	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier, decimal maxAllowedCoordinationFeeRate, CoinPrison coinPrison)
+	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier, decimal maxCoordinationFeeRate, CoinPrison coinPrison)
 	{
 		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
 		WalletProvider = walletProvider;
 		HttpClientFactory = coordinatorHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		CoordinatorIdentifier = coordinatorIdentifier;
-		MaxAllowedCoordinationFeeRate = maxAllowedCoordinationFeeRate;
+		MaxCoordinationFeeRate = maxCoordinationFeeRate;
 		CoinPrison = coinPrison;
 	}
 
@@ -46,7 +46,7 @@ public class CoinJoinManager : BackgroundService
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	public RoundStateUpdater RoundStatusUpdater { get; }
 	public string CoordinatorIdentifier { get; }
-	private decimal MaxAllowedCoordinationFeeRate { get; }
+	private decimal MaxCoordinationFeeRate { get; }
 	public CoinPrison CoinPrison { get; }
 	private CoinRefrigerator CoinRefrigerator { get; } = new();
 
@@ -156,7 +156,7 @@ public class CoinJoinManager : BackgroundService
 
 	private async Task HandleCoinJoinCommandsAsync(ConcurrentDictionary<WalletId, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
 	{
-		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(HttpClientFactory, RoundStatusUpdater, CoordinatorIdentifier, MaxAllowedCoordinationFeeRate, stoppingToken);
+		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(HttpClientFactory, RoundStatusUpdater, CoordinatorIdentifier, MaxCoordinationFeeRate, stoppingToken);
 
 		async void StartCoinJoinCommand(StartCoinJoinCommand startCommand)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -26,13 +26,14 @@ namespace WalletWasabi.WabiSabi.Client;
 
 public class CoinJoinManager : BackgroundService
 {
-	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier, CoinPrison coinPrison)
+	public CoinJoinManager(IWalletProvider walletProvider, RoundStateUpdater roundStatusUpdater, IWasabiHttpClientFactory coordinatorHttpClientFactory, IWasabiBackendStatusProvider wasabiBackendStatusProvider, string coordinatorIdentifier, decimal maxAllowedCoordinationFeeRate, CoinPrison coinPrison)
 	{
 		WasabiBackendStatusProvide = wasabiBackendStatusProvider;
 		WalletProvider = walletProvider;
 		HttpClientFactory = coordinatorHttpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		CoordinatorIdentifier = coordinatorIdentifier;
+		MaxAllowedCoordinationFeeRate = maxAllowedCoordinationFeeRate;
 		CoinPrison = coinPrison;
 	}
 
@@ -45,6 +46,7 @@ public class CoinJoinManager : BackgroundService
 	public IWasabiHttpClientFactory HttpClientFactory { get; }
 	public RoundStateUpdater RoundStatusUpdater { get; }
 	public string CoordinatorIdentifier { get; }
+	private decimal MaxAllowedCoordinationFeeRate { get; }
 	public CoinPrison CoinPrison { get; }
 	private CoinRefrigerator CoinRefrigerator { get; } = new();
 
@@ -154,7 +156,7 @@ public class CoinJoinManager : BackgroundService
 
 	private async Task HandleCoinJoinCommandsAsync(ConcurrentDictionary<WalletId, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
 	{
-		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(HttpClientFactory, RoundStatusUpdater, CoordinatorIdentifier, stoppingToken);
+		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(HttpClientFactory, RoundStatusUpdater, CoordinatorIdentifier, MaxAllowedCoordinationFeeRate, stoppingToken);
 
 		async void StartCoinJoinCommand(StartCoinJoinCommand startCommand)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
@@ -15,11 +15,13 @@ public class CoinJoinTrackerFactory
 		IWasabiHttpClientFactory httpClientFactory,
 		RoundStateUpdater roundStatusUpdater,
 		string coordinatorIdentifier,
+		decimal maxAllowedCoordinationFeeRate,
 		CancellationToken cancellationToken)
 	{
 		HttpClientFactory = httpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		CoordinatorIdentifier = coordinatorIdentifier;
+		MaxAllowedCoordinationFeeRate = maxAllowedCoordinationFeeRate;
 		CancellationToken = cancellationToken;
 		LiquidityClueProvider = new LiquidityClueProvider();
 	}
@@ -28,6 +30,7 @@ public class CoinJoinTrackerFactory
 	private RoundStateUpdater RoundStatusUpdater { get; }
 	private CancellationToken CancellationToken { get; }
 	private string CoordinatorIdentifier { get; }
+	private decimal MaxAllowedCoordinationFeeRate { get; }
 	private LiquidityClueProvider LiquidityClueProvider { get; }
 
 	public async Task<CoinJoinTracker> CreateAndStartAsync(IWallet wallet, IWallet? outputWallet, Func<Task<IEnumerable<SmartCoin>>> coinCandidatesFunc, bool stopWhenAllMixed, bool overridePlebStop)
@@ -51,6 +54,7 @@ public class CoinJoinTrackerFactory
 			CoordinatorIdentifier,
 			coinSelector,
 			LiquidityClueProvider,
+			MaxAllowedCoordinationFeeRate,
 			feeRateMedianTimeFrame: wallet.FeeRateMedianTimeFrame,
 			skipFactors: wallet.CoinjoinSkipFactors,
 			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1));

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
@@ -15,13 +15,13 @@ public class CoinJoinTrackerFactory
 		IWasabiHttpClientFactory httpClientFactory,
 		RoundStateUpdater roundStatusUpdater,
 		string coordinatorIdentifier,
-		decimal maxAllowedCoordinationFeeRate,
+		decimal maxCoordinationFeeRate,
 		CancellationToken cancellationToken)
 	{
 		HttpClientFactory = httpClientFactory;
 		RoundStatusUpdater = roundStatusUpdater;
 		CoordinatorIdentifier = coordinatorIdentifier;
-		MaxAllowedCoordinationFeeRate = maxAllowedCoordinationFeeRate;
+		MaxCoordinationFeeRate = maxCoordinationFeeRate;
 		CancellationToken = cancellationToken;
 		LiquidityClueProvider = new LiquidityClueProvider();
 	}
@@ -30,7 +30,7 @@ public class CoinJoinTrackerFactory
 	private RoundStateUpdater RoundStatusUpdater { get; }
 	private CancellationToken CancellationToken { get; }
 	private string CoordinatorIdentifier { get; }
-	private decimal MaxAllowedCoordinationFeeRate { get; }
+	private decimal MaxCoordinationFeeRate { get; }
 	private LiquidityClueProvider LiquidityClueProvider { get; }
 
 	public async Task<CoinJoinTracker> CreateAndStartAsync(IWallet wallet, IWallet? outputWallet, Func<Task<IEnumerable<SmartCoin>>> coinCandidatesFunc, bool stopWhenAllMixed, bool overridePlebStop)
@@ -54,7 +54,7 @@ public class CoinJoinTrackerFactory
 			CoordinatorIdentifier,
 			coinSelector,
 			LiquidityClueProvider,
-			MaxAllowedCoordinationFeeRate,
+			MaxCoordinationFeeRate,
 			feeRateMedianTimeFrame: wallet.FeeRateMedianTimeFrame,
 			skipFactors: wallet.CoinjoinSkipFactors,
 			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1));

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/StatusChangedEvents/StatusChangedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/StatusChangedEvents/StatusChangedEventArgs.cs
@@ -29,7 +29,8 @@ public enum CoinjoinError
 	OnlyImmatureCoinsAvailable,
 	OnlyExcludedCoinsAvailable,
 	UneconomicalRound,
-	RandomlySkippedRound
+	RandomlySkippedRound,
+	CoordinationFeeRateTooHigh
 }
 
 public class StatusChangedEventArgs : EventArgs


### PR DESCRIPTION
Fixes #13106

I used 0 as a default, not to enforce free coordinators but to protect clients. The reason is that we don't have any mechanism to enforce free remixing or to ensure that coordination fee doesn't change over time. Therefore, the coordinator as it is can be characterized as trust-minimized, because as I explained we didn't achieve real trustlessness yet. However, connecting to a coordinator that can charge a coordination fee requires some amount of trust, which is why 0 as a default is what makes the most sense.

Nevertheless, changing this setting is super easy when changing `CoordinatorURI`, as both are at the same place. As a result, a for-profit coordinator could instruct users that have a minimum amount of trust towards it to change both settings at the same time.

Finally, we could also change the setting dynamically if we create a coordinator discovery mechanism, fitting the current `RoundParameters` accepted by the user.