### PR TITLE
[Trivial] Switch default run on system startup to false

### DIFF
--- a/WalletWasabi.Fluent/UiConfig.cs
+++ b/WalletWasabi.Fluent/UiConfig.cs
@@ -151,7 +151,7 @@ public class UiConfig : ConfigBase
 	}
 
 	// OnDeserialized changes this default on Linux.
-	[DefaultValue(true)]
+	[DefaultValue(false)]
 	[JsonProperty(PropertyName = "RunOnSystemStartup", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool RunOnSystemStartup
 	{
@@ -187,24 +187,5 @@ public class UiConfig : ConfigBase
 	{
 		get => _windowHeight;
 		internal set => RaiseAndSetIfChanged(ref _windowHeight, value);
-	}
-
-	[OnDeserialized]
-	internal void OnDeserialized(StreamingContext context)
-	{
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // On win this works perfectly. By default Wasabi will run after startup.
-		{
-			return;
-		}
-
-		if (!Oobe) // We do not touch anything if it is not the first run.
-		{
-			return;
-		}
-
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) // On Linux we do not start Wasabi with OS by default - because Linux users knows better.
-		{
-			RunOnSystemStartup = false;
-		}
 	}
 }


### PR DESCRIPTION
This default is not good for several reasons:
- It requires some special handling in custom `Deserialize` function
- It is disabled on Linux but enabled on others because who knows
- It is definitely not common for a software handling MONEY to launch itself at startup like this
- On MacOs, this require to provide scary permissions on installation about system events
- Wasabi is pretty heavy and it has a high impact on startup performances
- If the wallet could load itself on launch then it would be useful to avoid sync, but it's not even the case

For all those reaosns, I believe that it is better to switch the default to false.