### PR TITLE
Revert "Reduce max input amount to 1343 btc"

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -108,7 +108,7 @@ public class MultipartyTransactionStateTests
 		}
 
 		// Check the distribution of MaxSuggestedAmounts.
-		Assert.Equal(1, histogram[Money.Coins(1_343.75m)]);
+		Assert.Equal(1, histogram[Money.Coins(10_000)]);
 		Assert.Equal(2, histogram[Money.Coins(1000)]);
 		Assert.Equal(4, histogram[Money.Coins(100)]);
 		Assert.Equal(8, histogram[Money.Coins(10)]);

--- a/WalletWasabi/WabiSabi/ProtocolConstants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolConstants.cs
@@ -3,7 +3,7 @@ namespace WalletWasabi.WabiSabi;
 public static class ProtocolConstants
 {
 	public const int CredentialNumber = 2;
-	public const long MaxAmountPerAlice = 4_300_000_000_000L / 32;
+	public const long MaxAmountPerAlice = 4_300_000_000_000L;
 	public const long MaxVsizeCredentialValue = 255;
 
 	public const string WabiSabiProtocolIdentifier = "WabiSabi_v1.0";


### PR DESCRIPTION
Reverts WalletWasabi/WalletWasabi#13403

It is necessary to implement it in a more elegant way because there are two values being used for the same thing, this one and MaxRegistrableAmount.