### PR TITLE
Fix Privacy progress tile is incorrect

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/CoinListModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/CoinListModel.cs
@@ -33,7 +33,7 @@ public abstract partial class CoinListModel : IDisposable
 				.Publish();
 
 		Pockets = signals.Fetch(GetPockets, x => x.Labels).DisposeWith(_disposables);
-		List = Pockets.Connect().MergeMany(x => x.Coins.Select(CreateCoinModel).AsObservableChangeSet()).AddKey(x => x.Key).AsObservableCache();
+		List = signals.Fetch(() => Wallet.Coins.Select(CreateCoinModel), x => x.Key).DisposeWith(_disposables);
 
 		signals
 			.Do(_ => Logger.LogDebug($"Refresh signal emitted in {walletModel.Name}"))


### PR DESCRIPTION
Fixes https://github.com/WalletWasabi/WalletWasabi/issues/13127

The previous code kept the old coin in the list even if it left the wallet which resulted in the issue mentioned above.

_(This is another example that we do not understand Reactive and things don't work as we expect, we should decrease the usage of it)_