### PR TITLE
Improve Fee estimation based on mempool histogram

### DIFF
--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -164,7 +164,9 @@ public static class RPCClientExtensions
 		// then we don't want our estimations to be affected by those rare cases.
 		var relevantFeeGroups = mempoolInfo.Histogram
 			.OrderByDescending(x => x.Group)
-			.SkipWhile(x => x.Count < mempoolInfo.Size / 1_000);
+			.SkipWhile((_, index) => mempoolInfo.Histogram.Take(index + 1).Sum(g => g.Count) < mempoolInfo.Size / 1_000)
+			.ToList();
+
 
 		// Splits multi-megabyte fee rate groups in 1mb chunk
 		// We need to count blocks (or 1MvB transaction chunks) so, in case fee

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -162,11 +162,13 @@ public static class RPCClientExtensions
 		// Filter those groups with very high fee transactions (less than 0.1%).
 		// This is because in case a few transactions pay unreasonably high fees
 		// then we don't want our estimations to be affected by those rare cases.
-		var relevantFeeGroups = mempoolInfo.Histogram
-			.OrderByDescending(x => x.Group)
-			.SkipWhile((_, index) => mempoolInfo.Histogram.Take(index + 1).Sum(g => g.Count) < mempoolInfo.Size / 1_000)
+		var histogram = mempoolInfo.Histogram.OrderByDescending(x => x.Group).ToArray();
+		var relevantFeeGroups = histogram
+			.Scan(0u, (acc, g) => acc + g.Count)
+			.Zip(histogram, (x, y) => (AccumulativeCount: x, Group: y))
+			.SkipWhile(x => x.AccumulativeCount < mempoolInfo.Size / 1_000)
+			.Select(x => x.Group)
 			.ToList();
-
 
 		// Splits multi-megabyte fee rate groups in 1mb chunk
 		// We need to count blocks (or 1MvB transaction chunks) so, in case fee


### PR DESCRIPTION
This PR, as it titles implies, uses the cumulative Count instead of the Count to skip fee groups

This piece of code as several conceptual flaws that lead to poor results.

I want to take them one at a time, and this is the biggest and easiest to solve one:
`FeeRateGroup.Count` is not cumulative ([source](https://github.com/bitcoinknots/bitcoin/blob/01ac32f90b6de7510c35a7fa2f35ca1ff6c0a5c2/src/rpc/mempool.cpp#L946)), so currently the concept is `Skip groups until we find one that has more txs in it than 0.001 * total number of txs in the mempool`

I believe it's a clear mistake, first because the logic sounds fishy but also because it's not in accordance with the comment right above `(less than 0.1%).`, which implies that only 0.1% of the transactions can be skipped, which is not true (much more can be skipped)

It will not fix all the problems caused by this piece of code, but will mitigate them strongly. Here's an example where this code led to problems:

![CleanShot 2024-07-21 at 11 44 22@2x](https://github.com/user-attachments/assets/31521310-4c8f-4b5c-ac51-4128a28405cd)

The 4 s/vb group was ignored because it contained less than 143 transactions in it. This then sowballed into the estimator thinking that the priority fee was 3 s/vb, when in fact there is a massive wall of transactions (something like 20 blocks worth) at 3.77 s/vb.

We can see that with this PR, this would be less likely to happen, but the problem will still be present.
Please note that in high fees environment with higher variance in fees and bigger mempool the problem is even worse.
