### PR TITLE
[UI] Review EditDiff usages

### DIFF
--- a/WalletWasabi.Fluent/Extensions/ObservableExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/ObservableExtensions.cs
@@ -108,11 +108,11 @@ public static class ObservableExtensions
 	public static IObservable<(T1, T2, T3)> Flatten<T1, T2, T3>(this IObservable<((T1, T2), T3)> source) =>
 		source.Select(t => (t.Item1.Item1, t.Item1.Item2, t.Item2));
 
-	public static IObservableCache<TObject, TKey> Fetch<TObject, TKey>(this IObservable<Unit> signal, Func<IEnumerable<TObject>> source, Func<TObject, TKey> keySelector)
+	public static IObservableCache<TObject, TKey> Fetch<TObject, TKey>(this IObservable<Unit> signal, Func<IEnumerable<TObject>> source, Func<TObject, TKey> keySelector, IEqualityComparer<TObject> equalityComparer)
 		where TKey : notnull where TObject : notnull
 	{
 		return signal.Select(_ => source())
-					 .EditDiff(keySelector)
+					 .EditDiff(keySelector, equalityComparer)
 					 .DisposeMany()
 					 .AsObservableCache();
 	}

--- a/WalletWasabi.Fluent/Helpers/LambdaComparer.cs
+++ b/WalletWasabi.Fluent/Helpers/LambdaComparer.cs
@@ -1,0 +1,31 @@
+namespace WalletWasabi.Fluent.Helpers;
+
+using System;
+using System.Collections.Generic;
+
+	public class LambdaComparer<T> : IEqualityComparer<T>
+	{
+		private readonly Func<T?, T?, bool> _lambdaComparer;
+		private readonly Func<T?, int> _lambdaHash;
+
+		public LambdaComparer(Func<T?, T?, bool> lambdaComparer) :
+			this(lambdaComparer, _ => 0)
+		{
+		}
+
+		public LambdaComparer(Func<T?, T?, bool> lambdaComparer, Func<T?, int> lambdaHash)
+		{
+			_lambdaComparer = lambdaComparer ?? throw new ArgumentNullException("lambdaComparer");
+			_lambdaHash = lambdaHash ?? throw new ArgumentNullException("lambdaHash");
+		}
+
+		public bool Equals(T? x, T? y)
+		{
+			return _lambdaComparer(x, y);
+		}
+
+		public int GetHashCode(T obj)
+		{
+			return _lambdaHash(obj);
+		}
+	}

--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
@@ -37,9 +37,9 @@ public partial class WalletCoinsModel : IDisposable
 				.Merge(isCoinjoinRunningChanged)
 				.Publish();
 
-		Pockets = signals.Fetch(GetPockets, x => x.Labels).DisposeWith(_disposables);
+		Pockets = signals.Fetch(GetPockets, x => x.Labels, new LambdaComparer<Pocket>((a, b) => Equals(a?.Labels, b?.Labels))).DisposeWith(_disposables);
 		List = Pockets.Connect().MergeMany(x => x.Coins.Select(GetCoinModel).AsObservableChangeSet()).AddKey(x => x.Key).AsObservableCache();
-		
+
 		signals
 			.Do(_ => Logger.LogDebug($"Refresh signal emitted in {walletModel.Name}"))
 			.Subscribe()

--- a/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Fluent.Extensions;
+using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Helpers;
 using WalletWasabi.Hwi.Models;
 using WalletWasabi.Models;
@@ -34,7 +35,7 @@ public partial class WalletRepository : ReactiveObject
 					  .StartWith(System.Reactive.Unit.Default);
 
 		Wallets =
-			signals.Fetch(() => Services.WalletManager.GetWallets(), x => x.WalletId)
+			signals.Fetch(() => Services.WalletManager.GetWallets(), x => x.WalletId, new LambdaComparer<Wallet>((a, b) => Equals(a?.WalletId, b?.WalletId)))
 				   .DisposeWith(_disposable)
 				   .Connect()
 				   .TransformWithInlineUpdate(CreateWalletModel, (_, _) => { })

--- a/WalletWasabi.Fluent/Models/Wallets/WalletTransactionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletTransactionsModel.cs
@@ -53,7 +53,7 @@ public partial class WalletTransactionsModel : ReactiveObject, IDisposable
 		Cache =
 			TransactionProcessed
 			.Merge(RequestedUnconfirmedTxChainArrived)
-			.Fetch(BuildSummary, model => model.Id)
+			.Fetch(BuildSummary, model => model.Id, new LambdaComparer<TransactionModel>((a, b) => Equals(a?.Id, b?.Id)))
 								.DisposeWith(_disposable);
 
 		IsEmpty = Cache.Empty();

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListItem.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListItem.cs
@@ -120,4 +120,6 @@ public abstract partial class CoinListItem : ViewModelBase, ITreeDataGridExpande
 	public virtual bool HasChildren() => Children.Count != 0;
 
 	public void Dispose() => _disposables.Dispose();
+
+	public abstract string Key { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListViewModel.cs
@@ -11,6 +11,7 @@ using DynamicData.Binding;
 using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Fluent.Controls.Sorting;
+using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
@@ -112,7 +113,7 @@ public class CoinListViewModel : ViewModelBase, IDisposable
 			new SortableItem("Amount") { SortByAscendingCommand = ReactiveCommand.Create(() => TreeDataGridSource.SortBy(TreeDataGridSource.Columns[2], ListSortDirection.Ascending)), SortByDescendingCommand = ReactiveCommand.Create(() => TreeDataGridSource.SortBy(TreeDataGridSource.Columns[2], ListSortDirection.Descending)) },
 			new SortableItem("Label") { SortByAscendingCommand = ReactiveCommand.Create(() => TreeDataGridSource.SortBy(TreeDataGridSource.Columns[3], ListSortDirection.Ascending)), SortByDescendingCommand = ReactiveCommand.Create(() => TreeDataGridSource.SortBy(TreeDataGridSource.Columns[3], ListSortDirection.Descending)) },
 		];
-		
+
 		SetInitialSelection(initialCoinSelection);
 	}
 
@@ -171,7 +172,7 @@ public class CoinListViewModel : ViewModelBase, IDisposable
 				return new PocketViewModel(_wallet, pocket, _allowCoinjoiningCoinSelection, _ignorePrivacyMode);
 			});
 
-		source.EditDiff(newItems);
+		source.EditDiff(newItems, new LambdaComparer<CoinListItem>((a, b) => Equals(a?.Key, b?.Key)));
 	}
 
 	private void RestoreExpandedRows(IEnumerable<LabelsArray> oldItemsLabels)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinViewModel.cs
@@ -31,7 +31,7 @@ public class CoinViewModel : CoinListItem
 			.Where(b => !b)
 			.Do(_ => IsSelected = false)
 			.Subscribe();
-		
+
         if (!canSelectWhenCoinjoining)
         {
             this.WhenAnyValue(x => x.Coin.IsCoinJoinInProgress, b => !b).BindTo(this, x => x.CanBeSelected).DisposeWith(_disposables);
@@ -39,4 +39,5 @@ public class CoinViewModel : CoinListItem
 	}
 
 	public ICoinModel Coin { get; }
+	public override string Key => Coin.Key.ToString();
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/PocketViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/PocketViewModel.cs
@@ -126,4 +126,6 @@ public class PocketViewModel : CoinListItem
 
 		return commonItem;
 	}
+
+	public override string Key => Labels.ToString();
 }


### PR DESCRIPTION
- I've investigated this issue https://github.com/WalletWasabi/WalletWasabi/issues/12985 and discovered.
- I've researched about the usage of EditDiff.
- Made some isolated tests to verify its behavior. https://reactivex.slack.com/archives/C4LF8S19N/p1718182734512799

And discovered that we are using the `EditDiff` method without a comparer where we SHOULD use it. 
EditDiff is given a key selector, but it won't magically compare instances for equality, so there are instances that we consider equal, that `EditDiff` won't.

This is incorrect.

It doesn't cause major issues, but it can be the source of many of our issues with lists, that are refreshed when they don't need to, thus decreasing the performance of the application.

This change improves this situation a lot. Now, the items that are the same aren't replaced by new instances. 
To achieve so, we need to provide an Equality Comparer to `EditDiff`. 

I've added a new LambaComparer to avoid creating a lot of new comparers.

Please, test the application to see if it works as expected now, especially places that use lists: Coin List, History and Send/Coin Selector.

Should fix https://github.com/WalletWasabi/WalletWasabi/issues/12985