### PR TITLE
Quick patch for Coordinator string

### DIFF
--- a/WalletWasabi/Discoverability/CoordinatorConnectionString.cs
+++ b/WalletWasabi/Discoverability/CoordinatorConnectionString.cs
@@ -53,7 +53,7 @@ public record CoordinatorConnectionString(
 			return false;
 		}
 
-		if (!decimal.TryParse(queryString["coordinationFeeRate"], NumberStyles.Any, CultureInfo.InvariantCulture, out var coordinationFeeRate))
+		if (!decimal.TryParse(queryString["coordinationFeeRate"], NumberStyles.Any, CultureInfo.InvariantCulture, out var coordinationFeeRate) || coordinationFeeRate < 0)
 		{
 			return false;
 		}

--- a/WalletWasabi/Discoverability/CoordinatorConnectionString.cs
+++ b/WalletWasabi/Discoverability/CoordinatorConnectionString.cs
@@ -17,19 +17,15 @@ public record CoordinatorConnectionString(
 {
 	public override string ToString()
 	{
-		var builder = new UriBuilder
-		{
-			Query = new NameValueCollection
-			{
-				["name"] = Uri.EscapeDataString(Name),
-				["network"] = Network.Name,
-				["coordinatorUri"] = Uri.EscapeDataString(CoordinatorUri.ToString()),
-				["coordinationFeeRate"] = CoordinationFeeRate.ToString(CultureInfo.InvariantCulture),
-				["absoluteMinInputCount"] = AbsoluteMinInputCount.ToString(),
-				["readMore"] = Uri.EscapeDataString(ReadMore.ToString())
-			}.ToString()
-		};
-		return builder.ToString();
+		return string.Join("&",
+		[
+			$"name={Uri.EscapeDataString(Name)}",
+			$"network={Network.Name}",
+			$"coordinatorUri={Uri.EscapeDataString(CoordinatorUri.ToString())}",
+			$"coordinationFeeRate={CoordinationFeeRate.ToString(CultureInfo.InvariantCulture)}",
+			$"readMore={Uri.EscapeDataString(ReadMore.ToString())}",
+			$"absoluteMinInputCount={AbsoluteMinInputCount.ToString()}",
+		]);
 	}
 
 	public static bool TryParse(string s, [NotNullWhen(true)] out CoordinatorConnectionString? coordinatorConnectionString)


### PR DESCRIPTION
- negative coordination fee rate is not accepted
- ToString method is fixed so it will pop a new dialog in the case of a new magic string while and old one is being opened.