### PR TITLE
Ignore compilation warning 

### DIFF
--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
+		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822;NU1903</NoWarn>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>


### PR DESCRIPTION
Ignore vulnerability warning until the dotnet sdk is available and installed by the team.