### PR TITLE
[vdg] rename excluded coins dialog

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Settings/ExcludedCoinsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Settings/ExcludedCoinsViewModel.cs
@@ -13,7 +13,7 @@ using WalletWasabi.Fluent.ViewModels.Wallets.Coins;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Settings;
 
-[NavigationMetaData(Title = "Excluded Coins", NavigationTarget = NavigationTarget.DialogScreen)]
+[NavigationMetaData(Title = "Exclude Coins", NavigationTarget = NavigationTarget.DialogScreen)]
 public partial class ExcludedCoinsViewModel : DialogViewModelBase<Unit>
 {
 	private readonly IWalletModel _wallet;


### PR DESCRIPTION
all other references in the GUI call it _Exclude Coins_, instead of the _Exclude**d** Coins_ dialog title.
-> update the title

(exclude, makes more sense anyway)