### PR TITLE
Also check blame round max fees

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -133,7 +133,7 @@ public class CoinJoinClient
 
 		if (roundState.CoinjoinState.Parameters.CoordinationFeeRate.Rate * 100 > CoinJoinConfiguration.MaxCoordinationFeeRate)
 		{
-			Logger.LogWarning("Coordinator is malicious and tried to tricked client into paying a higher coordination fee rate in the blame round");
+			Logger.LogWarning("The coordinator is malicious and tried to trick the client into paying a higher coordination fee rate in the blame round.");
 			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the coordination fee rate is too high");
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -134,7 +134,7 @@ public class CoinJoinClient
 		if (roundState.CoinjoinState.Parameters.CoordinationFeeRate.Rate * 100 > CoinJoinConfiguration.MaxCoordinationFeeRate)
 		{
 			Logger.LogWarning("The coordinator is malicious and tried to trick the client into paying a higher coordination fee rate in the blame round.");
-			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the coordination fee rate is too high");
+			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the coordination fee rate is too high.");
 		}
 
 		if (roundState.CoinjoinState.Parameters.MiningFeeRate.SatoshiPerByte > CoinJoinConfiguration.MaxCoinJoinMiningFeeRate)

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -131,6 +131,17 @@ public class CoinJoinClient
 			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the round is not economic.");
 		}
 
+		if (roundState.CoinjoinState.Parameters.CoordinationFeeRate.Rate * 100 > CoinJoinConfiguration.MaxCoordinationFeeRate)
+		{
+			Logger.LogWarning("Coordinator is malicious and tried to tricked client into paying a higher coordination fee rate in the blame round");
+			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the coordination fee rate is too high");
+		}
+
+		if (roundState.CoinjoinState.Parameters.MiningFeeRate.SatoshiPerByte > CoinJoinConfiguration.MaxCoinJoinMiningFeeRate)
+		{
+			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the mining fee rate is too high");
+		}
+
 		return roundState;
 	}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -133,13 +133,14 @@ public class CoinJoinClient
 
 		if (roundState.CoinjoinState.Parameters.CoordinationFeeRate.Rate * 100 > CoinJoinConfiguration.MaxCoordinationFeeRate)
 		{
-			Logger.LogWarning("The coordinator is malicious and tried to trick the client into paying a higher coordination fee rate in the blame round.");
-			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the coordination fee rate is too high.");
+			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: " +
+			                                    $"the coordinator is malicious and tried to trick the client into paying a coordination fee rate of {roundState.CoinjoinState.Parameters.CoordinationFeeRate.Rate * 100}% for the blame round");
 		}
 
 		if (roundState.CoinjoinState.Parameters.MiningFeeRate.SatoshiPerByte > CoinJoinConfiguration.MaxCoinJoinMiningFeeRate)
 		{
-			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the mining fee rate is too high.");
+			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: " +
+			                                    $"the mining fee rate for the round was {roundState.CoinjoinState.Parameters.MiningFeeRate.SatoshiPerByte} sats/vb but maximum allowed is {CoinJoinConfiguration.MaxCoinJoinMiningFeeRate}.");
 		}
 
 		return roundState;

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -139,7 +139,7 @@ public class CoinJoinClient
 
 		if (roundState.CoinjoinState.Parameters.MiningFeeRate.SatoshiPerByte > CoinJoinConfiguration.MaxCoinJoinMiningFeeRate)
 		{
-			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the mining fee rate is too high");
+			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the mining fee rate is too high.");
 		}
 
 		return roundState;


### PR DESCRIPTION
Thanks @Kruwed 

Both codes that `throw` if client refuse to participate (for new and blame rounds) should be combined, this duplication is the reason why I made the mistake.

Because this PR is important, I suggest to merge it ASAP then if you want we can think about combining both codes.