### PR TITLE
Update version in doc after a release

### DIFF
--- a/.github/workflows/onReleasePublished.yml
+++ b/.github/workflows/onReleasePublished.yml
@@ -1,0 +1,37 @@
+name: Update version in the docs after a release is published
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  trigger-doc-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check if release is a pre-release
+        id: check_prerelease
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "This is a pre-release, exiting."
+            exit 1
+          fi
+
+      - name: Get the published version
+        id: get_version
+        run: |
+          NEW_VERSION=${{ github.event.release.tag_name }}
+          NEW_VERSION=$(echo "${NEW_VERSION}" | sed 's/^v//')
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+
+      - name: Trigger WasabiDoc workflow
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{ secrets.WASABI_DOC_PAT }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/WalletWasabi/WasabiDoc/dispatches \
+          -d '{"event_type":"update-version","client_payload":{"new_version":"${{ steps.get_version.outputs.NEW_VERSION }}"}}'

--- a/.github/workflows/onReleasePublished.yml
+++ b/.github/workflows/onReleasePublished.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check if release is a pre-release
         id: check_prerelease
@@ -31,7 +31,7 @@ jobs:
       - name: Trigger WasabiDoc workflow
         run: |
           curl -X POST \
-          -H "Authorization: token ${{ secrets.WASABI_DOC_PAT }}" \
+          -H "Authorization: token ${{ secrets.DOC_UPDATE_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/WalletWasabi/WasabiDoc/dispatches \
           -d '{"event_type":"update-version","client_payload":{"new_version":"${{ steps.get_version.outputs.NEW_VERSION }}"}}'


### PR DESCRIPTION
This PR triggers https://github.com/WalletWasabi/WasabiDoc/pull/1836 after a release is published.

The reason it is not included in the release workflow is because we absolutely want this one after it is PUBLISHED, not still in draft.

It has a slight limitation: We do not use this GitHub feature, but on GitHub we can publish pre-releases (RC). This action ignores them, but then is not triggered if a pre-release is edited so it becomes the latest release. If we decide to use pre-releases in the future, we would need to delete them then create a new latest release (instead of editing)

Because it performs cross repo operations, it unfortunately needs a personal access token that is stored as a secret that I named `WASABI_DOC_PAT`. It must be from someone that has write access in the target repository, i.e. WasabiDoc.

I will do exactly the same for the website update