### PR TITLE
Make transaction broadcasting faster.

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Caching.Memory;
 using NBitcoin;
 using Nito.AsyncEx;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -37,7 +38,6 @@ using WalletWasabi.WebClients.BuyAnything;
 using WalletWasabi.WebClients.ShopWare;
 using WalletWasabi.Wallets.FilterProcessor;
 using WalletWasabi.Models;
-using WalletWasabi.WabiSabi.Models;
 
 namespace WalletWasabi.Daemon;
 
@@ -144,7 +144,18 @@ public class Global
 			Network == Network.RegTest ? null : HostedServices.Get<CpfpInfoProvider>());
 
 		WalletManager = new WalletManager(config.Network, DataDir, new WalletDirectories(Config.Network, DataDir), walletFactory);
-		TransactionBroadcaster = new TransactionBroadcaster(Network, BitcoinStore, HttpClientFactory, WalletManager);
+		var p2p = HostedServices.Get<P2pNetwork>();
+		var broadcasters = new List<IBroadcaster>();
+		if (BitcoinCoreNode?.RpcClient is not null)
+		{
+			broadcasters.Add(new RpcBroadcaster(BitcoinCoreNode.RpcClient));
+		}
+		broadcasters.AddRange([
+			new NetworkBroadcaster(BitcoinStore.MempoolService, p2p.Nodes),
+			new BackendBroadcaster(HttpClientFactory)
+		]);
+
+		TransactionBroadcaster = new TransactionBroadcaster(broadcasters.ToArray(), BitcoinStore.MempoolService, WalletManager);
 
 		var prisonForCoordinator = Path.Combine(DataDir, config.GetCoordinatorUri().Host);
 		CoinPrison = CoinPrison.CreateOrLoadFromFile(prisonForCoordinator);
@@ -267,7 +278,6 @@ public class Global
 
 				Logger.LogInfo("Start synchronizing filters...");
 
-				TransactionBroadcaster.Initialize(HostedServices.Get<P2pNetwork>().Nodes, BitcoinCoreNode?.RpcClient);
 				CoinJoinProcessor = new CoinJoinProcessor(Network, HostedServices.Get<WasabiSynchronizer>(), WalletManager, BitcoinCoreNode?.RpcClient);
 
 				await StartRpcServerAsync(terminateService, cancel).ConfigureAwait(false);

--- a/WalletWasabi.Tests/RegressionTests/BackendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/BackendTests.cs
@@ -174,8 +174,7 @@ public class BackendTests : IClassFixture<RegTestFixture>
 		var blockCount = await rpc.GetBlockCountAsync();
 		await setup.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), blockCount);
 
-		TransactionBroadcaster broadcaster = new(network, bitcoinStore, httpClientFactory, walletManager);
-		broadcaster.Initialize(nodes, rpc);
+		TransactionBroadcaster broadcaster = new([new RpcBroadcaster(rpc)], bitcoinStore.MempoolService, walletManager);
 
 		#endregion Initialize
 

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
@@ -111,8 +111,7 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 
 			var coin = Assert.Single(wallet.Coins);
 			Assert.True(coin.Confirmed);
-			TransactionBroadcaster broadcaster = new(network, bitcoinStore, httpClientFactory, walletManager);
-			broadcaster.Initialize(nodes, rpc);
+			TransactionBroadcaster broadcaster = new([], bitcoinStore.MempoolService, walletManager);
 
 			// Send money before reorg.
 			PaymentIntent operations = new(scp, Money.Coins(0.011m));

--- a/WalletWasabi.Tests/RegressionTests/CancelTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CancelTests.cs
@@ -101,9 +101,6 @@ public class CancelTests : IClassFixture<RegTestFixture>
 			await setup.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), blockCount);
 			wallet.Password = password;
 
-			TransactionBroadcaster broadcaster = new(network, bitcoinStore, httpClientFactory, walletManager);
-			broadcaster.Initialize(nodes, rpc);
-
 			var waitCount = 0;
 			while (wallet.Coins.Sum(x => x.Amount) == Money.Zero)
 			{
@@ -123,6 +120,7 @@ public class CancelTests : IClassFixture<RegTestFixture>
 
 			SetHighInputAnonsets(txToCancel);
 
+			TransactionBroadcaster broadcaster = new([new RpcBroadcaster(rpc)], bitcoinStore.MempoolService, walletManager);
 			await broadcaster.SendTransactionAsync(txToCancel.Transaction);
 
 			AssertAllAnonsets1(txToCancel);

--- a/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
@@ -108,9 +108,6 @@ public class MaxFeeTests : IClassFixture<RegTestFixture>
 			await setup.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), blockCount);
 			wallet.Password = password;
 
-			TransactionBroadcaster broadcaster = new(network, bitcoinStore, httpClientFactory, walletManager);
-			broadcaster.Initialize(nodes, rpc);
-
 			var waitCount = 0;
 			while (wallet.Coins.Sum(x => x.Amount) == Money.Zero)
 			{

--- a/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
@@ -98,9 +98,6 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 
 			wallet.Password = password;
 
-			TransactionBroadcaster broadcaster = new(network, bitcoinStore, httpClientFactory, walletManager);
-			broadcaster.Initialize(nodes, rpc);
-
 			// Get some money.
 			var key = keyManager.GetNextReceiveKey("foo");
 			var txId = await rpc.SendToAddressAsync(key.GetP2wpkhAddress(network), Money.Coins(1m));
@@ -122,6 +119,8 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 
 			Assert.True(bitcoinStore.TransactionStore.TryGetTransaction(txId, out var txToSpeedUp));
 			var cpfp = await wallet.SpeedUpTransactionAsync(txToSpeedUp, null, CancellationToken.None);
+
+			TransactionBroadcaster broadcaster = new([new RpcBroadcaster(rpc)], bitcoinStore.MempoolService, walletManager);
 			await broadcaster.SendTransactionAsync(cpfp.Transaction);
 
 			Assert.Equal("foo", txToSpeedUp.Labels.Single());

--- a/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
@@ -105,9 +105,6 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 
 			wallet.Password = password;
 
-			TransactionBroadcaster broadcaster = new(network, bitcoinStore, httpClientFactory, walletManager);
-			broadcaster.Initialize(nodes, rpc);
-
 			var waitCount = 0;
 			while (wallet.Coins.Sum(x => x.Amount) == Money.Zero)
 			{
@@ -124,6 +121,8 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 
 			Money amountToSend = wallet.Coins.Where(x => x.IsAvailable()).Sum(x => x.Amount) / 2;
 			var txToSpeedUp = wallet.BuildTransaction(password, new PaymentIntent(keyManager.GetNextReceiveKey("foo").GetAssumedScriptPubKey(), amountToSend, label: "bar"), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
+
+			TransactionBroadcaster broadcaster = new([new RpcBroadcaster(rpc)], bitcoinStore.MempoolService, walletManager);
 			await broadcaster.SendTransactionAsync(txToSpeedUp.Transaction);
 
 			Assert.Equal(Assert.Single(txToSpeedUp.SpentCoins).SpenderTransaction, txToSpeedUp.Transaction);

--- a/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
@@ -103,9 +103,6 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 			await setup.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), blockCount);
 			wallet.Password = password;
 
-			TransactionBroadcaster broadcaster = new(network, bitcoinStore, httpClientFactory, walletManager);
-			broadcaster.Initialize(nodes, rpc);
-
 			var waitCount = 0;
 			while (wallet.Coins.Sum(x => x.Amount) == Money.Zero)
 			{
@@ -122,6 +119,8 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 			Money amountToSend = wallet.Coins.Where(x => x.IsAvailable()).Sum(x => x.Amount) / 2;
 			var rpcAddress = await rpc.GetNewAddressAsync();
 			var txToSpeedUp = wallet.BuildTransaction(password, new PaymentIntent(rpcAddress, amountToSend, label: "bar"), FeeStrategy.SevenDaysConfirmationTargetStrategy, allowUnconfirmed: true);
+
+			TransactionBroadcaster broadcaster = new([new RpcBroadcaster(rpc)], bitcoinStore.MempoolService, walletManager);
 			await broadcaster.SendTransactionAsync(txToSpeedUp.Transaction);
 
 			Assert.Equal(Assert.Single(txToSpeedUp.SpentCoins).SpenderTransaction, txToSpeedUp.Transaction);

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -107,9 +107,6 @@ public class SendTests : IClassFixture<RegTestFixture>
 			var blockCount = await rpc.GetBlockCountAsync();
 			await setup.WaitForFiltersToBeProcessedAsync(TimeSpan.FromSeconds(120), blockCount);
 
-			TransactionBroadcaster broadcaster = new(network, bitcoinStore, httpClientFactory, walletManager);
-			broadcaster.Initialize(nodes, rpc);
-
 			var waitCount = 0;
 			while (wallet.Coins.Sum(x => x.Amount) == Money.Zero)
 			{
@@ -136,6 +133,8 @@ public class SendTests : IClassFixture<RegTestFixture>
 			Assert.Contains(new[] { key.P2wpkhScript, key2.P2wpkhScript }, x => x == spentCoin.ScriptPubKey);
 			Assert.Equal(Money.Coins(1m), res2.SpentCoins.Single().Amount);
 			Assert.False(res2.SpendsUnconfirmed);
+
+			TransactionBroadcaster broadcaster = new([new RpcBroadcaster(rpc)], bitcoinStore.MempoolService, walletManager);
 
 			await broadcaster.SendTransactionAsync(res2.Transaction);
 

--- a/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
@@ -114,9 +114,6 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 			Assert.Equal(tx0Id, eventArgs.NewlyReceivedCoins.Single().TransactionId);
 			Assert.Single(wallet.Coins);
 
-			TransactionBroadcaster broadcaster = new(network, bitcoinStore, httpClientFactory, walletManager);
-			broadcaster.Initialize(nodes, rpc);
-
 			using Key key2 = new();
 			using Key key3 = new();
 			var destination1 = key.PubKey.GetAddress(ScriptPubKeyType.Segwit, Network.Main);
@@ -135,6 +132,8 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 			eventAwaiter = new EventAwaiter<ProcessedResult>(
 				h => wallet.TransactionProcessor.WalletRelevantTransactionProcessed += h,
 				h => wallet.TransactionProcessor.WalletRelevantTransactionProcessed -= h);
+
+			TransactionBroadcaster broadcaster = new([new RpcBroadcaster(rpc)], bitcoinStore.MempoolService, walletManager);
 			await broadcaster.SendTransactionAsync(tx1Res.Transaction);
 			eventArgs = await eventAwaiter.WaitAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(tx0Id, eventArgs.NewlySpentCoins.Single().TransactionId);

--- a/WalletWasabi/BitcoinP2p/P2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/P2pBehavior.cs
@@ -90,13 +90,8 @@ public abstract class P2pBehavior : NodeBehavior
 
 		foreach (var inv in payload.Inventory.Where(inv => inv.Type.HasFlag(InventoryType.MSG_TX) || inv.Type.HasFlag(InventoryType.MSG_WTX)))
 		{
-			if (MempoolService.TryGetFromBroadcastStore(inv.Hash, out TransactionBroadcastEntry? entry)) // If we have the transaction to be broadcasted then broadcast it now.
+			if (MempoolService.TryGetFromBroadcastStore(inv.Hash, node.RemoteSocketEndpoint.ToString(),  out TransactionBroadcastEntry? entry)) // If we have the transaction to be broadcasted then broadcast it now.
 			{
-				if (entry.NodeRemoteSocketEndpoint != node.RemoteSocketEndpoint.ToString())
-				{
-					continue; // Would be strange. It could be some kind of attack.
-				}
-
 				try
 				{
 					var txPayload = new TxPayload(entry.Transaction.Transaction);

--- a/WalletWasabi/BitcoinP2p/TrustedP2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/TrustedP2pBehavior.cs
@@ -18,7 +18,7 @@ public class TrustedP2pBehavior : P2pBehavior
 	{
 		if (inv.Type.HasFlag(InventoryType.MSG_TX))
 		{
-			if (MempoolService.TryGetFromBroadcastStore(inv.Hash, out TransactionBroadcastEntry? entry)) // If we have the transaction then adjust confirmation.
+			if (MempoolService.TryGetFromBroadcastStore(inv.Hash, remoteSocketEndpoint.ToString(), out TransactionBroadcastEntry? entry)) // If we have the transaction then adjust confirmation.
 			{
 				if (entry.NodeRemoteSocketEndpoint == remoteSocketEndpoint.ToString())
 				{

--- a/WalletWasabi/BitcoinP2p/UntrustedP2pBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/UntrustedP2pBehavior.cs
@@ -23,7 +23,7 @@ public class UntrustedP2pBehavior : P2pBehavior
 	{
 		if (inv.Type.HasFlag(InventoryType.MSG_TX))
 		{
-			if (MempoolService.TryGetFromBroadcastStore(inv.Hash, out TransactionBroadcastEntry? entry)) // If we have the transaction then adjust confirmation.
+			if (MempoolService.TryGetFromBroadcastStore(inv.Hash, remoteSocketEndpoint.ToString(), out TransactionBroadcastEntry? entry)) // If we have the transaction then adjust confirmation.
 			{
 				if (entry.NodeRemoteSocketEndpoint == remoteSocketEndpoint.ToString())
 				{

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -21,11 +21,11 @@ using BroadcastingResult = Result<BroadcastError>;
 public abstract record BroadcastError
 {
 	public record SpentError : BroadcastError;
-	public record SpentInputError(OutPoint spentOutpoint) : BroadcastError;
-	public record RpcError(string rpcErrorMessage) : BroadcastError;
-	public record Unknown(string message) : BroadcastError;
+	public record SpentInputError(OutPoint SpentOutpoint) : BroadcastError;
+	public record RpcError(string RpcErrorMessage) : BroadcastError;
+	public record Unknown(string Message) : BroadcastError;
 	public record NotEnoughP2pNodes : BroadcastError;
-	public record AggregatedErrors(BroadcastError[] errors) : BroadcastError;
+	public record AggregatedErrors(BroadcastError[] Errors) : BroadcastError;
 }
 
 public interface IBroadcaster
@@ -54,7 +54,7 @@ public class BackendBroadcaster(IWasabiHttpClientFactory wasabiHttpClientFactory
 {
 	public async Task<BroadcastingResult> BroadcastAsync(SmartTransaction tx)
 	{
-		Logger.LogInfo($"Trying to broadcast transaction backend API:{tx.GetHash()}.");
+		Logger.LogInfo($"Trying to broadcast transaction via backend API:{tx.GetHash()}.");
 		try
 		{
 			var wasabiClient = new WasabiClient(wasabiHttpClientFactory.NewHttpClientWithCircuitPerRequest());
@@ -176,14 +176,14 @@ public class TransactionBroadcaster(IBroadcaster[] broadcasters, MempoolService 
 		switch (broadcastError)
 		{
 			case BroadcastError.RpcError rpcError:
-				Logger.LogInfo($"Failed to broadcast transaction via RPC. Reason: {rpcError.rpcErrorMessage}.");
+				Logger.LogInfo($"Failed to broadcast transaction via RPC. Reason: {rpcError.RpcErrorMessage}.");
 				break;
 			case BroadcastError.SpentError _:
 				Logger.LogError("Failed to broadcast transaction. There are spent inputs.");
 				break;
 			case BroadcastError.SpentInputError spentInputError:
-				Logger.LogError($"Failed to broadcast transaction. {spentInputError.spentOutpoint} is spent inputs.");
-				foreach (var coin in walletManager.CoinsByOutPoint(spentInputError.spentOutpoint))
+				Logger.LogError($"Failed to broadcast transaction. Input {spentInputError.SpentOutpoint} is already spent.");
+				foreach (var coin in walletManager.CoinsByOutPoint(spentInputError.SpentOutpoint))
 				{
 					coin.SpentAccordingToBackend = true;
 				}
@@ -192,10 +192,10 @@ public class TransactionBroadcaster(IBroadcaster[] broadcasters, MempoolService 
 				Logger.LogInfo("Failed to broadcast transaction via peer-to-peer network: We are not connected to enough nodes.");
 				break;
 			case BroadcastError.Unknown unknown:
-				Logger.LogInfo($"Failed to broadcast transaction: {unknown.message}.");
+				Logger.LogInfo($"Failed to broadcast transaction: {unknown.Message}.");
 				break;
 			case BroadcastError.AggregatedErrors aggregatedErrors:
-				foreach (var error in aggregatedErrors.errors)
+				foreach (var error in aggregatedErrors.Errors)
 				{
 					BroadcastError(error);
 				}

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -105,7 +105,7 @@ public class TransactionProcessor
 		uint256 txId = tx.GetHash();
 
 		// If we already have the transaction, then let's work on that.
-		if (MempoolService?.TryGetFromBroadcastStore(txId, out var foundEntry) is true)
+		if (MempoolService?.TryGetFromBroadcastStore(txId, null, out var foundEntry) is true)
 		{
 			// If we already have the transaction in the broadcast store, then let's work on that.
 			foundEntry.Transaction.TryUpdate(tx);

--- a/WalletWasabi/Blockchain/Transactions/TransactionBroadcastEntry.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionBroadcastEntry.cs
@@ -7,11 +7,8 @@ public class TransactionBroadcastEntry
 {
 	public TransactionBroadcastEntry(SmartTransaction transaction, string nodeRemoteSocketEndpoint)
 	{
-		Lock = new object();
 		Transaction = transaction;
 		TransactionId = Transaction.GetHash();
-		Broadcasted = false;
-		PropagationConfirmations = 0;
 		NodeRemoteSocketEndpoint = nodeRemoteSocketEndpoint;
 		BroadcastCompleted = new TaskCompletionSource();
 		PropagationConfirmed = new TaskCompletionSource();
@@ -23,55 +20,19 @@ public class TransactionBroadcastEntry
 
 	public TaskCompletionSource BroadcastCompleted { get; }
 	public TaskCompletionSource PropagationConfirmed { get; }
-	private bool Broadcasted { get; set; }
-	private int PropagationConfirmations { get; set; }
-
-	private object Lock { get; }
 
 	public void MakeBroadcasted()
 	{
-		lock (Lock)
-		{
-			Broadcasted = true;
-			BroadcastCompleted.TrySetResult();
-		}
-	}
-
-	public bool IsBroadcasted()
-	{
-		lock (Lock)
-		{
-			return Broadcasted;
-		}
+		BroadcastCompleted.TrySetResult();
 	}
 
 	public void ConfirmPropagationOnce()
 	{
-		lock (Lock)
-		{
-			Broadcasted = true;
-			PropagationConfirmations++;
-			if (PropagationConfirmations == 2)
-			{
-				PropagationConfirmed.SetResult();
-			}
-		}
+		PropagationConfirmed.TrySetResult();
 	}
 
 	public void ConfirmPropagationForGood()
 	{
-		lock (Lock)
-		{
-			Broadcasted = true;
-			PropagationConfirmations = 21;
-		}
-	}
-
-	public int GetPropagationConfirmations()
-	{
-		lock (Lock)
-		{
-			return PropagationConfirmations;
-		}
+		PropagationConfirmed.TrySetResult();
 	}
 }

--- a/WalletWasabi/Blockchain/Transactions/TransactionBroadcastEntry.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionBroadcastEntry.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using NBitcoin;
 
 namespace WalletWasabi.Blockchain.Transactions;
@@ -12,12 +13,16 @@ public class TransactionBroadcastEntry
 		Broadcasted = false;
 		PropagationConfirmations = 0;
 		NodeRemoteSocketEndpoint = nodeRemoteSocketEndpoint;
+		BroadcastCompleted = new TaskCompletionSource();
+		PropagationConfirmed = new TaskCompletionSource();
 	}
 
 	public SmartTransaction Transaction { get; }
 	public uint256 TransactionId { get; }
 	public string NodeRemoteSocketEndpoint { get; }
 
+	public TaskCompletionSource BroadcastCompleted { get; }
+	public TaskCompletionSource PropagationConfirmed { get; }
 	private bool Broadcasted { get; set; }
 	private int PropagationConfirmations { get; set; }
 
@@ -28,6 +33,7 @@ public class TransactionBroadcastEntry
 		lock (Lock)
 		{
 			Broadcasted = true;
+			BroadcastCompleted.TrySetResult();
 		}
 	}
 
@@ -45,6 +51,10 @@ public class TransactionBroadcastEntry
 		{
 			Broadcasted = true;
 			PropagationConfirmations++;
+			if (PropagationConfirmations == 2)
+			{
+				PropagationConfirmed.SetResult();
+			}
 		}
 	}
 

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -166,6 +166,17 @@ public static class LinqExtensions
 		}
 	}
 
+	public static async IAsyncEnumerable<T> TakeUntil<T>(this IAsyncEnumerable<T> list, Func<T, bool> predicate)
+	{
+		await foreach (T el in list)
+		{
+			yield return el;
+			if (predicate(el))
+			{
+				yield break;
+			}
+		}
+	}
 	public static IEnumerable<T> Singleton<T>(this T item)
 	{
 		yield return item;

--- a/WalletWasabi/Helpers/Result.cs
+++ b/WalletWasabi/Helpers/Result.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using WalletWasabi.Userfacing.Bip21;
 
 namespace WalletWasabi.Helpers;
 
@@ -91,6 +92,9 @@ public record Result<TError> : Result<Unit, TError>
 			.Match(
 				_ => Result<TError[]>.Ok(),
 				es => Result<TError[]>.Fail(es));
+
+	public Result<T> ThenError<T>(Func<TError, T> f) =>
+		Match(_=> Result<T>.Ok(), e => Result<T>.Fail(f(e)));
 }
 
 public static class ResultExtensions

--- a/WalletWasabi/Helpers/Result.cs
+++ b/WalletWasabi/Helpers/Result.cs
@@ -55,6 +55,8 @@ public record Result<TValue,TError>
 		}
 	}
 
+	public bool IsOk => _isSuccess;
+
 	public Result<T, TError> Then<T>(Func<TValue, T> f) =>
 		Match(v => Result<T, TError>.Ok(f(v)), e => e);
 


### PR DESCRIPTION
Instead of trying to broadcast a transaction with nodes one by one, this version tries with one or more in parallel. It doesn't iterate in a loop but uses a `TaskCompletion` task to get a notification when the tx is propagated.

The number of selected nodes is one thrid of the connected nodes plus one, what makes sure to have always connected nodes (it doesn't disconnect them all). Also, this allows users to broadcast transaction immediately after the wallet starts because at that moment there use to be a very few connected nodes. Before, this was almost always impossible and the backend had to be used in most of the cases.