### PR TITLE
More strict coinjoin parameters

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -193,9 +193,14 @@ public class Config
 
 	public bool EnableGpu => GetEffectiveValue<BoolValue, bool>(nameof(EnableGpu));
 	public string CoordinatorIdentifier => GetEffectiveValue<StringValue, string>(nameof(CoordinatorIdentifier));
-	public decimal MaxCoordinationFeeRate => GetEffectiveValue<DecimalValue, decimal>(nameof(MaxCoordinationFeeRate));
+	public decimal MaxCoordinationFeeRate => decimal.Min(
+		GetEffectiveValue<DecimalValue, decimal>(nameof(MaxCoordinationFeeRate)),
+		Constants.AbsoluteMaxCoordinationFeeRate);
 	public decimal MaxCoinjoinMiningFeeRate => GetEffectiveValue<DecimalValue, decimal>(nameof(MaxCoinjoinMiningFeeRate));
-	public int AbsoluteMinInputCount => GetEffectiveValue<IntValue, int>(nameof(AbsoluteMinInputCount));
+	public int AbsoluteMinInputCount => int.Max(
+		GetEffectiveValue<IntValue, int>(nameof(AbsoluteMinInputCount)),
+		Constants.AbsoluteMinInputCount);
+
 	public ServiceConfiguration ServiceConfiguration { get; }
 
 	public static string DataDir { get; } = GetStringValue(

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -400,7 +400,7 @@ public class Global
 		Tor.Http.IHttpClient roundStateUpdaterHttpClient = CoordinatorHttpClientFactory.NewHttpClient(Mode.SingleCircuitPerLifetime, RoundStateUpdaterCircuit);
 		HostedServices.Register<RoundStateUpdater>(() => new RoundStateUpdater(TimeSpan.FromSeconds(10), new WabiSabiHttpApiClient(roundStateUpdaterHttpClient)), "Round info updater");
 
-		var coinJoinConfiguration = new CoinJoinConfiguration(Config.CoordinatorIdentifier, Config.MaxCoordinationFeeRate, Config.MaxCoinjoinMiningFeeRate, Config.AbsoluteMinInputCount);
+		var coinJoinConfiguration = new CoinJoinConfiguration(Config.CoordinatorIdentifier, Config.MaxCoordinationFeeRate, Config.MaxCoinjoinMiningFeeRate, Config.AbsoluteMinInputCount, AllowSoloCoinjoining: false);
 		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager, HostedServices.Get<RoundStateUpdater>(), CoordinatorHttpClientFactory, HostedServices.Get<WasabiSynchronizer>(), coinJoinConfiguration, CoinPrison), "CoinJoin Manager");
 	}
 

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -341,7 +341,7 @@ public static class WabiSabiFactory
 			outputProvider,
 			roundStateUpdater,
 			coinSelector,
-			new CoinJoinConfiguration("CoinJoinCoordinatorIdentifier", 0.3m, 150.0m, 1),
+			new CoinJoinConfiguration("CoinJoinCoordinatorIdentifier", 0.3m, 150.0m, 1, AllowSoloCoinjoining: true),
 			new LiquidityClueProvider(),
 			TimeSpan.Zero,
 			TimeSpan.Zero,

--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
@@ -42,7 +42,7 @@ public class ConfigManagerTests
 		// Change coordination fee rate.
 		{
 			// Double coordination fee rate.
-			config.CoordinationFeeRate = new CoordinationFeeRate(rate: 0.006m);
+			config.CoordinationFeeRate = new CoordinationFeeRate(rate: 0.005m);
 
 			// Change should be detected.
 			Assert.True(ConfigManager.CheckFileChange(configPath, config));
@@ -50,7 +50,7 @@ public class ConfigManagerTests
 			// Now store and check that JSON is as expected.
 			config.ToFile();
 
-			string expectedFileContents = GetVanillaConfigString(coordinationFeeRate: 0.006m);
+			string expectedFileContents = GetVanillaConfigString(coordinationFeeRate: 0.005m);
 			string actualFileContents = ReadAllTextAndNormalize(configPath);
 
 			Assert.Equal(expectedFileContents, actualFileContents);

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -68,8 +68,8 @@ public static class Constants
 	public const decimal DefaultMaxCoordinationFeeRate = 0.0m;
 	public const decimal DefaultMaxCoinJoinMiningFeeRate = 150.0m;
 	public const int DefaultAbsoluteMinInputCount = 21;
-	public const int AbsoluteMinInputCount = 2;
-	public const decimal AbsoluteMaxCoordinationFeeRate = 0.01m;
+	public const int AbsoluteMinInputCount = 5;
+	public const decimal AbsoluteMaxCoordinationFeeRate = 0.005m;
 
 	public const string AlphaNumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 	public const string CapitalAlphaNumericCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -876,21 +876,32 @@ public class CoinJoinClient
 		// now when we identify as satoshi.
 		// In this scenario we should ban the coordinator and stop dealing with it.
 		// see more: https://github.com/WalletWasabi/WalletWasabi/issues/8171
-		bool mustSignAllInputs = SanityCheck(outputTxOuts, unsignedCoinJoin.Transaction.Outputs);
+		var isItSoloCoinjoin =  signingState.Inputs.Count() == registeredAliceClients.Length;
+		var isItForbiddenSoloCoinjoining = isItSoloCoinjoin && !CoinJoinConfiguration.AllowSoloCoinjoining;
+		if (isItForbiddenSoloCoinjoining)
+		{
+			roundState.LogInfo($"I am the only one in that coinjoin.");
+		}
+		bool allMyOutputsArePresent = SanityCheck(outputTxOuts, unsignedCoinJoin.Transaction.Outputs);
+
+		if (!allMyOutputsArePresent)
+		{
+			roundState.LogInfo($"There are missing outputs.");
+		}
+
+		// Assert that the effective fee rate is at least what was agreed on.
+		// Otherwise, coordinator could take some of the mining fees for itself.
+		// There is a tolerance because before constructing the transaction only an estimation can be computed.
+		var isCoordinatorTakingExtraFees = signingState.EffectiveFeeRate.FeePerK.Satoshi <= signingState.Parameters.MiningFeeRate.FeePerK.Satoshi * 0.90;
+		if (isCoordinatorTakingExtraFees)
+		{
+			roundState.LogInfo($"Effective fee rate of the transaction is lower than expected.");
+		}
+
+		var mustSignAllInputs = !isItForbiddenSoloCoinjoining && allMyOutputsArePresent && !isCoordinatorTakingExtraFees;
 		if (!mustSignAllInputs)
 		{
-			roundState.LogInfo($"There are missing outputs. A subset of inputs will be signed.");
-		}
-		else
-		{
-			// Assert that the effective fee rate is at least what was agreed on.
-			// Otherwise, coordinator could take some of the mining fees for itself.
-			// There is a tolerance because before constructing the transaction only an estimation can be computed.
-			mustSignAllInputs = signingState.EffectiveFeeRate.FeePerK.Satoshi > signingState.Parameters.MiningFeeRate.FeePerK.Satoshi * 0.90;
-			if (!mustSignAllInputs)
-			{
-				roundState.LogInfo($"Effective fee rate of the transaction is lower than expected. A subset of inputs will be signed.");
-			}
+			roundState.LogInfo($"A subset of inputs will be signed.	");
 		}
 
 		// Send signature.

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -783,4 +783,4 @@ public class CoinJoinManager : BackgroundService
 	private record UiBlockedStateHolder(bool NeedRestart, bool StopWhenAllMixed, bool OverridePlebStop, IWallet OutputWallet);
 }
 
-public record CoinJoinConfiguration(string CoordinatorIdentifier, decimal MaxCoordinationFeeRate, decimal MaxCoinJoinMiningFeeRate, int AbsoluteMinInputCount);
+public record CoinJoinConfiguration(string CoordinatorIdentifier, decimal MaxCoordinationFeeRate, decimal MaxCoinJoinMiningFeeRate, int AbsoluteMinInputCount, bool AllowSoloCoinjoining);


### PR DESCRIPTION
This PR reduce the absolute max coordination fee to 0.005 and the absolute min input count to 5 while prevents solo coinjoining.