### PR TITLE
Allow connection to puned local node

### DIFF
--- a/WalletWasabi/BitcoinCore/P2pNode.cs
+++ b/WalletWasabi/BitcoinCore/P2pNode.cs
@@ -64,7 +64,7 @@ public class P2pNode
 
 		if (!Node.PeerVersion.Services.HasFlag(NodeServices.Network))
 		{
-			throw new InvalidOperationException("Wasabi cannot use the local node because it does not provide blocks.");
+			Logger.LogWarning("The local node because it does not provide blocks.");
 		}
 
 		if (!Node.IsConnected)


### PR DESCRIPTION
In the context of our downsize efforts, the backend server should be able to work with pruned nodes. The `IndexBuilderService`  doesn't really needs a full blockchain but it can work with a manually prune one from the segwit activation height to generate the filters. However, once the filters have been generated, the blockchain can be pruned even further or automatically pruned.

Other features that prevent pruning  are those that use the transaction index, basically the `GetRawTransaction`  which we are removing in next prs.