### PR TITLE
Introduce AbsoluteMininputCount coordinator config

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -133,6 +133,9 @@ public class Config
 			[ nameof(MaxCoinjoinMiningFeeRate)] = (
 				"Max mining fee rate in s/vb the client is willing to pay to participate into a round",
 				GetDecimalValue("MaxCoinjoinMiningFeeRate", PersistentConfig.MaxCoinJoinMiningFeeRate, cliArgs)),
+			[ nameof(AbsoluteMinInputCount)] = (
+				"Minimum number of inputs the client is willing to accept to participate into a round",
+				GetLongValue("AbsoluteMinInputCount", PersistentConfig.AbsoluteMinInputCount, cliArgs)),
 		};
 
 		// Check if any config value is overridden (either by an environment value, or by a CLI argument).
@@ -192,6 +195,7 @@ public class Config
 	public string CoordinatorIdentifier => GetEffectiveValue<StringValue, string>(nameof(CoordinatorIdentifier));
 	public decimal MaxCoordinationFeeRate => GetEffectiveValue<DecimalValue, decimal>(nameof(MaxCoordinationFeeRate));
 	public decimal MaxCoinjoinMiningFeeRate => GetEffectiveValue<DecimalValue, decimal>(nameof(MaxCoinjoinMiningFeeRate));
+	public int AbsoluteMinInputCount => GetEffectiveValue<IntValue, int>(nameof(AbsoluteMinInputCount));
 	public ServiceConfiguration ServiceConfiguration { get; }
 
 	public static string DataDir { get; } = GetStringValue(

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -400,7 +400,7 @@ public class Global
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = CoordinatorHttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
 
-		var coinJoinConfiguration = new CoinJoinConfiguration(Config.CoordinatorIdentifier, Config.MaxCoordinationFeeRate, Config.MaxCoinjoinMiningFeeRate);
+		var coinJoinConfiguration = new CoinJoinConfiguration(Config.CoordinatorIdentifier, Config.MaxCoordinationFeeRate, Config.MaxCoinjoinMiningFeeRate, Config.AbsoluteMinInputCount);
 		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, HostedServices.Get<WasabiSynchronizer>(), coinJoinConfiguration, CoinPrison), "CoinJoin Manager");
 	}
 

--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -123,6 +123,9 @@ public record PersistentConfig : IConfigNg
 	[JsonPropertyName("MaxCoinJoinMiningFeeRate")]
 	public decimal MaxCoinJoinMiningFeeRate { get; init; } = Constants.DefaultMaxCoinJoinMiningFeeRate;
 
+	[JsonPropertyName("AbsoluteMinInputCount")]
+	public int AbsoluteMinInputCount { get; init; } = Constants.DefaultAbsoluteMinInputCount;
+
 	public bool DeepEquals(PersistentConfig other)
 	{
 		bool useTorIsEqual = Config.ObjectToTorMode(UseTor) == Config.ObjectToTorMode(other.UseTor);
@@ -152,7 +155,8 @@ public record PersistentConfig : IConfigNg
 			EnableGpu == other.EnableGpu &&
 			CoordinatorIdentifier == other.CoordinatorIdentifier &&
 			MaxCoordinationFeeRate == other.MaxCoordinationFeeRate &&
-			MaxCoinJoinMiningFeeRate == other.MaxCoinJoinMiningFeeRate;
+			MaxCoinJoinMiningFeeRate == other.MaxCoinJoinMiningFeeRate &&
+			AbsoluteMinInputCount == other.AbsoluteMinInputCount;
 	}
 
 	public EndPoint GetBitcoinP2pEndPoint()

--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -43,10 +43,14 @@ public partial class ApplicationSettings : ReactiveObject
 	[AutoNotify] private string _localBitcoinCoreDataDir;
 	[AutoNotify] private bool _stopLocalBitcoinCoreOnShutdown;
 	[AutoNotify] private string _bitcoinP2PEndPoint;
+	[AutoNotify] private string _dustThreshold;
+
+	// Coordinator
 	[AutoNotify] private string _coordinatorUri;
 	[AutoNotify] private string _maxCoordinationFeeRate;
 	[AutoNotify] private string _maxCoinJoinMiningFeeRate;
-	[AutoNotify] private string _dustThreshold;
+	[AutoNotify] private string _absoluteMinInputCount;
+	[AutoNotify] private string _readMoreUri;
 
 	// General
 	[AutoNotify] private bool _darkModeEnabled;
@@ -89,10 +93,13 @@ public partial class ApplicationSettings : ReactiveObject
 		_localBitcoinCoreDataDir = _startupConfig.LocalBitcoinCoreDataDir;
 		_stopLocalBitcoinCoreOnShutdown = _startupConfig.StopLocalBitcoinCoreOnShutdown;
 		_bitcoinP2PEndPoint = _startupConfig.GetBitcoinP2pEndPoint().ToString(defaultPort: -1);
+		_dustThreshold = _startupConfig.DustThreshold.ToString();
+
+		// Coordinator
 		_coordinatorUri = _startupConfig.GetCoordinatorUri();
 		_maxCoordinationFeeRate = _startupConfig.MaxCoordinationFeeRate.ToString(CultureInfo.InvariantCulture);
 		_maxCoinJoinMiningFeeRate = _startupConfig.MaxCoinJoinMiningFeeRate.ToString(CultureInfo.InvariantCulture);
-		_dustThreshold = _startupConfig.DustThreshold.ToString();
+		_absoluteMinInputCount = _startupConfig.AbsoluteMinInputCount.ToString(CultureInfo.InvariantCulture);
 
 		// General
 		_darkModeEnabled = _uiConfig.DarkModeEnabled;
@@ -138,10 +145,11 @@ public partial class ApplicationSettings : ReactiveObject
 			.Subscribe();
 
 		// Save on change - continuation. WhenAnyValue cannot have more than 12 arguments.
-		this.WhenAnyValue(x =>
-				x.MaxCoordinationFeeRate,
+		this.WhenAnyValue(
+				x => x.MaxCoordinationFeeRate,
 				x => x.MaxCoinJoinMiningFeeRate,
-				(_, _) => Unit.Default)
+				x => x.AbsoluteMinInputCount,
+				(_, _, _) => Unit.Default)
 			.Skip(1)
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Throttle(TimeSpan.FromMilliseconds(ThrottleTime))
@@ -281,7 +289,10 @@ public partial class ApplicationSettings : ReactiveObject
 					Constants.DefaultMaxCoordinationFeeRate,
 				MaxCoinJoinMiningFeeRate = decimal.TryParse(MaxCoinJoinMiningFeeRate, out var maxCoinjoinMiningFeeRate) ?
 					maxCoinjoinMiningFeeRate :
-					Constants.DefaultMaxCoinJoinMiningFeeRate
+					Constants.DefaultMaxCoinJoinMiningFeeRate,
+				AbsoluteMinInputCount = int.TryParse(AbsoluteMinInputCount, out var absoluteMinInputCount) ?
+					absoluteMinInputCount :
+					Constants.DefaultAbsoluteMinInputCount
 			};
 		}
 		else

--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -50,7 +50,6 @@ public partial class ApplicationSettings : ReactiveObject
 	[AutoNotify] private string _maxCoordinationFeeRate;
 	[AutoNotify] private string _maxCoinJoinMiningFeeRate;
 	[AutoNotify] private string _absoluteMinInputCount;
-	[AutoNotify] private string _readMoreUri;
 
 	// General
 	[AutoNotify] private bool _darkModeEnabled;

--- a/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
@@ -24,6 +24,7 @@ public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 	[AutoNotify] private string _coordinatorUri;
 	[AutoNotify] private string _maxCoordinationFeeRate;
 	[AutoNotify] private string _maxCoinJoinMiningFeeRate;
+	[AutoNotify] private string _absoluteMinInputCount;
 
 	public CoordinatorTabSettingsViewModel(IApplicationSettings settings)
 	{
@@ -32,11 +33,13 @@ public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 		this.ValidateProperty(x => x.CoordinatorUri, ValidateCoordinatorUri);
 		this.ValidateProperty(x => x.MaxCoordinationFeeRate, ValidateMaxCoordinationFeeRate);
 		this.ValidateProperty(x => x.MaxCoinJoinMiningFeeRate, ValidateMaxCoinJoinMiningFeeRate);
+		this.ValidateProperty(x => x.AbsoluteMinInputCount, ValidateAbsoluteMinInputCount);
 
 
 		_coordinatorUri = settings.CoordinatorUri;
 		_maxCoordinationFeeRate = settings.MaxCoordinationFeeRate;
 		_maxCoinJoinMiningFeeRate = settings.MaxCoinJoinMiningFeeRate;
+		_absoluteMinInputCount = settings.AbsoluteMinInputCount;
 
 		this.WhenAnyValue(x => x.Settings.CoordinatorUri)
 			.Subscribe(x => CoordinatorUri = x);
@@ -116,5 +119,29 @@ public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 		}
 
 		Settings.MaxCoinJoinMiningFeeRate = maxCoinJoinMiningFeeRateDecimal.ToString(CultureInfo.InvariantCulture);
+	}
+
+	private void ValidateAbsoluteMinInputCount(IValidationErrors errors)
+	{
+		var absoluteMinInputCount = AbsoluteMinInputCount;
+
+		if (string.IsNullOrEmpty(absoluteMinInputCount))
+		{
+			return;
+		}
+
+		if (!int.TryParse(absoluteMinInputCount, out var absoluteMinInputCountInt))
+		{
+			errors.Add(ErrorSeverity.Error, "Invalid number.");
+			return;
+		}
+
+		if (absoluteMinInputCountInt < 2)
+		{
+			errors.Add(ErrorSeverity.Error, "Absolute min input count should be at least 2");
+			return;
+		}
+
+		Settings.AbsoluteMinInputCount = absoluteMinInputCountInt.ToString(CultureInfo.InvariantCulture);
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -24,6 +24,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private const string RandomlySkippedRoundMessage = "Skipping a round for better privacy";
 	private const string CoordinationFeeRateTooHighMessage = "Coordination fee rate was too high";
 	private const string CoinjoinMiningFeeRateTooHighMessage = "Mining fee rate was too high";
+	private const string MinInputCountTooLowMessage = "Min input count was too low";
 	private const string PauseMessage = "Coinjoin is paused";
 	private const string StoppedMessage = "Coinjoin has stopped";
 	private const string PressPlayToStartMessage = "Press Play to start";
@@ -386,6 +387,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 					CoinjoinError.RandomlySkippedRound => RandomlySkippedRoundMessage,
 					CoinjoinError.CoordinationFeeRateTooHigh => CoordinationFeeRateTooHighMessage,
 					CoinjoinError.MiningFeeRateTooHigh => CoinjoinMiningFeeRateTooHighMessage,
+					CoinjoinError.MinInputCountTooLow => MinInputCountTooLowMessage,
 					_ => GeneralErrorMessage
 				};
 

--- a/WalletWasabi.Fluent/Views/Settings/CoordinatorTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/CoordinatorTabSettingsView.axaml
@@ -30,5 +30,9 @@
       <CurrencyEntryBox Classes="standalone" Name="CoinJoinMiningFeeRateTextBox" Text="{Binding MaxCoinJoinMiningFeeRate}" CurrencyCode="s/vb"/>
     </StackPanel>
 
+    <StackPanel ToolTip.Tip="The client will refuse to participate in rounds with a minimum input count lower than the value indicated here.">
+      <TextBlock Text="Min Input Count" />
+      <TextBox Classes="standalone" Name="AbsoluteMinInputCountTextBox" Text="{Binding AbsoluteMinInputCount}"/>
+    </StackPanel>
   </StackPanel>
 </UserControl>

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -342,7 +342,7 @@ public static class WabiSabiFactory
 			outputProvider,
 			roundStateUpdater,
 			coinSelector,
-			new CoinJoinConfiguration("CoinJoinCoordinatorIdentifier", 0.3m, 150.0m),
+			new CoinJoinConfiguration("CoinJoinCoordinatorIdentifier", 0.3m, 150.0m, 21),
 			new LiquidityClueProvider(),
 			TimeSpan.Zero,
 			TimeSpan.Zero,

--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
@@ -76,7 +76,8 @@ public class ConfigManagerNgTests
 			  "EnableGpu": true,
 			  "CoordinatorIdentifier": "CoinJoinCoordinatorIdentifier",
 			  "MaxCoordinationFeeRate": 0.0,
-			  "MaxCoinJoinMiningFeeRate": 150.0
+			  "MaxCoinJoinMiningFeeRate": 150.0,
+			  "AbsoluteMinInputCount": 21
 			}
 			""";
 

--- a/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullApplicationSettings.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullApplicationSettings.cs
@@ -20,6 +20,7 @@ public class NullApplicationSettings : IApplicationSettings
 	public string BitcoinP2PEndPoint { get; set; } = "";
 	public string MaxCoordinationFeeRate { get; set; } = "";
 	public string MaxCoinJoinMiningFeeRate { get; set; } = "";
+	public string AbsoluteMinInputCount { get; set; } = "";
 	public string CoordinatorUri { get; set; } = "";
 	public string BackendUri { get; set; } = "";
 	public string DustThreshold { get; set; } = "";

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -67,6 +67,7 @@ public static class Constants
 	public const decimal DefaultDustThreshold = 0.00005m;
 	public const decimal DefaultMaxCoordinationFeeRate = 0.0m;
 	public static readonly decimal DefaultMaxCoinJoinMiningFeeRate = 150.0m;
+	public static readonly int DefaultAbsoluteMinInputCount = 21;
 
 	public const string AlphaNumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 	public const string CapitalAlphaNumericCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -783,4 +783,4 @@ public class CoinJoinManager : BackgroundService
 	private record UiBlockedStateHolder(bool NeedRestart, bool StopWhenAllMixed, bool OverridePlebStop, IWallet OutputWallet);
 }
 
-public record CoinJoinConfiguration(string CoordinatorIdentifier, decimal MaxCoordinationFeeRate, decimal MaxCoinJoinMiningFeeRate);
+public record CoinJoinConfiguration(string CoordinatorIdentifier, decimal MaxCoordinationFeeRate, decimal MaxCoinJoinMiningFeeRate, int AbsoluteMinInputCount);

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/StatusChangedEvents/StatusChangedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/StatusChangedEvents/StatusChangedEventArgs.cs
@@ -32,6 +32,7 @@ public enum CoinjoinError
 	RandomlySkippedRound,
 	CoordinationFeeRateTooHigh,
 	MiningFeeRateTooHigh,
+	MinInputCountTooLow
 }
 
 public class StatusChangedEventArgs : EventArgs


### PR DESCRIPTION
I believe that this should be the last coordinator config.
We need to also have `Name` and `ReadMoreURI` but..... Those are not configs, there are coordinators properties, that we should probably store somewhere else.

These coordinator configs are also slightly annoying because most are network-agnostic, except the endpoint. I think it is ok, but it would probably be better to completely separate