### PR TITLE
[UI] Use the correct setting for Tor when --UseTor parameter is used

### DIFF
--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -104,7 +104,7 @@ public partial class ApplicationSettings : ReactiveObject
 			: FeeDisplayUnit.Satoshis;
 		_runOnSystemStartup = _uiConfig.RunOnSystemStartup;
 		_hideOnClose = _uiConfig.HideOnClose;
-		_useTor = Config.ObjectToTorMode(_startupConfig.UseTor);
+		_useTor = Config.ObjectToTorMode(_config.UseTor);
 		_terminateTorOnExit = _startupConfig.TerminateTorOnExit;
 		_downloadNewVersion = _startupConfig.DownloadNewVersion;
 


### PR DESCRIPTION
The configuration source for the Tor setting has been changed. Instead of deriving the Tor setting from '_startupConfig.UseTor', it is now set via '_config.UseTor'. This change ensures the consistency in the UI as well.

Fixes #13093