### PR TITLE
Fix shared transaction overhead calculation

### DIFF
--- a/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
@@ -2,10 +2,10 @@ using NBitcoin;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
 using WalletWasabi.WabiSabi.Backend.Rounds;
-using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
 namespace WalletWasabi.Tests.Helpers;
 
@@ -83,5 +83,5 @@ public class ArenaBuilder
 	public static ArenaBuilder From(WabiSabiConfig cfg, IRPCClient mockRpc, Prison prison) => new() { Config = cfg, Rpc = mockRpc, Prison = prison };
 
 	private static RoundParameterFactory CreateRoundParameterFactory(WabiSabiConfig cfg, Network network) =>
-		WabiSabiFactory.CreateRoundParametersFactory(cfg, network, maxVsizeAllocationPerAlice: 11 + 31 + MultipartyTransactionParameters.SharedOverhead);
+		WabiSabiFactory.CreateRoundParametersFactory(cfg, network, Constants.P2wpkhInputVirtualSize + Constants.P2wpkhOutputVirtualSize);
 }

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -83,7 +83,8 @@ public static class WabiSabiFactory
 	public static Round CreateRound(WabiSabiConfig cfg) =>
 		CreateRound(CreateRoundParameters(cfg) with
 		{
-			MaxVsizeAllocationPerAlice = 11 + 31 + MultipartyTransactionParameters.SharedOverhead
+			MaxVsizeAllocationPerAlice =
+				Constants.P2wpkhInputVirtualSize + Constants.P2wpkhOutputVirtualSize // enough vsize for one input and one output
 		});
 
 	public static MockRpcClient CreatePreconfiguredRpcClient(params Coin[] coins)

--- a/WalletWasabi/Helpers/VirtualSizeHelpers.cs
+++ b/WalletWasabi/Helpers/VirtualSizeHelpers.cs
@@ -7,7 +7,7 @@ public static class VirtualSizeHelpers
 	public const int VirtualByteInWeightUnits = 4;
 
 	public static int WeightUnitsToVirtualSize(int weightUnits) =>
-		(weightUnits / VirtualByteInWeightUnits) + ((weightUnits % VirtualByteInWeightUnits) == 0 ? 0 : 1); // ceiling(VirtualSize / VirtualByteInWeightUnits)
+		(weightUnits + VirtualByteInWeightUnits - 1) / VirtualByteInWeightUnits;
 
 	public static int VirtualSize(int nonSegwitBytes, int segwitBytes) =>
 		WeightUnitsToVirtualSize(WeightUnits(nonSegwitBytes, segwitBytes));

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionParameters.cs
@@ -21,7 +21,7 @@ public record MultipartyTransactionParameters
 			1 + // marker
 			1;  // flag
 
-		return VirtualSizeHelpers.WeightUnits(nonSegwitData, segwitData);
+		return VirtualSizeHelpers.VirtualSize(nonSegwitData, segwitData);
 	}
 
 	private static int VarIntLength(long value) =>


### PR DESCRIPTION
`SharedOverhead` (a weight measure) was used in vsize calculations (apples + oranges).