### PR TITLE
Increase same tx allowance to 2 on average

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
@@ -210,40 +210,8 @@ public class CoinJoinCoinSelector
 		}
 		Logger.LogDebug($"Selected the final selection candidate: {finalCandidate.Count()} coins, {string.Join(", ", finalCandidate.Select(x => x.Amount.ToString(false, true)).ToArray())} BTC.");
 
-		// Let's remove some coins coming from the same tx in the final candidate:
-		// The smaller our balance is the more privacy we gain and the more the user cares about the costs, so more interconnectedness allowance makes sense.
-		var toRegister = finalCandidate.Sum(x => x.Amount);
-		int percent;
-		if (toRegister < 10_000)
-		{
-			percent = 20;
-		}
-		else if (toRegister < 100_000)
-		{
-			percent = 30;
-		}
-		else if (toRegister < 1_000_000)
-		{
-			percent = 40;
-		}
-		else if (toRegister < 10_000_000)
-		{
-			percent = 50;
-		}
-		else if (toRegister < 100_000_000) // 1 BTC
-		{
-			percent = 60;
-		}
-		else if (toRegister < 1_000_000_000)
-		{
-			percent = 70;
-		}
-		else
-		{
-			percent = 80;
-		}
-
-		int sameTxAllowance = Generator.GetRandomBiasedSameTxAllowance(percent);
+		// Let's remove some coins coming from the same tx in the final candidate, allow 2 on average.
+		int sameTxAllowance = Generator.GetRandomBiasedSameTxAllowance(67);
 
 		List<TCoin> winner = new()
 		{


### PR DESCRIPTION
Same Tx Allowance degrades performances and increase cost of coinjoin significantly for small wallets remixing a lot.

In fact, this comment:

> // The smaller our balance is the more privacy we gain and the more the user cares about the costs, so more interconnectedness allowance makes sense.

is incorrect because a small value for same tx allowance will result in less consolidation, which means higher costs, especially for small wallets.

It's a negative spiral because the coins get more decomposed, which would over time, further decrease the same tx allowance (as the registered amount will be reduced). Consolidation will also become harder and harder, same for payments into coinjoin etc etc etc

Even worse, we sort private coins by amount. Therefore, even if we try to avoid selecting coins from the same transaction, the coins of lower amounts tend to be from the same transactions. We remove them after selection, which creates cycles of coinjoins of 2-3 inputs but of 7-8 outputs....

As a result, I now believe that this is the main cause for crumbling problems for wallets remixing a lot.

This PR doesn't fix the problem, but tries to mitigate it significantly while being as safe and simple as possible. I used the magic number 67% because allowing 2 extra inputs coming from the same transactions, up more than 1.5 for small wallets, is what made sense to me. It is not the result of a thorough experiment. 

I believe this can be a good first step because if I'm correct we should see significant improvements improvement already, which should confort us into this direction being the correct area of research to mitigate the crumbling problem, which seems to have worsen with new paradigm.