### PR TITLE
[UI] Set fixed width for TextBoxes in SettingsLayout

### DIFF
--- a/WalletWasabi.Fluent/Styles/SettingsLayout.axaml
+++ b/WalletWasabi.Fluent/Styles/SettingsLayout.axaml
@@ -19,6 +19,10 @@
     <Setter Property="HorizontalAlignment" Value="Right" />
   </Style>
 
+  <Style Selector="StackPanel.settingsLayout TextBox">
+    <Setter Property="Width" Value="360" />
+  </Style>
+
   <Style Selector="StackPanel.settingsLayout > DockPanel > TextBlock">
     <Setter Property="Margin" Value="0 8 20 0" />
     <Setter Property="VerticalAlignment" Value="Top" />


### PR DESCRIPTION
A new style selector for TextBox in StackPanel.settingsLayout has been added. This sets the width of the TextBox to a value of 360 to ensure TextBox doesn't grow indefintely.

Fixes #13163