### PR TITLE
make sure coins are updated when selecting a wallet

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/CoinListModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/CoinListModel.cs
@@ -24,11 +24,13 @@ public abstract partial class CoinListModel : IDisposable
 		var transactionProcessed = walletModel.Transactions.TransactionProcessed;
 		var anonScoreTargetChanged = this.WhenAnyValue(x => x.WalletModel.Settings.AnonScoreTarget).Skip(1).ToSignal();
 		var isCoinjoinRunningChanged = walletModel.Coinjoin.IsRunning.ToSignal();
+		var isSelected = this.WhenAnyValue(x => x.WalletModel.IsSelected).Skip(1).ToSignal();
 
 		var signals =
 			transactionProcessed
 				.Merge(anonScoreTargetChanged)
 				.Merge(isCoinjoinRunningChanged)
+				.Merge(isSelected)
 				.Publish();
 
 		Pockets = signals.Fetch(GetPockets, x => x.Labels).DisposeWith(_disposables);

--- a/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
@@ -22,6 +22,7 @@ public partial class WalletModel : ReactiveObject
 
 	[AutoNotify] private bool _isLoggedIn;
 	[AutoNotify] private bool _isLoaded;
+	[AutoNotify] private bool _isSelected;
 
 	public WalletModel(Wallet wallet, IAmountProvider amountProvider)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletPageViewModel.cs
@@ -68,6 +68,10 @@ public partial class WalletPageViewModel : ViewModelBase, IDisposable
 			.BindTo(this, x => x.Title)
 			.DisposeWith(_disposables);
 
+		this.WhenAnyValue(x => x.IsSelected)
+			.Do(value => WalletModel.IsSelected = value)
+			.Subscribe();
+
 		SetIcon();
 	}
 

--- a/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
@@ -114,3 +114,4 @@ public class ReceiveAddressViewModelTests
 		}
 	}
 }
+

--- a/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
@@ -114,4 +114,3 @@ public class ReceiveAddressViewModelTests
 		}
 	}
 }
-

--- a/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
@@ -75,6 +75,8 @@ public class ReceiveAddressViewModelTests
 
 		public bool IsLoaded { get; set; }
 
+		public bool IsSelected { get; set; }
+
 		public IAddress GetNextReceiveAddress(IEnumerable<string> destinationLabels)
 		{
 			throw new NotSupportedException();

--- a/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
@@ -207,6 +207,8 @@ public class SuggestionLabelsViewModelTests
 
 		public bool IsLoaded { get; set; }
 
+		public bool IsSelected { get; set; }
+
 		public IAddress GetNextReceiveAddress(IEnumerable<string> destinationLabels)
 		{
 			throw new NotSupportedException();


### PR DESCRIPTION
Closes https://github.com/WalletWasabi/WalletWasabi/issues/12927

The current design doesn't allow only load values when a wallet is selected, and I am not even sure how much refactoring is needed to achieve it.
(The first sign of it is the usage of Lazy)

This is the minimum change to fix the issue.