### PR TITLE
Migrate MaxCoordinationFeeRate to rate

### DIFF
--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -176,8 +176,6 @@ public record PersistentConfig
 		return this;
 	}
 
-
-
 	private PersistentConfig MigrateMaxCoordinationFeeRate()
 	{
 		return this with

--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -29,13 +29,13 @@ public record PersistentConfig
 	/// </remarks>
 	public object UseTor { get; init; } = "Enabled";
 
-	public bool TerminateTorOnExit { get; init; } = false;
+	public bool TerminateTorOnExit { get; init; }
 
 	public string[] TorBridges { get; init; } = [];
 
 	public bool DownloadNewVersion { get; init; } = true;
 
-	public bool StartLocalBitcoinCoreOnStartup { get; init; } = false;
+	public bool StartLocalBitcoinCoreOnStartup { get; init; }
 
 	public bool StopLocalBitcoinCoreOnShutdown { get; init; } = true;
 
@@ -53,11 +53,11 @@ public record PersistentConfig
 
 	public string JsonRpcPassword { get; init; } = "";
 
-	public string[] JsonRpcServerPrefixes { get; init; } = new[]
-	{
+	public string[] JsonRpcServerPrefixes { get; init; } =
+	[
 		"http://127.0.0.1:37128/",
 		"http://localhost:37128/"
-	};
+	];
 
 	public Money DustThreshold { get; init; } = Money.Coins(Constants.DefaultDustThreshold);
 
@@ -70,12 +70,14 @@ public record PersistentConfig
 	public decimal MaxCoinJoinMiningFeeRate { get; init; } = Constants.DefaultMaxCoinJoinMiningFeeRate;
 
 	public int AbsoluteMinInputCount { get; init; } = Constants.DefaultAbsoluteMinInputCount;
+	public int ConfigVersion { get; init; }
 
 	public bool DeepEquals(PersistentConfig other)
 	{
 		bool useTorIsEqual = Config.ObjectToTorMode(UseTor) == Config.ObjectToTorMode(other.UseTor);
 
 		return
+			ConfigVersion == other.ConfigVersion &&
 			Network == other.Network &&
 			MainNetBackendUri == other.MainNetBackendUri &&
 			TestNetBackendUri == other.TestNetBackendUri &&
@@ -161,21 +163,36 @@ public record PersistentConfig
 		throw new NotSupportedNetworkException(Network);
 	}
 
-	public bool MigrateOldDefaultBackendUris([NotNullWhen(true)] out PersistentConfig? newConfig)
-	{
-		bool hasChanged = false;
-		newConfig = null;
+	public PersistentConfig Migrate() =>
+		MigrateMaxCoordinationFeeRate()
+		.MigrateOldDefaultBackendUris();
 
+
+	private PersistentConfig MigrateMaxCoordinationFeeRate()
+	{
+		if (ConfigVersion == 0)
+		{
+			return this with
+			{
+				ConfigVersion = 1,
+				MaxCoordinationFeeRate = MaxCoordinationFeeRate / 100.0m
+			};
+		}
+
+		return this;
+	}
+
+	private PersistentConfig MigrateOldDefaultBackendUris()
+	{
 		if (MainNetBackendUri == "https://wasabiwallet.io/" || TestNetBackendUri == "https://wasabiwallet.co/")
 		{
-			hasChanged = true;
-			newConfig = this with
+			return this with
 			{
 				MainNetBackendUri = "https://api.wasabiwallet.io/",
 				TestNetBackendUri = "https://api.wasabiwallet.co/",
 			};
 		}
 
-		return hasChanged;
+		return this;
 	}
 }

--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -163,23 +163,27 @@ public record PersistentConfig
 		throw new NotSupportedNetworkException(Network);
 	}
 
-	public PersistentConfig Migrate() =>
-		MigrateMaxCoordinationFeeRate()
-		.MigrateOldDefaultBackendUris();
-
-
-	private PersistentConfig MigrateMaxCoordinationFeeRate()
+	public PersistentConfig Migrate()
 	{
 		if (ConfigVersion == 0)
 		{
-			return this with
+			return MigrateMaxCoordinationFeeRate().MigrateOldDefaultBackendUris() with
 			{
-				ConfigVersion = 1,
-				MaxCoordinationFeeRate = MaxCoordinationFeeRate / 100.0m
+				ConfigVersion = 1
 			};
 		}
 
 		return this;
+	}
+
+
+
+	private PersistentConfig MigrateMaxCoordinationFeeRate()
+	{
+		return this with
+		{
+			MaxCoordinationFeeRate = MaxCoordinationFeeRate / 100.0m
+		};
 	}
 
 	private PersistentConfig MigrateOldDefaultBackendUris()

--- a/WalletWasabi.Daemon/WasabiApplication.cs
+++ b/WalletWasabi.Daemon/WasabiApplication.cs
@@ -105,7 +105,8 @@ public class WasabiApplication
 	{
 		PersistentConfig persistentConfig = ConfigManagerNg.LoadFile<PersistentConfig>(ConfigFilePath, createIfMissing: true);
 
-		if (persistentConfig.MigrateOldDefaultBackendUris(out PersistentConfig? newConfig))
+		var newConfig = persistentConfig.Migrate();
+		if (!persistentConfig.DeepEquals(newConfig))
 		{
 			persistentConfig = newConfig;
 			ConfigManagerNg.ToFile(ConfigFilePath, persistentConfig);

--- a/WalletWasabi.Fluent/Views/Settings/CoordinatorTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/CoordinatorTabSettingsView.axaml
@@ -20,9 +20,9 @@
       </TextBox>
     </StackPanel>
 
-    <StackPanel ToolTip.Tip="The client will refuse to participate in rounds charging a coordination fee rate (percentage) higher than the value indicated here.">
-      <TextBlock Text="Max Coordination Fee (percent)" />
-      <CurrencyEntryBox Classes="standalone" Name="CoordinationFeeRateTextBox" Text="{Binding MaxCoordinationFeeRate}" CurrencyCode="%" />
+    <StackPanel ToolTip.Tip="The client will refuse to participate in rounds charging a coordination fee rate higher than the value indicated here.">
+      <TextBlock Text="Max Coordination Fee Rate" />
+      <CurrencyEntryBox Classes="standalone" Name="CoordinationFeeRateTextBox" Text="{Binding MaxCoordinationFeeRate}"/>
     </StackPanel>
 
     <StackPanel ToolTip.Tip="The client will refuse to participate in rounds with a mining fee rate (s/vb) higher than the value indicated here.">

--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
@@ -77,7 +77,8 @@ public class ConfigManagerNgTests
 			  "CoordinatorIdentifier": "CoinJoinCoordinatorIdentifier",
 			  "MaxCoordinationFeeRate": 0.0,
 			  "MaxCoinJoinMiningFeeRate": 150.0,
-			  "AbsoluteMinInputCount": 21
+			  "AbsoluteMinInputCount": 21,
+			  "ConfigVersion": 0
 			}
 			""";
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -131,10 +131,10 @@ public class CoinJoinClient
 			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: the round is not economic.");
 		}
 
-		if (roundState.CoinjoinState.Parameters.CoordinationFeeRate.Rate * 100 > CoinJoinConfiguration.MaxCoordinationFeeRate)
+		if (roundState.CoinjoinState.Parameters.CoordinationFeeRate.Rate > CoinJoinConfiguration.MaxCoordinationFeeRate)
 		{
 			throw new InvalidOperationException($"Blame Round ({roundState.Id}): Abandoning: " +
-			                                    $"the coordinator is malicious and tried to trick the client into paying a coordination fee rate of {roundState.CoinjoinState.Parameters.CoordinationFeeRate.Rate * 100}% for the blame round");
+			                                    $"the coordinator is malicious and tried to trick the client into paying a coordination fee rate of {roundState.CoinjoinState.Parameters.CoordinationFeeRate.Rate} for the blame round");
 		}
 
 		if (roundState.CoinjoinState.Parameters.MiningFeeRate.SatoshiPerByte > CoinJoinConfiguration.MaxCoinJoinMiningFeeRate)
@@ -169,9 +169,9 @@ public class CoinJoinClient
 					currentRoundState.LogInfo(roundSkippedMessage);
 					throw new CoinJoinClientException(CoinjoinError.UneconomicalRound, roundSkippedMessage);
 				}
-				if (roundParameters.CoordinationFeeRate.Rate * 100 > CoinJoinConfiguration.MaxCoordinationFeeRate)
+				if (roundParameters.CoordinationFeeRate.Rate > CoinJoinConfiguration.MaxCoordinationFeeRate)
 				{
-					string roundSkippedMessage = $"Coordination fee rate was {roundParameters.CoordinationFeeRate.Rate * 100} but max allowed is {CoinJoinConfiguration.MaxCoordinationFeeRate}.";
+					string roundSkippedMessage = $"Coordination fee rate was {roundParameters.CoordinationFeeRate.Rate} but max allowed is {CoinJoinConfiguration.MaxCoordinationFeeRate}.";
 					currentRoundState.LogInfo(roundSkippedMessage);
 					throw new CoinJoinClientException(CoinjoinError.CoordinationFeeRateTooHigh, roundSkippedMessage);
 				}


### PR DESCRIPTION
This PR changes the `MaxCoordinationFeeRate`  semantic from percentage to rate value to make it content consistent with its name and the rest of the code base.

It adds a version number to the config file in order to know which migrations needs to be done. Ideally we should move to something like what I did for Wasabito: https://github.com/lontivero/Wasabito/commit/1e18aa0e2332a14c69761edb43bb9d5eefe0f9a4 (see config files there) 