### PR TITLE
Make Wasabi FREE by default (compatible)

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
@@ -42,7 +42,7 @@ public class ConfigManagerTests
 		// Change coordination fee rate.
 		{
 			// Double coordination fee rate.
-			config.CoordinationFeeRate = new CoordinationFeeRate(rate: 0.006m, plebsDontPayThreshold: Money.Coins(0.01m));
+			config.CoordinationFeeRate = new CoordinationFeeRate(rate: 0.006m);
 
 			// Change should be detected.
 			Assert.True(ConfigManager.CheckFileChange(configPath, config));
@@ -56,7 +56,7 @@ public class ConfigManagerTests
 			Assert.Equal(expectedFileContents, actualFileContents);
 		}
 
-		static string GetVanillaConfigString(decimal coordinationFeeRate = 0.003m)
+		static string GetVanillaConfigString(decimal coordinationFeeRate = 0.0m)
 				=> $$"""
 			{
 			  "ConfirmationTarget": 108,
@@ -84,8 +84,7 @@ public class ConfigManagerTests
 			  "MinInputCountByBlameRoundMultiplier": 0.4,
 			  "RoundDestroyerThreshold": 375,
 			  "CoordinationFeeRate": {
-			    "Rate": {{coordinationFeeRate}},
-			    "PlebsDontPayThreshold": 1000000
+			    "Rate": {{coordinationFeeRate}}
 			  },
 			  "CoordinatorExtPubKey": "xpub6C13JhXzjAhVRgeTcRSWqKEPe1vHi3Tmh2K9PN1cZaZFVjjSaj76y5NNyqYjc2bugj64LVDFYu8NZWtJsXNYKFb9J94nehLAPAKqKiXcebC",
 			  "CoordinatorExtPubKeyCurrentDepth": 1,

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -66,7 +66,7 @@ public class StepOutputRegistrationTests
 		Assert.Equal(Phase.TransactionSigning, round.Phase);
 		var tx = round.Assert<SigningState>().CreateTransaction();
 		Assert.Equal(2, tx.Inputs.Count);
-		Assert.Equal(2 + 1, tx.Outputs.Count); // +1 for the coordinator fee
+		Assert.Equal(2, tx.Outputs.Count);
 
 		await arena.StopAsync(token);
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterInputSuccessTests.cs
@@ -41,7 +41,7 @@ public class RegisterInputSuccessTests
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
-		var (resp, _) = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
+		var resp = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
 		AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
 
 		await arena.StopAsync(CancellationToken.None);
@@ -69,7 +69,7 @@ public class RegisterInputSuccessTests
 			arena);
 		var ownershipProof = OwnershipProof.GenerateCoinJoinInputProof(key, new OwnershipIdentifier(key, key.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit)), new CoinJoinInputCommitmentData("test", round.Id), ScriptPubKeyType.Segwit);
 
-		var (resp, _) = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
+		var resp = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
 		AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
 
 		await arena.StopAsync(CancellationToken.None);
@@ -92,11 +92,8 @@ public class RegisterInputSuccessTests
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id);
 
-		var (resp, _) = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
+		var resp = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
 		AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
-
-		var myAlice = Assert.Single(round.Alices);
-		Assert.True(myAlice.IsCoordinationFeeExempted);
 
 		await arena.StopAsync(CancellationToken.None);
 	}
@@ -140,7 +137,7 @@ public class RegisterInputSuccessTests
 		var arenaClient = WabiSabiFactory.CreateArenaClient(arena);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id, ScriptPubKeyType.TaprootBIP86);
 
-		var (resp, _) = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
+		var resp = await arenaClient.RegisterInputAsync(round.Id, coin.Outpoint, ownershipProof, CancellationToken.None);
 		AssertSingleAliceSuccessfullyRegistered(round, minAliceDeadline, resp);
 
 		await arena.StopAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -195,7 +195,7 @@ public class ArenaClientTests
 			wabiSabiApi);
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(key, round.Id, scriptPubKeyType);
 
-		var (inputRegistrationResponse, _) = await aliceArenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None);
+		var inputRegistrationResponse = await aliceArenaClient.RegisterInputAsync(round.Id, outpoint, ownershipProof, CancellationToken.None);
 		var aliceId = inputRegistrationResponse.Value;
 
 		var amountsToRequest = new[]
@@ -285,6 +285,6 @@ public class ArenaClientTests
 
 		var tx = round.Assert<SigningState>().CreateTransaction();
 		Assert.Single(tx.Inputs);
-		Assert.Equal(2 + 1, tx.Outputs.Count); // +1 because it pays coordination fees
+		Assert.Equal(2, tx.Outputs.Count);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -583,7 +583,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		RoundState round = rounds.First(x => x.CoinjoinState is ConstructionState);
 
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(signingKey, round.Id);
-		var (response, _) = await apiClient.RegisterInputAsync(round.Id, coinToRegister.Outpoint, ownershipProof, CancellationToken.None);
+		var response = await apiClient.RegisterInputAsync(round.Id, coinToRegister.Outpoint, ownershipProof, CancellationToken.None);
 
 		Assert.NotEqual(Guid.Empty, response.Value);
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -415,7 +415,7 @@ public class MultipartyTransactionTests
 		Random random = new(12345);
 
 		FeeRate feeRate = new(satoshiPerByte: decimal.Parse(feeRateString));
-		CoordinationFeeRate coordinatorFeeRate = new(0m, Money.Zero);
+		CoordinationFeeRate coordinatorFeeRate = CoordinationFeeRate.Zero;
 
 		var parameters = WabiSabiFactory.CreateRoundParameters(new()
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/SerializationTests.cs
@@ -44,8 +44,7 @@ public class SerializationTests
 		var message = new InputRegistrationResponse(
 			Guid.NewGuid(),
 			CreateCredentialsResponse(),
-			CreateCredentialsResponse(),
-			true);
+			CreateCredentialsResponse());
 
 		AssertSerialization(message);
 	}

--- a/WalletWasabi/Crypto/StrobeProtocol/StrobeHasherExtensions.cs
+++ b/WalletWasabi/Crypto/StrobeProtocol/StrobeHasherExtensions.cs
@@ -30,5 +30,5 @@ public static class StrobeHasherExtensions
 	public static StrobeHasher Append(this StrobeHasher hasher, string fieldName, CoordinationFeeRate coordinationFeeRate)
 		=> hasher
 			.Append($"{fieldName}.Rate", coordinationFeeRate.Rate)
-			.Append($"{fieldName}.PlebsDontPayThreshold", coordinationFeeRate.PlebsDontPayThreshold);
+			.Append($"{fieldName}.PlebsDontPayThreshold", Money.Zero);
 }

--- a/WalletWasabi/JsonConverters/DefaultValueCoordinationFeeRateAttribute.cs
+++ b/WalletWasabi/JsonConverters/DefaultValueCoordinationFeeRateAttribute.cs
@@ -1,4 +1,3 @@
-using NBitcoin;
 using System.ComponentModel;
 using WalletWasabi.WabiSabi.Models;
 
@@ -6,8 +5,8 @@ namespace WalletWasabi.JsonConverters;
 
 public class DefaultValueCoordinationFeeRateAttribute : DefaultValueAttribute
 {
-	public DefaultValueCoordinationFeeRateAttribute(double feeRate, double plebsDontPayThreshold)
-		: base(new CoordinationFeeRate((decimal)feeRate, Money.Coins((decimal)plebsDontPayThreshold)))
+	public DefaultValueCoordinationFeeRateAttribute(double feeRate)
+		: base(new CoordinationFeeRate((decimal)feeRate))
 	{
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/Alice.cs
@@ -15,7 +15,6 @@ public class Alice
 		Coin = coin;
 		OwnershipProof = ownershipProof;
 		Id = id;
-		IsCoordinationFeeExempted = isCoordinationFeeExempted;
 	}
 
 	public Round Round { get; }
@@ -28,12 +27,11 @@ public class Alice
 
 	public bool ConfirmedConnection { get; set; } = false;
 	public bool ReadyToSign { get; set; }
-	public bool IsCoordinationFeeExempted { get; } = false;
 
 	public long CalculateRemainingVsizeCredentials(int maxRegistrableSize) => maxRegistrableSize - TotalInputVsize;
 
 	public Money CalculateRemainingAmountCredentials(FeeRate feeRate, CoordinationFeeRate coordinationFeeRate) =>
-		Coin.EffectiveValue(feeRate, IsCoordinationFeeExempted ? CoordinationFeeRate.Zero : coordinationFeeRate);
+		Coin.EffectiveValue(feeRate, coordinationFeeRate);
 
 	public void SetDeadlineRelativeTo(TimeSpan connectionConfirmationTimeout)
 	{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -121,8 +121,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 
 			return new(alice.Id,
 				commitAmountCredentialResponse,
-				commitVsizeCredentialResponse,
-				alice.IsCoordinationFeeExempted);
+				commitVsizeCredentialResponse);
 		}
 	}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -19,7 +19,6 @@ using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
-using WalletWasabi.Helpers;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
@@ -627,7 +626,7 @@ public partial class Arena : PeriodicRunner
 		var sizeToPayFor = coinjoin.EstimatedVsize + coordinatorScriptPubKey.EstimateOutputVsize();
 		var miningFee = round.Parameters.MiningFeeRate.GetFee(sizeToPayFor) + Money.Satoshis(1);
 
-		var expectedCoordinationFee = round.Alices.Where(a => !a.IsCoordinationFeeExempted).Sum(x => round.Parameters.CoordinationFeeRate.GetFee(x.Coin.Amount));
+		var expectedCoordinationFee = round.Alices.Sum(x => round.Parameters.CoordinationFeeRate.GetFee(x.Coin.Amount));
 		var availableCoordinationFee = coinjoin.Balance - miningFee;
 
 		round.LogInfo($"Expected coordination fee: {expectedCoordinationFee} - Available coordination: {availableCoordinationFee}.");
@@ -697,11 +696,6 @@ public partial class Arena : PeriodicRunner
 	{
 		SigningState signingState = constructionState.Finalize();
 		return signingState;
-	}
-
-	public override void Dispose()
-	{
-		base.Dispose();
 	}
 
 	/// <summary>

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -131,9 +131,9 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "RoundDestroyerThreshold", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public int RoundDestroyerThreshold { get; set; } = 375;
 
-	[DefaultValueCoordinationFeeRate(0.003, 0.01)]
+	[DefaultValueCoordinationFeeRate(0.0)]
 	[JsonProperty(PropertyName = "CoordinationFeeRate", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public CoordinationFeeRate CoordinationFeeRate { get; set; } = new CoordinationFeeRate(0.003m, Money.Coins(0.01m));
+	public CoordinationFeeRate CoordinationFeeRate { get; set; } = new(0.0m);
 
 	[JsonProperty(PropertyName = "CoordinatorExtPubKey")]
 	public ExtPubKey CoordinatorExtPubKey { get; private set; } = NBitcoinHelpers.BetterParseExtPubKey(Constants.WabiSabiFallBackCoordinatorExtPubKey);

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/AliceClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/AliceClient.cs
@@ -24,8 +24,7 @@ public class AliceClient
 		ArenaClient arenaClient,
 		SmartCoin coin,
 		IEnumerable<Credential> issuedAmountCredentials,
-		IEnumerable<Credential> issuedVsizeCredentials,
-		bool isCoordinationFeeExempted)
+		IEnumerable<Credential> issuedVsizeCredentials)
 	{
 		var roundParameters = roundState.CoinjoinState.Parameters;
 		AliceId = aliceId;
@@ -38,7 +37,6 @@ public class AliceClient
 		IssuedVsizeCredentials = issuedVsizeCredentials;
 		MaxVsizeAllocationPerAlice = roundParameters.MaxVsizeAllocationPerAlice;
 		ConfirmationTimeout = roundParameters.ConnectionConfirmationTimeout / 2;
-		IsCoordinationFeeExempted = isCoordinationFeeExempted;
 	}
 
 	public Guid AliceId { get; }
@@ -51,7 +49,6 @@ public class AliceClient
 	public IEnumerable<Credential> IssuedVsizeCredentials { get; private set; }
 	private long MaxVsizeAllocationPerAlice { get; }
 	private TimeSpan ConfirmationTimeout { get; }
-	public bool IsCoordinationFeeExempted { get; }
 
 	public DateTimeOffset LastSuccessfulInputConnectionConfirmation { get; private set; } = DateTimeOffset.UtcNow;
 
@@ -110,8 +107,8 @@ public class AliceClient
 			coin,
 			new CoinJoinInputCommitmentData(arenaClient.CoordinatorIdentifier, roundState.Id));
 
-		var (response, isCoordinationFeeExempted) = await arenaClient.RegisterInputAsync(roundState.Id, coin.Coin.Outpoint, ownershipProof, cancellationToken).ConfigureAwait(false);
-		aliceClient = new(response.Value, roundState, arenaClient, coin, response.IssuedAmountCredentials, response.IssuedVsizeCredentials, isCoordinationFeeExempted);
+		var response = await arenaClient.RegisterInputAsync(roundState.Id, coin.Coin.Outpoint, ownershipProof, cancellationToken).ConfigureAwait(false);
+		aliceClient = new(response.Value, roundState, arenaClient, coin, response.IssuedAmountCredentials, response.IssuedVsizeCredentials);
 		coin.CoinJoinInProgress = true;
 
 		Logger.LogInfo($"Round ({roundState.Id}), Alice ({aliceClient.AliceId}): Registered {coin.Outpoint}.");
@@ -219,5 +216,5 @@ public class AliceClient
 		Logger.LogInfo($"Round ({RoundId}), Alice ({AliceId}): Ready to sign.");
 	}
 
-	public Money EffectiveValue => SmartCoin.EffectiveValue(FeeRate, IsCoordinationFeeExempted ? CoordinationFeeRate.Zero : CoordinationFeeRate);
+	public Money EffectiveValue => SmartCoin.EffectiveValue(FeeRate, CoordinationFeeRate);
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/ArenaClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/ArenaClient.cs
@@ -32,7 +32,7 @@ public class ArenaClient
 	public string CoordinatorIdentifier { get; }
 	public IWabiSabiApiRequestHandler RequestHandler { get; }
 
-	public async Task<(ArenaResponse<Guid> ArenaResponse, bool IsCoordinationFeeExempted)> RegisterInputAsync(
+	public async Task<ArenaResponse<Guid>> RegisterInputAsync(
 		uint256 roundId,
 		OutPoint outPoint,
 		OwnershipProof ownershipProof,
@@ -53,7 +53,7 @@ public class ArenaClient
 		var realAmountCredentials = AmountCredentialClient.HandleResponse(inputRegistrationResponse.AmountCredentials, zeroAmountCredentialRequestData.CredentialsResponseValidation);
 		var realVsizeCredentials = VsizeCredentialClient.HandleResponse(inputRegistrationResponse.VsizeCredentials, zeroVsizeCredentialRequestData.CredentialsResponseValidation);
 
-		return (new(inputRegistrationResponse.AliceId, realAmountCredentials, realVsizeCredentials), inputRegistrationResponse.IsCoordinationFeeExempted);
+		return new(inputRegistrationResponse.AliceId, realAmountCredentials, realVsizeCredentials);
 	}
 
 	public async Task RemoveInputAsync(uint256 roundId, Guid aliceId, CancellationToken cancellationToken)

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -719,7 +719,7 @@ public class CoinJoinClient
 		var inputNetworkFee = Money.Satoshis(registeredAliceClients.Sum(alice => feeRate.GetFee(alice.SmartCoin.Coin.ScriptPubKey.EstimateInputVsize())));
 		var outputNetworkFee = Money.Satoshis(myOutputs.Sum(output => feeRate.GetFee(output.ScriptPubKey.EstimateOutputVsize())));
 		var totalNetworkFee = inputNetworkFee + outputNetworkFee;
-		var totalCoordinationFee = Money.Satoshis(registeredAliceClients.Where(a => !a.IsCoordinationFeeExempted).Sum(a => roundParameters.CoordinationFeeRate.GetFee(a.SmartCoin.Amount)));
+		var totalCoordinationFee = Money.Satoshis(registeredAliceClients.Sum(a => roundParameters.CoordinationFeeRate.GetFee(a.SmartCoin.Amount)));
 
 		string[] summary = new string[]
 		{

--- a/WalletWasabi/WabiSabi/Models/CoordinationFeeRate.cs
+++ b/WalletWasabi/WabiSabi/Models/CoordinationFeeRate.cs
@@ -1,31 +1,20 @@
 using NBitcoin;
-using WalletWasabi.Helpers;
 
 namespace WalletWasabi.WabiSabi.Models;
 
 public readonly struct CoordinationFeeRate
 {
-	public static readonly CoordinationFeeRate Zero = new(0, Money.Zero);
+	public static readonly CoordinationFeeRate Zero = new(0);
 
-	public CoordinationFeeRate(decimal rate, Money plebsDontPayThreshold)
+	public CoordinationFeeRate(decimal rate)
 	{
-		Rate = Guard.InRangeAndNotNull(nameof(rate), rate, 0m, 0.01m);
-		PlebsDontPayThreshold = plebsDontPayThreshold ?? Money.Zero;
+		Rate = rate >= 0 ? rate : throw new ArgumentOutOfRangeException(nameof(rate));
 	}
 
 	public decimal Rate { get; }
-	public Money PlebsDontPayThreshold { get; }
 
 	public Money GetFee(Money amount)
 	{
-		// Plebs don't have to pay.
-		if (amount <= PlebsDontPayThreshold)
-		{
-			return Money.Zero;
-		}
-		else
-		{
-			return Money.Satoshis(Math.Floor(amount.Satoshi * Rate));
-		}
+		return Money.Satoshis(Math.Floor(amount.Satoshi * Rate));
 	}
 }

--- a/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
+++ b/WalletWasabi/WabiSabi/Models/InputRegistrationResponse.cs
@@ -6,6 +6,5 @@ namespace WalletWasabi.WabiSabi.Models;
 public record InputRegistrationResponse(
 	Guid AliceId,
 	CredentialsResponse AmountCredentials,
-	CredentialsResponse VsizeCredentials,
-	[property: JsonProperty("isPayingZeroCoordinationFee")] bool IsCoordinationFeeExempted
+	CredentialsResponse VsizeCredentials
 );


### PR DESCRIPTION
This is the same that https://github.com/WalletWasabi/WalletWasabi/pull/13005 but it doesn't break backward compatibility. The thing is that the coordinator continue sending the `plebsDontPayThreshold` to the client, and committing to it as part of the round id, but the value is hardcoded to 0 (zero).