### PR TITLE
Fix CreateCoinModels logic

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/CoinListModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/CoinListModel.cs
@@ -33,7 +33,7 @@ public abstract partial class CoinListModel : IDisposable
 				.Publish();
 
 		Pockets = signals.Fetch(GetPockets, x => x.Labels).DisposeWith(_disposables);
-		List = signals.Fetch(() => Wallet.Coins.Select(CreateCoinModel), x => x.Key).DisposeWith(_disposables);
+		List = signals.Fetch(CreateCoinModels, x => x.Key).DisposeWith(_disposables);
 
 		signals
 			.Do(_ => Logger.LogDebug($"Refresh signal emitted in {walletModel.Name}"))
@@ -56,14 +56,14 @@ public abstract partial class CoinListModel : IDisposable
 		return List.Items.First(coinModel => coinModel.Key == smartCoin.Outpoint.GetHashCode());
 	}
 
-	private ICoinModel CreateCoinModel(SmartCoin smartCoin)
+	protected ICoinModel CreateCoinModel(SmartCoin smartCoin)
 	{
 		return new CoinModel(smartCoin, WalletModel.Settings.AnonScoreTarget);
 	}
 
 	protected abstract Pocket[] GetPockets();
 
-	protected abstract ICoinModel[] GetCoins();
+	protected abstract ICoinModel[] CreateCoinModels();
 
 	public void Dispose() => _disposables.Dispose();
 }

--- a/WalletWasabi.Fluent/Models/Wallets/UserSelectionCoinListModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/UserSelectionCoinListModel.cs
@@ -9,9 +9,9 @@ namespace WalletWasabi.Fluent.Models.Wallets;
 [AutoInterface]
 public partial class UserSelectionCoinListModel(Wallet wallet, IWalletModel walletModel, SmartCoin[] selectedCoins) : CoinListModel(wallet, walletModel)
 {
-	protected override ICoinModel[] GetCoins()
+	protected override ICoinModel[] CreateCoinModels()
 	{
-		return selectedCoins.Select(GetCoinModel).ToArray();
+		return selectedCoins.Select(CreateCoinModel).ToArray();
 	}
 
 	protected override Pocket[] GetPockets()

--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
@@ -41,8 +41,8 @@ public partial class WalletCoinsModel(Wallet wallet, IWalletModel walletModel) :
 		return Wallet.GetPockets().ToArray();
 	}
 
-	protected override ICoinModel[] GetCoins()
+	protected override ICoinModel[] CreateCoinModels()
 	{
-		return Wallet.Coins.Select(GetCoinModel).ToArray();
+		return Wallet.Coins.Select(CreateCoinModel).ToArray();
 	}
 }


### PR DESCRIPTION
The `CoinListModel` class is used for Wallet Coins and for the selection list of Manual Control. In the case of the second the logic was wrong because the class held the total number of coins instead of only the selected one.