### PR TITLE
Remove usages of getrawtransaction

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -5,6 +5,7 @@ using NBitcoin.RPC;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Runtime.InteropServices.JavaScript;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models.Responses;
@@ -233,6 +234,6 @@ public class BlockchainController : ControllerBase
 	[ProducesResponseType(400)]
 	public IActionResult GetUnconfirmedTransactionChain([FromQuery, Required] string transactionId, CancellationToken cancellationToken)
 	{
-		return BadRequest("Deprecated, please update.");
+		return Ok(Array.Empty<uint256>());
 	}
 }

--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -15,7 +15,6 @@ using WalletWasabi.Cache;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
-using WalletWasabi.Models;
 
 namespace WalletWasabi.Backend.Controllers;
 
@@ -129,141 +128,6 @@ public class BlockchainController : ControllerBase
 	}
 
 	/// <summary>
-	/// Attempts to get transactions.
-	/// </summary>
-	/// <param name="transactionIds">The transactions the client is interested in.</param>
-	/// <returns>200 Ok on with the list of found transactions. This list can be empty if none of the transactions are found.</returns>
-	/// <response code="200">Returns the list of transactions hexes. The list can be empty.</response>
-	/// <response code="400">Something went wrong.</response>
-	[HttpGet("transaction-hexes")]
-	[ProducesResponseType(200)]
-	[ProducesResponseType(400)]
-	public async Task<IActionResult> GetTransactionsAsync([FromQuery, Required] IEnumerable<string> transactionIds, CancellationToken cancellationToken)
-	{
-		const int MaxTxToRequest = 10;
-		int requestCount = transactionIds.Count();
-
-		if (requestCount > MaxTxToRequest)
-		{
-			return BadRequest($"Maximum {MaxTxToRequest} transactions can be requested.");
-		}
-
-		uint256[] parsedTxIds;
-
-		// Make sure TXIDs are not malformed.
-		try
-		{
-			parsedTxIds = transactionIds.Select(x => new uint256(x)).ToArray();
-		}
-		catch
-		{
-			return BadRequest("Invalid transaction Ids.");
-		}
-
-		try
-		{
-			Transaction[] txs = await FetchTransactionsAsync(parsedTxIds, cancellationToken).ConfigureAwait(false);
-			string[] hexes = txs.Select(x => x.ToHex()).ToArray();
-
-			return Ok(hexes);
-		}
-		catch (Exception ex)
-		{
-			Logger.LogDebug(ex);
-			return BadRequest(ex.Message);
-		}
-	}
-
-	/// <summary>
-	/// Fetches transactions from cache if possible and missing transactions are fetched using RPC.
-	/// </summary>
-	/// <exception cref="AggregateException">If RPC client succeeds in getting some transactions but not all.</exception>
-	private async Task<Transaction[]> FetchTransactionsAsync(uint256[] txIds, CancellationToken cancellationToken)
-	{
-		int requestCount = txIds.Length;
-		Dictionary<uint256, TaskCompletionSource<Transaction>> txIdsRetrieve = [];
-		TaskCompletionSource<Transaction>[] txsCompletionSources = new TaskCompletionSource<Transaction>[requestCount];
-
-		try
-		{
-			// Get task completion sources for transactions. They are either new (no one else is getting that transaction right now) or existing
-			// and then some other caller needs the same transaction so we can use the existing task completion source.
-			for (int i = 0; i < requestCount; i++)
-			{
-				uint256 txId = txIds[i];
-				string cacheKey = $"{nameof(GetTransactionsAsync)}#{txId}";
-
-				if (Cache.TryAddKey(cacheKey, TransactionCacheOptions, out TaskCompletionSource<Transaction> tcs))
-				{
-					txIdsRetrieve.Add(txId, tcs);
-				}
-
-				txsCompletionSources[i] = tcs;
-			}
-
-			if (txIdsRetrieve.Count > 0)
-			{
-				// Ask to get missing transactions over RPC.
-				IEnumerable<Transaction> txs = await RpcClient.GetRawTransactionsAsync(txIdsRetrieve.Keys, cancellationToken).ConfigureAwait(false);
-
-				Dictionary<uint256, Transaction> rpcBatch = txs.ToDictionary(x => x.GetHash(), x => x);
-
-				foreach (KeyValuePair<uint256, Transaction> kvp in rpcBatch)
-				{
-					txIdsRetrieve[kvp.Key].TrySetResult(kvp.Value);
-				}
-
-				// RPC client does not throw if a transaction is missing, so we need to account for this case.
-				if (rpcBatch.Count < txIdsRetrieve.Count)
-				{
-					IReadOnlyList<Exception> exceptions = MarkNotFinishedTasksAsFailed(txIdsRetrieve);
-					throw new AggregateException(exceptions);
-				}
-			}
-
-			Transaction[] result = new Transaction[requestCount];
-
-			// Add missing transactions to the result array.
-			for (int i = 0; i < requestCount; i++)
-			{
-				Transaction tx = await txsCompletionSources[i].Task.ConfigureAwait(false);
-				result[i] = tx;
-			}
-
-			return result;
-		}
-		finally
-		{
-			if (txIdsRetrieve.Count > 0)
-			{
-				MarkNotFinishedTasksAsFailed(txIdsRetrieve);
-			}
-		}
-
-		IReadOnlyList<Exception> MarkNotFinishedTasksAsFailed(Dictionary<uint256, TaskCompletionSource<Transaction>> txIdsRetrieve)
-		{
-			List<Exception>? exceptions = null;
-
-			// It's necessary to always set a result to the task completion sources. Otherwise, cache can get corrupted.
-			foreach ((uint256 txid, TaskCompletionSource<Transaction> tcs) in txIdsRetrieve)
-			{
-				if (!tcs.Task.IsCompleted)
-				{
-					exceptions ??= new();
-
-					// Prefer new cache requests to try again rather than getting the exception. The window is small though.
-					Exception e = new InvalidOperationException($"Failed to get the transaction '{txid}'.");
-					exceptions.Add(e);
-					Cache.Remove($"{nameof(GetTransactionsAsync)}#{txid}");
-					tcs.SetException(e);
-				}
-			}
-
-			return exceptions ?? [];
-		}
-	}
-
-	/// <summary>
 	/// Attempts to broadcast a transaction.
 	/// </summary>
 	/// <remarks>
@@ -304,8 +168,7 @@ public class BlockchainController : ControllerBase
 		catch (RPCException ex)
 		{
 			Logger.LogDebug(ex);
-			var spenders = Global.HostedServices.Get<MempoolMirror>().GetSpenderTransactions(transaction.Inputs.Select(x => x.PrevOut));
-			return BadRequest($"{ex.Message}:::{string.Join(":::", spenders.Select(x => x.ToHex()))}");
+			return BadRequest($"{ex.Message}");
 		}
 
 		return Ok("Transaction is successfully broadcasted.");
@@ -365,130 +228,11 @@ public class BlockchainController : ControllerBase
 		return Ok(response);
 	}
 
-
 	[HttpGet("unconfirmed-transaction-chain")]
 	[ProducesResponseType(200)]
 	[ProducesResponseType(400)]
-	public async Task<IActionResult> GetUnconfirmedTransactionChainAsync([FromQuery, Required] string transactionId, CancellationToken cancellationToken)
+	public IActionResult GetUnconfirmedTransactionChain([FromQuery, Required] string transactionId, CancellationToken cancellationToken)
 	{
-		try
-		{
-			uint256 txId = new(transactionId);
-
-			var cacheKey = $"{nameof(GetUnconfirmedTransactionChainAsync)}_{txId}";
-			var ret = await Cache.GetCachedResponseAsync(
-				cacheKey,
-				action: (request, token) => GetUnconfirmedTransactionChainNoCacheAsync(txId, token),
-				options: UnconfirmedTransactionChainCacheEntryOptions,
-				cancellationToken);
-			return ret;
-		}
-		catch (OperationCanceledException)
-		{
-			return BadRequest("Operation took more than 10 seconds. Aborting.");
-		}
-		catch (Exception ex)
-		{
-			Logger.LogDebug($"Failed to compute unconfirmed chain for {transactionId}. {ex}");
-			return BadRequest($"Failed to compute unconfirmed chain for {transactionId}");
-		}
-	}
-
-	private async Task<IActionResult> GetUnconfirmedTransactionChainNoCacheAsync(uint256 txId, CancellationToken cancellationToken)
-	{
-		var mempoolHashes = Mempool.GetMempoolHashes();
-		if (!mempoolHashes.Contains(txId))
-		{
-			return BadRequest("Requested transaction is not present in the mempool, probably confirmed.");
-		}
-
-		using CancellationTokenSource timeoutCts = new(TimeSpan.FromSeconds(10));
-		using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
-		var linkedCancellationToken = linkedCts.Token;
-
-		var unconfirmedTxsChainById = await BuildUnconfirmedTransactionChainAsync(txId, mempoolHashes, linkedCancellationToken);
-		return Ok(unconfirmedTxsChainById.Values.ToList());
-	}
-
-	private async Task<Dictionary<uint256, UnconfirmedTransactionChainItem>> BuildUnconfirmedTransactionChainAsync(uint256 requestedTxId, IEnumerable<uint256> mempoolHashes, CancellationToken cancellationToken)
-	{
-		var unconfirmedTxsChainById = new Dictionary<uint256, UnconfirmedTransactionChainItem>();
-		var toFetchFeeList = new List<uint256> { requestedTxId };
-
-		while (toFetchFeeList.Count > 0)
-		{
-			cancellationToken.ThrowIfCancellationRequested();
-
-			var currentTxId = toFetchFeeList.First();
-
-			// Check if we just computed the item.
-			var cacheKey = $"{nameof(ComputeUnconfirmedTransactionChainItemAsync)}_{currentTxId}";
-
-			var currentTxChainItem = await Cache.GetCachedResponseAsync(
-				cacheKey,
-				action: (request, token) => ComputeUnconfirmedTransactionChainItemAsync(currentTxId, mempoolHashes, token),
-				options: UnconfirmedTransactionChainItemCacheEntryOptions,
-				cancellationToken);
-
-			toFetchFeeList.Remove(currentTxId);
-
-			var discoveredTxsToFetchFee = currentTxChainItem.Parents
-				.Union(currentTxChainItem.Children)
-				.Where(x => !unconfirmedTxsChainById.ContainsKey(x) && !toFetchFeeList.Contains(x));
-
-			toFetchFeeList.AddRange(discoveredTxsToFetchFee);
-
-			unconfirmedTxsChainById.Add(currentTxId, currentTxChainItem);
-		}
-
-		return unconfirmedTxsChainById;
-	}
-
-	private async Task<UnconfirmedTransactionChainItem> ComputeUnconfirmedTransactionChainItemAsync(uint256 currentTxId, IEnumerable<uint256> mempoolHashes, CancellationToken cancellationToken)
-	{
-		var currentTx = (await FetchTransactionsAsync([currentTxId], cancellationToken).ConfigureAwait(false)).First();
-
-		var txsToFetch = currentTx.Inputs.Select(input => input.PrevOut.Hash).Distinct().ToArray();
-
-		Transaction[] parentTxs;
-		try
-		{
-			parentTxs = await FetchTransactionsAsync(txsToFetch, cancellationToken).ConfigureAwait(false);
-		}
-		catch(AggregateException ex)
-		{
-			throw new InvalidOperationException($"Some transactions part of the chain were not found: {ex}");
-		}
-
-		// Get unconfirmed parents and children
-		var unconfirmedParents = parentTxs.Where(x => mempoolHashes.Contains(x.GetHash())).ToHashSet();
-		var unconfirmedChildrenTxs = Mempool.GetSpenderTransactions(currentTx.Outputs.Select((txo, index) => new OutPoint(currentTx, index))).ToHashSet();
-
-		return new UnconfirmedTransactionChainItem(
-			TxId: currentTxId,
-			Size: currentTx.GetVirtualSize(),
-			Fee: ComputeFee(currentTx, parentTxs, cancellationToken),
-			Parents: unconfirmedParents.Select(x => x.GetHash()).ToHashSet(),
-			Children: unconfirmedChildrenTxs.Select(x => x.GetHash()).ToHashSet());
-	}
-
-	private Money ComputeFee(Transaction currentTx, IEnumerable<Transaction> parentTxs, CancellationToken cancellationToken)
-	{
-		cancellationToken.ThrowIfCancellationRequested();
-
-		var inputs = new List<Coin>();
-
-		var prevOutsForCurrentTx = currentTx.Inputs
-			.Select(input => input.PrevOut)
-			.ToList();
-
-		foreach (var prevOut in prevOutsForCurrentTx)
-		{
-			var parentTx = parentTxs.First(x => x.GetHash() == prevOut.Hash);
-			var txOut = parentTx.Outputs[prevOut.N];
-			inputs.Add(new Coin(prevOut, txOut));
-		}
-
-		return currentTx.GetFee(inputs.ToArray());
+		return BadRequest("Deprecated, please update.");
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/MempoolTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/MempoolTests.cs
@@ -49,105 +49,25 @@ public class MempoolTests
 
 		Assert.False(mempool.ContainsTransaction(tx1.GetHash()));
 
-		mempool.AddTransaction(tx1);
+		mempool.AddTransaction(tx1.GetHash());
 		Assert.True(mempool.ContainsTransaction(tx1.GetHash()));
 
 		// Tests that no exception is thrown.
-		mempool.AddTransaction(tx1);
+		mempool.AddTransaction(tx1.GetHash());
 		Assert.True(mempool.ContainsTransaction(tx1.GetHash()));
 		Assert.Equal(new HashSet<uint256>() { tx1.GetHash() }, mempool.GetMempoolTxids());
 
-		// Now we expect that tx1 will be removed from the mempool because it spends
-		// the same transaction output as tx2.
-		mempool.AddTransaction(tx2);
-		Assert.False(mempool.ContainsTransaction(tx1.GetHash()));
+		// Both transactions are in the mempool, leading to an incorrect state.
+		// This is because the Mempool doesn't have access to the transaction.
+		// It must resynchronize the state later on with the Bitcoin node in a reasonable time.
+		mempool.AddTransaction(tx2.GetHash());
+		Assert.True(mempool.ContainsTransaction(tx1.GetHash()));
 		Assert.True(mempool.ContainsTransaction(tx2.GetHash()));
-		Assert.Equal(new HashSet<uint256>() { tx2.GetHash() }, mempool.GetMempoolTxids());
 
-		// tx1 is not in the mempool anymore.
-		Assert.False(mempool.TryRemoveTransaction(tx1.GetHash()));
-		Assert.True(mempool.TryRemoveTransaction(tx2.GetHash()));
+		Assert.True(mempool.RemoveTransaction(tx1.GetHash()));
+		Assert.True(mempool.RemoveTransaction(tx2.GetHash()));
 
 		// There are no transactions in the mempool now.
 		Assert.Equal(Array.Empty<uint256>(), mempool.GetMempoolTxids());
-	}
-
-	/// <summary>
-	/// Verifies that <see cref="Mempool.GetSpenderTransactions(IEnumerable{OutPoint})"/>
-	/// returns correct distinct transactions from the mirrored mempool.
-	/// </summary>
-	[Fact]
-	public void GetSpenderTransactions()
-	{
-		Mempool mempool = new();
-
-		// Empty mirrored mempool & no transaction outputs.
-		{
-			IEnumerable<OutPoint> txOuts = Enumerable.Empty<OutPoint>();
-			IEnumerable<Transaction> transactions = mempool.GetSpenderTransactions(txOuts);
-
-			Assert.Empty(transactions);
-		}
-
-		// Empty mirrored mempool & a single transaction output.
-		{
-			OutPoint[] txOuts = new[] { new OutPoint(uint256.One, 1) };
-			IEnumerable<Transaction> transactions = mempool.GetSpenderTransactions(txOuts);
-
-			Assert.Empty(transactions);
-		}
-
-		Transaction tx1;
-		OutPoint tx1prevOut1;
-		OutPoint tx1prevOut2;
-		TxOut tx1Out1;
-
-		// Add a single transaction to the mirrored mempool.
-		{
-			tx1 = Network.Main.CreateTransaction();
-			tx1prevOut1 = new(hashIn: new uint256(0x1), nIn: 0);
-			tx1.Inputs.Add(new TxIn(tx1prevOut1));
-
-			tx1prevOut2 = new(hashIn: new uint256(0x2), nIn: 0);
-			tx1.Inputs.Add(new TxIn(tx1prevOut2));
-
-			tx1Out1 = new TxOut(Money.Coins(0.1m), scriptPubKey: Script.Empty);
-			tx1.Outputs.Add(tx1Out1);
-
-			// Add the transaction.
-			Assert.Equal(1, mempool.AddMissingTransactions(new Transaction[] { tx1 }));
-		}
-
-		// Mirrored mempool with tx1 & a non-existent prevOut.
-		{
-			OutPoint madeUpPrevOut = new(hashIn: new uint256(0x77777), nIn: 0);
-			IReadOnlySet<Transaction> transactions = mempool.GetSpenderTransactions(new[] { madeUpPrevOut });
-
-			Assert.Empty(transactions);
-		}
-
-		// Mirrored mempool with tx1 & existing tx1prevOut1.
-		{
-			IReadOnlySet<Transaction> transactions = mempool.GetSpenderTransactions(new[] { tx1prevOut1 });
-
-			Transaction actualTx = Assert.Single(transactions);
-			Assert.Equal(tx1, actualTx);
-		}
-
-		// Mirrored mempool with tx1 & existing tx1prevOut2.
-		{
-			IReadOnlySet<Transaction> transactions = mempool.GetSpenderTransactions(new[] { tx1prevOut2 });
-
-			Transaction actualTx = Assert.Single(transactions);
-			Assert.Equal(tx1, actualTx);
-		}
-
-		// Mirrored mempool with tx1 & existing tx1prevOut1 and tx1prevOut2.
-		{
-			IReadOnlySet<Transaction> transactions = mempool.GetSpenderTransactions(new[] { tx1prevOut1, tx1prevOut2 });
-
-			Transaction actualTx = Assert.Single(transactions);
-			Assert.Equal(tx1, actualTx);
-		}
 	}
 }

--- a/WalletWasabi/BitcoinCore/Mempool/Mempool.cs
+++ b/WalletWasabi/BitcoinCore/Mempool/Mempool.cs
@@ -8,10 +8,7 @@ namespace WalletWasabi.BitcoinCore.Mempool;
 public class Mempool
 {
 	/// <summary>Mapping of transaction hashes to the corresponding transactions.</summary>
-	private Dictionary<uint256, Transaction> TransactionIndex { get; init; } = new();
-
-	/// <summary>Mapping of UTXOs to the corresponding spending transactions.</summary>
-	private Dictionary<OutPoint, Transaction> PrevOutsIndex { get; init; } = new();
+	private Dictionary<uint256, byte> TransactionIndex { get; init; } = new();
 
 	/// <summary>
 	/// Checks whether a transaction with the given hash is in the mempool.
@@ -23,46 +20,24 @@ public class Mempool
 
 	/// <summary>
 	/// Adds a new transaction to the mempool.
-	/// If <paramref name="tx"/> spends an <see cref="OutPoint"/> that is already spent by a different mempool transaction
-	/// in the mempool, we remove the mempool transaction(s).
 	/// </summary>
-	/// <exception cref="ArgumentException">If the transaction is already in the mempool.</exception>
-	/// <exception cref="InvalidOperationException">If there is an internal issue.</exception>
-	public void AddTransaction(Transaction tx)
-	{
-		// Evict double spends.
-		foreach (TxIn txInput in tx.Inputs)
-		{
-			// tx spends a UTXO which some *other* transaction in the mempool *already* spends.
-			if (PrevOutsIndex.TryGetValue(txInput.PrevOut, out Transaction? mempoolTx))
-			{
-				// Remove the old transaction from our mempool snapshot.
-				if (!TryRemoveTransaction(mempoolTx.GetHash()))
-				{
-					throw new InvalidOperationException($"Failed to remove '{mempoolTx.GetHash()}' transaction.");
-				}
-			}
-		}
-
-		TransactionIndex.Add(tx.GetHash(), tx);
-
-		foreach (TxIn txInput in tx.Inputs)
-		{
-			PrevOutsIndex.Add(txInput.PrevOut, tx);
-		}
-	}
+	/// <remarks>
+	/// Double spends are not evicted, but they will be invalidated at every call of GetRawMempoolAsync
+	/// </remarks>
+	public bool AddTransaction(uint256 txHash)
+		=> TransactionIndex.TryAdd(txHash, new byte());
 
 	/// <summary>
 	/// Adds the given transactions to the mempool.
 	/// <para>If the transaction is already in the mempool, it is not added.</para>
 	/// </summary>
 	/// <returns>Number of added transactions.</returns>
-	public int AddMissingTransactions(IEnumerable<Transaction> txs)
+	public int AddMissingTransactions(IEnumerable<uint256> txsHash)
 	{
 		int added = 0;
-		foreach (Transaction tx in txs.Where(x => !ContainsTransaction(x.GetHash())))
+		foreach (uint256 txHash in txsHash.Where(x => !ContainsTransaction(x)))
 		{
-			AddTransaction(tx);
+			TransactionIndex.TryAdd(txHash, new byte());
 			added++;
 		}
 
@@ -72,21 +47,8 @@ public class Mempool
 	/// <summary>
 	/// Removes the transaction with the given transaction hash from the mempool.
 	/// </summary>
-	public bool TryRemoveTransaction(uint256 txHash)
-	{
-		if (TransactionIndex.Remove(txHash, out Transaction? transaction))
-		{
-			// Remove all UTXOs of the removed transaction from our helper index.
-			foreach (TxIn txInput in transaction.Inputs)
-			{
-				PrevOutsIndex.Remove(txInput.PrevOut);
-			}
-
-			return true;
-		}
-
-		return false;
-	}
+	public bool RemoveTransaction(uint256 txHashToRemove)
+		=> TransactionIndex.Remove(txHashToRemove, out _);
 
 	/// <summary>
 	/// Gets a copy of all transaction hashes in the mempool.
@@ -94,26 +56,5 @@ public class Mempool
 	public ISet<uint256> GetMempoolTxids()
 	{
 		return TransactionIndex.Keys.ToHashSet();
-	}
-
-	/// <summary>
-	/// Gets transactions from the mempool that spends <paramref name="txOuts"/>.
-	/// </summary>
-	public IReadOnlySet<Transaction> GetSpenderTransactions(IEnumerable<OutPoint> txOuts)
-	{
-		HashSet<OutPoint> txOutsSet = txOuts.ToHashSet();
-
-		return txOutsSet.Where(prevOut => PrevOutsIndex.ContainsKey(prevOut))
-			.Select(prevOut => PrevOutsIndex[prevOut])
-			.ToHashSet();
-	}
-
-	public Mempool Clone()
-	{
-		return new Mempool()
-		{
-			TransactionIndex = new Dictionary<uint256, Transaction>(TransactionIndex),
-			PrevOutsIndex = new Dictionary<OutPoint, Transaction>(PrevOutsIndex)
-		};
 	}
 }


### PR DESCRIPTION
This PR removes all usages of `getrawtransaction` in the backend in a really straight-forward way, and creates only 2 small issues:
- In case of double spends, the state of the in-memory mempool will be incorrect for maximum 21s as the double-spent transaction won't be removed until node's mempool is re-cloned.
- This PR disables `unconfirmed-transactions-chain`, but old clients (i.e. clients prior merge of #13193) will still try to access it. This will cause the old clients to have no details about the confirmation ETA for transactions such as coinjoins (like before @adamPetho's work), and these clients will re-try the request 3 times in a row, leading of 3 log warning asking to update. This behavior can be changed if we want by either:
    - Returning a `Ok(dummy value)` instead of `BadRequest`
    - Keep providing a correct response by requesting the data to a third party such as mempool.space (i.e. implement #13193 on server side), for which only problem would be rate limitation