### PR TITLE
[Trivial] Change coordinator's default to false

### DIFF
--- a/WalletWasabi/Discoverability/AnnouncerConfig.cs
+++ b/WalletWasabi/Discoverability/AnnouncerConfig.cs
@@ -8,7 +8,7 @@ namespace WalletWasabi.Discoverability;
 public record AnnouncerConfig
 {
 	public string CoordinatorName { get; init; } = "Coordinator";
-	public bool IsEnabled { get; init; } = true;
+	public bool IsEnabled { get; init; } = false;
 	public string CoordinatorDescription { get; init; } = "WabiSabi Coinjoin Coordinator";
 	public string CoordinatorUri { get; init; } = "https://api.example.com/";
 	public uint AbsoluteMinInputCount { get; init; } = 21;


### PR DESCRIPTION
This makes sense currently because the separation coordinator/backend is still not complete