### PR TITLE
[Coordinator] Collect coordinator output if and only if economical

### DIFF
--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -618,14 +618,16 @@ public partial class Arena : PeriodicRunner
 
 		round.LogInfo($"Available coordination: {availableCoordinationFee}.");
 
-		var minEconomicalOutput = round.Parameters.MiningFeeRate.GetFee(coordinatorScriptPubKey.EstimateInputVsize() + coordinatorScriptPubKey.EstimateOutputVsize());
+		// The coordinator must pay output creation at round's FeeRate, but then he can wait to spend the output.
+		var minEconomicalOutput = round.Parameters.MiningFeeRate.GetFee(coordinatorScriptPubKey.EstimateOutputVsize()) +
+		                          new FeeRate(1.0m).GetFee(coordinatorScriptPubKey.EstimateInputVsize());
 
 		if (availableCoordinationFee > minEconomicalOutput)
 		{
 			var txOut = new TxOut(availableCoordinationFee, coordinatorScriptPubKey);
 			if (!txOut.IsDust())
 			{
-				return coinjoin.AddOutputBypassMinAmount(txOut)
+				return coinjoin.AddOutputNoMinAmountCheck(txOut)
 					.AsPayingForSharedOverhead();
 			}
 		}

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -72,12 +72,10 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
 		}
 
-		return AddOutputCore(output);
+		return AddOutputNoMinAmountCheck(output);
 	}
 
-	public ConstructionState AddOutputBypassMinAmount(TxOut output) => AddOutputCore(output);
-
-	private ConstructionState AddOutputCore(TxOut output)
+	public ConstructionState AddOutputNoMinAmountCheck(TxOut output)
 	{
 		if (output.Value > Parameters.AllowedOutputAmounts.Max)
 		{

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -72,6 +72,13 @@ public record ConstructionState : MultipartyTransactionState
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
 		}
 
+		return AddOutputCore(output);
+	}
+
+	public ConstructionState AddOutputBypassMinAmount(TxOut output) => AddOutputCore(output);
+
+	private ConstructionState AddOutputCore(TxOut output)
+	{
 		if (output.Value > Parameters.AllowedOutputAmounts.Max)
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);


### PR DESCRIPTION
Fixes #13448

Note that in some cases where we coordinator would be collecting the output, now it won't collect it anymore (if fees are expansive)

An alternative concept would be to check the cost of creating an output at current mining fee rate, but the cost of spending it at 1s/vb, as the coordinator can wait.