### PR TITLE
Delete .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,4 +1,0 @@
-version = 1
-
-[[analyzers]]
-name = "shell"


### PR DESCRIPTION
I think there is no point in keeping this as it is not being used.

Deepsource was the failed AI code review experiment, and was already disabled for C# https://github.com/WalletWasabi/WalletWasabi/pull/10998.