### PR TITLE
Work around IOException in SmartResyncIfCorrupted

### DIFF
--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -453,7 +453,16 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 			// It is not worth it to try to estimate when there are that few filters, just delete them.
 			// This will be really few users and those filters almost have no data anyway.
 			Logger.LogWarning("Refreshing filters because they are potentially corrupted (wrong endian).");
-			DeleteIndex(NewIndexFilePath);
+			try
+			{
+				DeleteIndex(NewIndexFilePath);
+			}
+			catch(IOException)
+			{
+				IndexStorage.RemoveNewerThan(StartingFilters.GetStartingFilter(Network.Main).Header.Height);
+				return;
+			}
+
 			IndexStorage = CreateBlockFilterSqliteStorage();
 			return;
 		}
@@ -484,7 +493,15 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 			{
 				// A really old filter is invalid, better to delete everything
 				Logger.LogWarning($"A really old filter is corrupted ({firstInvalidHeight}), better to delete the index.");
-				DeleteIndex(NewIndexFilePath);
+				try
+				{
+					DeleteIndex(NewIndexFilePath);
+				}
+				catch(IOException)
+				{
+					IndexStorage.RemoveNewerThan(StartingFilters.GetStartingFilter(Network.Main).Header.Height);
+					return;
+				}
 				IndexStorage = CreateBlockFilterSqliteStorage();
 				return;
 			}

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -453,17 +453,7 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 			// It is not worth it to try to estimate when there are that few filters, just delete them.
 			// This will be really few users and those filters almost have no data anyway.
 			Logger.LogWarning("Refreshing filters because they are potentially corrupted (wrong endian).");
-			try
-			{
-				DeleteIndex(NewIndexFilePath);
-			}
-			catch(IOException)
-			{
-				IndexStorage.RemoveNewerThan(StartingFilters.GetStartingFilter(Network.Main).Header.Height);
-				return;
-			}
-
-			IndexStorage = CreateBlockFilterSqliteStorage();
+			IndexStorage.RemoveNewerThan(StartingFilters.GetStartingFilter(Network.Main).Header.Height);
 			return;
 		}
 
@@ -493,16 +483,7 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 			{
 				// A really old filter is invalid, better to delete everything
 				Logger.LogWarning($"A really old filter is corrupted ({firstInvalidHeight}), better to delete the index.");
-				try
-				{
-					DeleteIndex(NewIndexFilePath);
-				}
-				catch(IOException)
-				{
-					IndexStorage.RemoveNewerThan(StartingFilters.GetStartingFilter(Network.Main).Header.Height);
-					return;
-				}
-				IndexStorage = CreateBlockFilterSqliteStorage();
+				IndexStorage.RemoveNewerThan(StartingFilters.GetStartingFilter(Network.Main).Header.Height);
 				return;
 			}
 			Logger.LogWarning($"Filter ({firstInvalidHeight}) corrupted (wrong endian), deleting Index from {firstInvalidHeight - batchSize}.");


### PR DESCRIPTION
Some users are reporting this issue, not worth it to investigate, this change in code would work around it.