### PR TITLE
[Feature] Add coinjoin inputs/outputs summary

### DIFF
--- a/WalletWasabi.Fluent/Controls/TreeDataGrid.axaml
+++ b/WalletWasabi.Fluent/Controls/TreeDataGrid.axaml
@@ -17,6 +17,8 @@
       <TreeDataGridRow Theme="{StaticResource WalletCoinsViewTreeDataGridRow}" />
       <!-- ReceiveAddressesView -->
       <TreeDataGridRow Theme="{StaticResource ReceiveAddressesViewTreeDataGridRow}" />
+      <!-- CoinjoinCoinListView -->
+      <TreeDataGridRow Theme="{StaticResource CoinjoinCoinListViewTreeDataGridRow}" />
     </StackPanel>
   </Design.PreviewWith>
 
@@ -313,6 +315,71 @@
           <i:Interaction.Behaviors>
             <ExecuteCommandOnDoubleTappedBehavior Command="{Binding NavigateCommand, Mode=OneWay}" />
           </i:Interaction.Behaviors>
+          <Panel>
+            <Border Name="BackgroundRectangle" />
+            <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
+                                        ElementFactory="{TemplateBinding ElementFactory}"
+                                        Items="{TemplateBinding Columns}"
+                                        Rows="{TemplateBinding Rows}"
+                                        Margin="0 0 -2 0" />
+          </Panel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <!-- TreeDataGridRow: CoinjoinCoinsListView.axaml -->
+  <ControlTheme x:Key="CoinjoinCoinsListViewTreeDataGridExpanderCell" TargetType="TreeDataGridExpanderCell">
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}">
+          <DockPanel>
+            <Border DockPanel.Dock="Left"
+                    Margin="4 0 0 0"
+                    Width="12" Height="12">
+              <ToggleButton Theme="{StaticResource FluentTreeViewExpandCollapseChevron}"
+                            Focusable="False"
+                            IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
+                            Cursor="Hand">
+                <ToggleButton.IsVisible>
+                  <MultiBinding Converter="{x:Static BoolConverters.And}">
+                    <Binding Path="ShowExpander" RelativeSource="{RelativeSource TemplatedParent}" />
+                    <Binding Path="!IsChild" />
+                  </MultiBinding>
+                </ToggleButton.IsVisible>
+              </ToggleButton>
+            </Border>
+            <Decorator Name="PART_Content" />
+          </DockPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+  <ControlTheme x:Key="CoinjoinCoinsListViewTreeDataGridRow" TargetType="TreeDataGridRow" BasedOn="{StaticResource GenericTreeDataGridRow}">
+    <Setter Property="Focusable" Value="False" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border x:Name="PART_SelectionIndicator"
+                x:CompileBindings="True" x:DataType="treeDataGrid:ITreeDataGridExpanderItem"
+                Classes.isChild="{Binding IsChild}"
+                Classes.isLastChild="{Binding IsLastChild}"
+                Classes.isExpanded="{Binding IsExpanded}"
+                Classes.isParentPointerOver="{Binding IsParentPointerOver}"
+                Classes.isParentSelected="{Binding IsParentSelected}">
+          <Classes.lastChildIsParentPointerOver>
+            <MultiBinding Converter="{x:Static BoolConverters.And}">
+              <Binding Path="IsParentPointerOver" />
+              <Binding Path="IsLastChild" />
+            </MultiBinding>
+          </Classes.lastChildIsParentPointerOver>
+          <Classes.lastChildIsParentSelected>
+            <MultiBinding Converter="{x:Static BoolConverters.And}">
+              <Binding Path="IsParentSelected" />
+              <Binding Path="IsLastChild" />
+            </MultiBinding>
+          </Classes.lastChildIsParentSelected>
           <Panel>
             <Border Name="BackgroundRectangle" />
             <TreeDataGridCellsPresenter Name="PART_CellsPresenter"

--- a/WalletWasabi.Fluent/Controls/TreeDataGrid.axaml
+++ b/WalletWasabi.Fluent/Controls/TreeDataGrid.axaml
@@ -346,6 +346,7 @@
                   <MultiBinding Converter="{x:Static BoolConverters.And}">
                     <Binding Path="ShowExpander" RelativeSource="{RelativeSource TemplatedParent}" />
                     <Binding Path="!IsChild" />
+                    <Binding Path="HasChildren" />
                   </MultiBinding>
                 </ToggleButton.IsVisible>
               </ToggleButton>

--- a/WalletWasabi.Fluent/Converters/ThicknessConverters.cs
+++ b/WalletWasabi.Fluent/Converters/ThicknessConverters.cs
@@ -8,4 +8,10 @@ public class ThicknessConverters
 	public static readonly IValueConverter Negate =
 		new FuncValueConverter<Thickness, Thickness>(thickness =>
 			new Thickness(-thickness.Left, -thickness.Top, -thickness.Right, -thickness.Bottom));
+
+	public static readonly IValueConverter ApplyCoinjoinAnonScoreMargins =
+		new FuncValueConverter<bool, Thickness>(x => x ? new Thickness(8, 0, 0, 0) : new Thickness(0, 0, 0, 0));
+
+	public static readonly IValueConverter ApplyCoinjoinAmountMargins =
+		new FuncValueConverter<bool, Thickness>(x => x ? new Thickness(-52, 0, 0, 0) : new Thickness(-30, 0, 0, 0));
 }

--- a/WalletWasabi.Fluent/Models/Wallets/TransactionModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/TransactionModel.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using ReactiveUI;
 using System.Collections.Generic;
 using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.TransactionOutputs;
 
 namespace WalletWasabi.Fluent.Models.Wallets;
 
@@ -35,6 +36,13 @@ public partial class TransactionModel : ReactiveObject
 
 	public bool IsChild { get; set; }
 
+	public required Func<IReadOnlyCollection<OutPoint>> ForeignInputsFunction{ get; set; }
+	public Lazy<IReadOnlyCollection<OutPoint>> ForeignInputs => new(ForeignInputsFunction());
+	public required IReadOnlyCollection<SmartCoin> WalletInputs { get; set; }
+
+	public required Func<IReadOnlyCollection<OutPoint>> ForeignOutputsFunction{ get; set; }
+	public Lazy<IReadOnlyCollection<OutPoint>> ForeignOutputs => new(ForeignOutputsFunction());
+	public required IReadOnlyCollection<SmartCoin> WalletOutputs { get; set; }
 	public required Money Amount { get; set; }
 
 	public Money DisplayAmount => GetAmount();

--- a/WalletWasabi.Fluent/Models/Wallets/TransactionTreeBuilder.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/TransactionTreeBuilder.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Avalonia.Controls;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Helpers;
@@ -139,6 +138,10 @@ public class TransactionTreeBuilder
 			Confirmations = confirmations,
 			BlockHeight = transactionSummary.Height.Type == HeightType.Chain ? transactionSummary.Height.Value : 0,
 			BlockHash = transactionSummary.BlockHash,
+			WalletInputs = transactionSummary.WalletInputs,
+			ForeignInputsFunction = transactionSummary.ForeignInputs,
+			WalletOutputs = transactionSummary.WalletOutputs,
+			ForeignOutputsFunction = transactionSummary.ForeignOutputs,
 			Fee = transactionSummary.GetFee(),
 			FeeRate = transactionSummary.FeeRate(),
 			ConfirmedTooltip = await GetConfirmationToolTipAsync(status, confirmations, transactionSummary.Transaction, cancellationToken),
@@ -162,6 +165,10 @@ public class TransactionTreeBuilder
 			DateString = date.ToUserFacingFriendlyString(),
 			DateToolTipString = date.ToUserFacingString(),
 			OrderIndex = index,
+			WalletInputs = transactionSummary.WalletInputs,
+			ForeignInputsFunction = transactionSummary.ForeignInputs,
+			WalletOutputs = transactionSummary.WalletOutputs,
+			ForeignOutputsFunction = transactionSummary.ForeignOutputs,
 			Type = TransactionType.CoinjoinGroup,
 			Status = status,
 		};
@@ -182,6 +189,10 @@ public class TransactionTreeBuilder
 			Confirmations = parent.Confirmations,
 			BlockHeight = parent.BlockHeight,
 			BlockHash = parent.BlockHash,
+			WalletInputs = transactionSummary.WalletInputs,
+			ForeignInputsFunction = transactionSummary.ForeignInputs,
+			WalletOutputs = transactionSummary.WalletOutputs,
+			ForeignOutputsFunction = transactionSummary.ForeignOutputs,
 			ConfirmedTooltip = parent.ConfirmedTooltip,
 			Labels = parent.Labels,
 			CanCancelTransaction = transactionSummary.Transaction.IsCancellable(_wallet.KeyManager),
@@ -278,6 +289,10 @@ public class TransactionTreeBuilder
 			Confirmations = confirmations,
 			BlockHeight = transactionSummary.Height.Type == HeightType.Chain ? transactionSummary.Height.Value : 0,
 			BlockHash = transactionSummary.BlockHash,
+			WalletInputs = transactionSummary.WalletInputs,
+			ForeignInputsFunction = transactionSummary.ForeignInputs,
+			WalletOutputs = transactionSummary.WalletOutputs,
+			ForeignOutputsFunction = transactionSummary.ForeignOutputs,
 			ConfirmedTooltip = await GetConfirmationToolTipAsync(status, confirmations, transactionSummary.Transaction, cancellationToken),
 			Fee = transactionSummary.GetFee(),
 			FeeRate = transactionSummary.FeeRate()

--- a/WalletWasabi.Fluent/ViewModels/CoinControl/CoinControlLabelComparer.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinControl/CoinControlLabelComparer.cs
@@ -1,5 +1,5 @@
 using WalletWasabi.Fluent.Helpers;
-using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
+using WalletWasabi.Fluent.ViewModels.Wallets.Coins;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinControl;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListDataGridSource.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListDataGridSource.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using Avalonia.Controls;
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Templates;
+using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.TreeDataGrid;
+using WalletWasabi.Fluent.Views.Wallets.Coinjoins.Columns;
+
+namespace WalletWasabi.Fluent.ViewModels.Wallets.Coinjoins;
+
+public static class CoinjoinCoinListDataGridSource
+{
+	public static HierarchicalTreeDataGridSource<CoinjoinCoinListItem> Create(IEnumerable<CoinjoinCoinListItem> source)
+	{
+		// [Column]			[View]					[Header]	[Width]		[MinWidth]		[MaxWidth]	[CanUserSort]
+		// AnonymityScore	AnonymityColumnView		<custom>	50			-				-			true
+		// Amount			AmountColumnView		Amount		Auto		-				-			true
+		var result = new HierarchicalTreeDataGridSource<CoinjoinCoinListItem>(source)
+		{
+			Columns =
+			{
+				AnonymityScoreColumn(),
+				AmountColumn(),
+			}
+		};
+		return result;
+	}
+
+	private static IColumn<CoinjoinCoinListItem> AmountColumn()
+	{
+		return new PrivacyTextColumn<CoinjoinCoinListItem>(
+			null,
+			node => node.IsChild ? $"{node.Amount.ToFormattedString()} BTC" : $"{node.Children.Count} out of {node.TotalCoinsOnSideCount} ",
+			GridLength.Star,
+			new ColumnOptions<CoinjoinCoinListItem>
+			{
+				CompareAscending = Sort<CoinjoinCoinListItem>.Ascending(x => x.Amount),
+				CompareDescending = Sort<CoinjoinCoinListItem>.Descending(x => x.Amount)
+			},
+			PrivacyCellType.Amount,
+			9);
+	}
+
+	private static IColumn<CoinjoinCoinListItem> AnonymityScoreColumn()
+	{
+		return new HierarchicalExpanderColumn<CoinjoinCoinListItem>(
+			new TemplateColumn<CoinjoinCoinListItem>(
+			null,
+			new FuncDataTemplate<CoinjoinCoinListItem>((_, _) => new AnonymityScoreColumnView(), true),
+			null,
+			GridLength.Star,
+			new TemplateColumnOptions<CoinjoinCoinListItem>
+			{
+				CompareAscending = Sort<CoinjoinCoinListItem>.Ascending(b => b.AnonymityScore),
+				CompareDescending = Sort<CoinjoinCoinListItem>.Descending(b => b.AnonymityScore)
+			}),
+		group => group.Children,
+		node => true,
+		node => node.IsExpanded);
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListItem.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListItem.cs
@@ -43,6 +43,7 @@ public abstract partial class CoinjoinCoinListItem : ViewModelBase, ITreeDataGri
 	public int? AnonymityScore { get; protected set; }
 
 	public IReadOnlyCollection<CoinjoinCoinViewModel> Children { get; protected set; } = new List<CoinjoinCoinViewModel>();
+	public bool HasChildren => Children.Count > 0;
 
 	public int? TotalCoinsOnSideCount { get; set; }
 	public bool IsChild { get; set; }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListItem.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListItem.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Reactive.Disposables;
+using NBitcoin;
+using ReactiveUI;
+using System.Reactive.Linq;
+using WalletWasabi.Fluent.TreeDataGrid;
+
+namespace WalletWasabi.Fluent.ViewModels.Wallets.Coinjoins;
+
+public abstract partial class CoinjoinCoinListItem : ViewModelBase, ITreeDataGridExpanderItem, IDisposable
+{
+	protected readonly CompositeDisposable _disposables = new();
+
+	[AutoNotify] private bool _isParentPointerOver;
+	[AutoNotify] private bool _isControlPointerOver;
+	[AutoNotify] private bool _isExpanded;
+
+	protected CoinjoinCoinListItem()
+	{
+		this.WhenAnyValue(x => x.IsControlPointerOver)
+			.Do(x =>
+			{
+				foreach (var child in Children)
+				{
+					child.IsParentPointerOver = x;
+				}
+			})
+			.Subscribe();
+
+		this.WhenAnyValue(x => x.IsExpanded)
+			.Do(x =>
+			{
+				foreach (var child in Children)
+				{
+					child.IsExpanded = x;
+				}
+			})
+			.Subscribe();
+	}
+
+	public Money Amount { get; protected set; } = Money.Zero;
+
+	public int? AnonymityScore { get; protected set; }
+
+	public IReadOnlyCollection<CoinjoinCoinViewModel> Children { get; protected set; } = new List<CoinjoinCoinViewModel>();
+
+	public int? TotalCoinsOnSideCount { get; set; }
+	public bool IsChild { get; set; }
+	public bool IsLastChild { get; set; }
+	public bool IsParentSelected { get; set; } = false;
+
+	public void Dispose() => _disposables.Dispose();
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListViewModel.cs
@@ -11,9 +11,9 @@ public class CoinjoinCoinListViewModel : ViewModelBase, IDisposable
 {
 	private readonly CompositeDisposable _disposables = new();
 
-	public CoinjoinCoinListViewModel(IEnumerable<SmartCoin> availableCoins, int totalCoinsOnSideCount, uint256 txId)
+	public CoinjoinCoinListViewModel(IEnumerable<SmartCoin> availableCoins, int totalCoinsOnSideCount)
 	{
-		var coinItems = availableCoins.Select(x => new CoinjoinCoinViewModel(x, txId)).ToList();
+		var coinItems = availableCoins.Select(x => new CoinjoinCoinViewModel(x)).ToList();
 		foreach (var coin in coinItems)
 		{
 			coin.IsChild = true;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinListViewModel.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using Avalonia.Controls;
+using NBitcoin;
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.Fluent.ViewModels.Wallets.Coinjoins;
+
+public class CoinjoinCoinListViewModel : ViewModelBase, IDisposable
+{
+	private readonly CompositeDisposable _disposables = new();
+
+	public CoinjoinCoinListViewModel(IEnumerable<SmartCoin> availableCoins, int totalCoinsOnSideCount, uint256 txId)
+	{
+		var coinItems = availableCoins.Select(x => new CoinjoinCoinViewModel(x, txId)).ToList();
+		foreach (var coin in coinItems)
+		{
+			coin.IsChild = true;
+		}
+
+		if (coinItems.Count > 0)
+		{
+			coinItems.Last().IsLastChild = true;
+		}
+
+		var parentItem = new CoinjoinCoinViewModel(coinItems.ToArray(), totalCoinsOnSideCount);
+		coinItems.Insert(0, parentItem);
+		_disposables.Add(parentItem);
+
+		TreeDataGridSource = CoinjoinCoinListDataGridSource.Create(new List<CoinjoinCoinListItem> { parentItem });
+		TreeDataGridSource.DisposeWith(_disposables);
+	}
+
+	public HierarchicalTreeDataGridSource<CoinjoinCoinListItem> TreeDataGridSource { get; }
+
+	public void Dispose()
+	{
+		_disposables.Dispose();
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinViewModel.cs
@@ -6,11 +6,11 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Coinjoins;
 
 public class CoinjoinCoinViewModel : CoinjoinCoinListItem
 {
-    public CoinjoinCoinViewModel(SmartCoin coin, uint256 txId)
+    public CoinjoinCoinViewModel(SmartCoin coin)
 	{
 		Coin = coin;
 		Amount = coin.Amount;
-		if(coin.HdPubKey.HistoricalAnonSet.TryGetValue(txId, out var anonSetWhenTxProcessed))
+		if(coin.HdPubKey.HistoricalAnonSet.TryGetValue(coin.Outpoint.Hash, out var anonSetWhenTxProcessed))
 		{
 			AnonymityScore = (int)anonSetWhenTxProcessed;
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coinjoins/CoinjoinCoinViewModel.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using NBitcoin;
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.Fluent.ViewModels.Wallets.Coinjoins;
+
+public class CoinjoinCoinViewModel : CoinjoinCoinListItem
+{
+    public CoinjoinCoinViewModel(SmartCoin coin, uint256 txId)
+	{
+		Coin = coin;
+		Amount = coin.Amount;
+		if(coin.HdPubKey.HistoricalAnonSet.TryGetValue(txId, out var anonSetWhenTxProcessed))
+		{
+			AnonymityScore = (int)anonSetWhenTxProcessed;
+		}
+		else
+		{
+			AnonymityScore = (int)coin.AnonymitySet;
+		}
+	}
+
+	public CoinjoinCoinViewModel(CoinjoinCoinViewModel[] coins, int coinjoinInputCount)
+	{
+		Amount = coins.Sum(x => x.Amount);
+		Children = coins;
+		TotalCoinsOnSideCount = coinjoinInputCount;
+		IsExpanded = false;
+	}
+
+	public SmartCoin? Coin { get; }
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListDataGridSource.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListDataGridSource.cs
@@ -6,7 +6,6 @@ using Avalonia.Controls.Templates;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.TreeDataGrid;
 using WalletWasabi.Fluent.ViewModels.CoinControl;
-using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
 using WalletWasabi.Fluent.Views.CoinControl.Core.Cells;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Coins;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListItem.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListItem.cs
@@ -6,10 +6,9 @@ using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.TreeDataGrid;
-using WalletWasabi.Fluent.ViewModels.Wallets.Coins;
 using ScriptType = WalletWasabi.Fluent.Models.Wallets.ScriptType;
 
-namespace WalletWasabi.Fluent.ViewModels.CoinControl.Core;
+namespace WalletWasabi.Fluent.ViewModels.Wallets.Coins;
 
 public abstract partial class CoinListItem : ViewModelBase, ITreeDataGridExpanderItem, IDisposable
 {

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListViewModel.cs
@@ -14,7 +14,6 @@ using WalletWasabi.Fluent.Controls.Sorting;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.Models.Wallets;
-using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Coins;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinViewModel.cs
@@ -4,7 +4,6 @@ using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Models.Wallets;
-using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Coins;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/PocketViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/PocketViewModel.cs
@@ -8,7 +8,6 @@ using ReactiveUI;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Fluent.Models;
 using WalletWasabi.Fluent.Models.Wallets;
-using WalletWasabi.Fluent.ViewModels.CoinControl.Core;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Coins;
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
@@ -28,8 +28,8 @@ public partial class CoinJoinDetailsViewModel : RoutableViewModel
 
 	public CoinJoinDetailsViewModel(UiContext uiContext, IWalletModel wallet, TransactionModel transaction)
 	{
-		InputList = new CoinjoinCoinListViewModel(transaction.WalletInputs, transaction.WalletInputs.Count + transaction.ForeignInputs.Value.Count, transaction.Id);
-		OutputList = new CoinjoinCoinListViewModel(transaction.WalletOutputs, transaction.WalletOutputs.Count + transaction.ForeignOutputs.Value.Count, transaction.Id);
+		InputList = new CoinjoinCoinListViewModel(transaction.WalletInputs, transaction.WalletInputs.Count + transaction.ForeignInputs.Value.Count);
+		OutputList = new CoinjoinCoinListViewModel(transaction.WalletOutputs, transaction.WalletOutputs.Count + transaction.ForeignOutputs.Value.Count);
 
 		_wallet = wallet;
 		_transaction = transaction;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
@@ -6,6 +6,7 @@ using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Models.UI;
 using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.ViewModels.Navigation;
+using WalletWasabi.Fluent.ViewModels.Wallets.Coinjoins;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.History.Details;
 
@@ -27,6 +28,9 @@ public partial class CoinJoinDetailsViewModel : RoutableViewModel
 
 	public CoinJoinDetailsViewModel(UiContext uiContext, IWalletModel wallet, TransactionModel transaction)
 	{
+		InputList = new CoinjoinCoinListViewModel(transaction.WalletInputs, transaction.WalletInputs.Count + transaction.ForeignInputs.Value.Count, transaction.Id);
+		OutputList = new CoinjoinCoinListViewModel(transaction.WalletOutputs, transaction.WalletOutputs.Count + transaction.ForeignOutputs.Value.Count, transaction.Id);
+
 		_wallet = wallet;
 		_transaction = transaction;
 
@@ -35,6 +39,9 @@ public partial class CoinJoinDetailsViewModel : RoutableViewModel
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 		NextCommand = CancelCommand;
 	}
+
+	public CoinjoinCoinListViewModel InputList { get; }
+	public CoinjoinCoinListViewModel OutputList { get; }
 
 	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinsDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinsDetailsViewModel.cs
@@ -41,8 +41,8 @@ public partial class CoinJoinsDetailsViewModel : RoutableViewModel
 		var freshInputs = allInputs.Where(x => !allOutputs.Contains(x));
 		var finalOutputs = allOutputs.Where(x => !allInputs.Contains(x));
 
-		InputList = new CoinjoinCoinListViewModel(freshWalletInputs, freshWalletInputs.Count + freshInputs.Count(), transaction.Id);
-		OutputList = new CoinjoinCoinListViewModel(finalWalletOutputs, finalWalletOutputs.Count + finalOutputs.Count(), transaction.Id);
+		InputList = new CoinjoinCoinListViewModel(freshWalletInputs, freshWalletInputs.Count + freshInputs.Count());
+		OutputList = new CoinjoinCoinListViewModel(finalWalletOutputs, finalWalletOutputs.Count + finalOutputs.Count());
 
 		UiContext = uiContext;
 

--- a/WalletWasabi.Fluent/Views/CoinControl/Core/Cells/IndicatorsCellView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinControl/Core/Cells/IndicatorsCellView.axaml
@@ -2,9 +2,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:core="clr-namespace:WalletWasabi.Fluent.ViewModels.CoinControl.Core"
+             xmlns:coins="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Coins"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:DataType="core:CoinListItem"
+             x:DataType="coins:CoinListItem"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.CoinControl.Core.Cells.IndicatorsCellView">
 

--- a/WalletWasabi.Fluent/Views/CoinControl/Core/Cells/LabelsCellView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinControl/Core/Cells/LabelsCellView.axaml
@@ -2,10 +2,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:core="clr-namespace:WalletWasabi.Fluent.ViewModels.CoinControl.Core"
+             xmlns:coins="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Coins"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="WalletWasabi.Fluent.Views.CoinControl.Core.Cells.LabelsCellView"
-             x:DataType="core:CoinListItem"
+             x:DataType="coins:CoinListItem"
              x:CompileBindings="True">
 
   <UserControl.Styles>

--- a/WalletWasabi.Fluent/Views/CoinControl/Core/Cells/SelectionCellView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinControl/Core/Cells/SelectionCellView.axaml
@@ -2,10 +2,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:core="clr-namespace:WalletWasabi.Fluent.ViewModels.CoinControl.Core"
+             xmlns:coins="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Coins"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="WalletWasabi.Fluent.Views.CoinControl.Core.Cells.SelectionCellView"
-             x:DataType="core:CoinListItem"
+             x:DataType="coins:CoinListItem"
              x:CompileBindings="True">
   <UserControl.Styles>
     <Style Selector="Border">

--- a/WalletWasabi.Fluent/Views/Wallets/Coinjoins/CoinjoinCoinListView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Coinjoins/CoinjoinCoinListView.axaml
@@ -1,0 +1,40 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:coinjoins="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Coinjoins"
+             xmlns:treeDataGrid="clr-namespace:WalletWasabi.Fluent.TreeDataGrid"
+             xmlns:converters="clr-namespace:WalletWasabi.Fluent.Converters"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="WalletWasabi.Fluent.Views.Wallets.Coinjoins.CoinjoinCoinListView"
+             x:DataType="coinjoins:CoinjoinCoinListViewModel"
+             x:CompileBindings="True">
+  <Panel>
+    <TreeDataGrid x:Name="TreeDataGrid" Source="{Binding TreeDataGridSource}">
+      <TreeDataGrid.Styles>
+        <Style Selector="treeDataGrid|TreeDataGridAmountPrivacyTextCell" x:DataType="coinjoins:CoinjoinCoinListItem">
+          <Setter Property="FontFamily" Value="{StaticResource MonospacedFont}" />
+          <Setter Property="FontWeight" Value="Bold" />
+          <Setter Property="Opacity" Value="1" />
+          <Setter Property="FontSize" Value="14" />
+          <Setter Property="Margin" Value="{Binding !IsChild, Converter={x:Static converters:ThicknessConverters.ApplyCoinjoinAmountMargins}}"/>
+          <Setter Property="Background" Value="Transparent" />
+          <Setter Property="Foreground" Value="{DynamicResource TextForegroundColor}" />
+        </Style>
+        <Style Selector="TreeDataGridExpanderCell" x:DataType="coinjoins:CoinjoinCoinListItem">
+          <Setter Property="Theme" Value="{StaticResource CoinjoinCoinsListViewTreeDataGridExpanderCell}" />
+          <Setter Property="Margin" Value="{Binding !IsChild, Converter={x:Static converters:ThicknessConverters.ApplyCoinjoinAnonScoreMargins}}"/>
+        </Style>
+        <Style Selector="TreeDataGridRow" x:DataType="coinjoins:CoinjoinCoinListItem">
+          <Setter Property="Theme" Value="{StaticResource CoinjoinCoinsListViewTreeDataGridRow}" />
+        </Style>
+      </TreeDataGrid.Styles>
+      <Interaction.Behaviors>
+        <SetLastChildBehavior />
+      </Interaction.Behaviors>
+      <TreeDataGrid.ElementFactory>
+        <treeDataGrid:PrivacyElementFactory />
+      </TreeDataGrid.ElementFactory>
+    </TreeDataGrid>
+  </Panel>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Coinjoins/CoinjoinCoinListView.axaml.cs
+++ b/WalletWasabi.Fluent/Views/Wallets/Coinjoins/CoinjoinCoinListView.axaml.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.Wallets.Coinjoins;
+public class CoinjoinCoinListView : UserControl
+{
+	public CoinjoinCoinListView()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/Wallets/Coinjoins/Columns/AnonymityScoreColumnView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Coinjoins/Columns/AnonymityScoreColumnView.axaml
@@ -2,12 +2,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:coins="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Coins"
+             xmlns:coinjoins="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Coinjoins"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:DataType="coins:CoinListItem"
+             x:DataType="coinjoins:CoinjoinCoinListItem"
              x:CompileBindings="True"
-             x:Class="WalletWasabi.Fluent.Views.CoinControl.Core.Cells.AnonymityScoreCellView">
-  <InvalidatingStackPanel IsVisible="{Binding !!AnonymityScore}" Orientation="Horizontal" Margin="20 0" Spacing="2" HorizontalAlignment="Left" ToolTip.Tip="Anonymity Score">
+             x:Class="WalletWasabi.Fluent.Views.Wallets.Coinjoins.Columns.AnonymityScoreColumnView">
+  <InvalidatingStackPanel IsVisible="{Binding !!AnonymityScore}" Orientation="Horizontal" Margin="10 0" Spacing="2" HorizontalAlignment="Left" ToolTip.Tip="Anonymity Score">
     <PathIcon Data="{StaticResource anonscore}" VerticalAlignment="Center" Opacity="0.6" Height="15" />
     <TextBlock Text="{Binding AnonymityScore}" VerticalAlignment="Center" FontWeight="Bold" />
   </InvalidatingStackPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Coinjoins/Columns/AnonymityScoreColumnView.axaml.cs
+++ b/WalletWasabi.Fluent/Views/Wallets/Coinjoins/Columns/AnonymityScoreColumnView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.Wallets.Coinjoins.Columns;
+
+public class AnonymityScoreColumnView : UserControl
+{
+	public AnonymityScoreColumnView()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/Wallets/Coins/CoinListView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Coins/CoinListView.axaml
@@ -3,7 +3,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:treeDataGrid="clr-namespace:WalletWasabi.Fluent.TreeDataGrid"
-             xmlns:core="clr-namespace:WalletWasabi.Fluent.ViewModels.CoinControl.Core"
              xmlns:behaviors="clr-namespace:WalletWasabi.Fluent.Behaviors"
              xmlns:coins="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Coins"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -25,7 +24,7 @@
         <Style Selector="TreeDataGridExpanderCell">
           <Setter Property="Theme" Value="{StaticResource SelectCoinsDialogViewTreeDataGridExpanderCell}" />
         </Style>
-        <Style Selector="TreeDataGridRow" x:DataType="core:CoinListItem">
+        <Style Selector="TreeDataGridRow" x:DataType="coins:CoinListItem">
           <Setter Property="Theme" Value="{StaticResource SelectCoinsDialogViewTreeDataGridRow}" />
           <Setter Property="IsPointerOver" Value="{Binding IsPointerOverProxy, Mode=OneWayToSource}" />
           <Setter Property="IsSelected" Value="{Binding IsSelectedProxy, Mode=OneWayToSource}" />

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:details="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Home.History.Details"
              xmlns:conv="clr-namespace:WalletWasabi.Fluent.Converters"
+             xmlns:coinjoins="clr-namespace:WalletWasabi.Fluent.Views.Wallets.Coinjoins"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="details:CoinJoinDetailsViewModel"
              x:CompileBindings="True"
@@ -45,6 +46,31 @@
           <TextBlock IsVisible="{Binding IsConfirmed}" Margin="4 0 0 0 " Text="{Binding Confirmations, StringFormat='({0} confirmations)'}" />
         </StackPanel>
       </PreviewItem>
+
+      <!-- Inputs/Outputs -->
+      <Separator />
+      <PreviewItem Icon="{StaticResource input_count}" />
+      <DockPanel Margin="0 -35 0 0" LastChildFill="True">
+        <Grid DockPanel.Dock="Top" HorizontalAlignment="Stretch">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Text="Inputs" FontSize="14" FontWeight="Bold" HorizontalAlignment="Center"/>
+          <TextBlock Grid.Column="1" Text="Outputs" FontSize="14" FontWeight="Bold" HorizontalAlignment="Center"/>
+        </Grid>
+
+        <Grid Margin="0 10 0 0">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+          </Grid.ColumnDefinitions>
+
+          <coinjoins:CoinjoinCoinListView Grid.Column="0" Margin="30 0 30 0" DataContext="{Binding InputList}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+          <coinjoins:CoinjoinCoinListView Grid.Column="1" Margin="30 0 30 0" DataContext="{Binding OutputList}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+        </Grid>
+      </DockPanel>
 
       <Separator />
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinsDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinsDetailsView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:details="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Home.History.Details"
              xmlns:conv="clr-namespace:WalletWasabi.Fluent.Converters"
+             xmlns:coinjoins="clr-namespace:WalletWasabi.Fluent.Views.Wallets.Coinjoins"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:DataType="details:CoinJoinsDetailsViewModel"
              x:CompileBindings="True"
@@ -37,6 +38,31 @@
                      CopyableContent="{Binding TxCount}">
         <TextBlock Text="{Binding TxCount, Mode=OneWay}" />
       </PreviewItem>
+
+      <!-- Inputs/Outputs -->
+      <Separator />
+      <PreviewItem Icon="{StaticResource input_count}" />
+      <DockPanel Margin="0 -35 0 0" LastChildFill="True">
+        <Grid DockPanel.Dock="Top" HorizontalAlignment="Stretch">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+          </Grid.ColumnDefinitions>
+
+          <TextBlock Grid.Column="0" Text="Inputs" FontSize="14" FontWeight="Bold" HorizontalAlignment="Center"/>
+          <TextBlock Grid.Column="1" Text="Outputs" FontSize="14" FontWeight="Bold" HorizontalAlignment="Center"/>
+        </Grid>
+
+        <Grid Margin="0 10 0 0">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*"/>
+          </Grid.ColumnDefinitions>
+
+          <coinjoins:CoinjoinCoinListView Grid.Column="0" Margin="30 0 30 0" DataContext="{Binding InputList}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+          <coinjoins:CoinjoinCoinListView Grid.Column="1" Margin="30 0 30 0" DataContext="{Binding OutputList}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+        </Grid>
+      </DockPanel>
 
       <Separator />
 

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -242,14 +242,14 @@ public class BlockchainAnalyzer
 					// If it's a reuse of an input's pubkey, then intersection punishment is senseless.
 					hdPubKey.SetAnonymitySet(startingOutputAnonset.sanctioned, txid);
 				}
-				else if (hdPubKey.OutputAnonSetReasons.Contains(txid))
+				else if (hdPubKey.HistoricalAnonSet.ContainsKey(txid))
 				{
 					// If we already processed this transaction for this script
 					// then we'll go with normal processing.
 					// It may be a duplicated processing or new information arrived (like other wallet loaded)
 					// If there are more anonsets already
 					// then it's address reuse that we have already punished so leave it alone.
-					if (hdPubKey.OutputAnonSetReasons.Count == 1)
+					if (hdPubKey.HistoricalAnonSet.Count == 1)
 					{
 						hdPubKey.SetAnonymitySet(anonset, txid);
 					}

--- a/WalletWasabi/Blockchain/Keys/HdPubKey.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKey.cs
@@ -56,7 +56,7 @@ public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 		set => RaiseAndSetIfChanged(ref _cluster, value);
 	}
 
-	public HashSet<uint256> OutputAnonSetReasons { get; } = new();
+	public Dictionary<uint256, double> HistoricalAnonSet { get; } = new();
 
 	public double AnonymitySet
 	{
@@ -89,11 +89,11 @@ public class HdPubKey : NotifyPropertyChangedBase, IEquatable<HdPubKey>
 	public int Index { get; }
 	public bool IsInternal { get; }
 
-	public void SetAnonymitySet(double anonset, uint256? outputAnonSetReason = null)
+	public void SetAnonymitySet(double anonset, uint256? outputAnonSetReasonTxId = null)
 	{
-		if (outputAnonSetReason is not null)
+		if (outputAnonSetReasonTxId is not null)
 		{
-			OutputAnonSetReasons.Add(outputAnonSetReason);
+			HistoricalAnonSet[outputAnonSetReasonTxId] = anonset;
 		}
 
 		AnonymitySet = anonset;

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -1,5 +1,8 @@
+using System.Collections.Generic;
+using System.Linq;
 using NBitcoin;
 using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Models;
 
 namespace WalletWasabi.Blockchain.Transactions;
@@ -17,6 +20,10 @@ public class TransactionSummary
 	public Money Amount { get; set; }
 	public FeeRate? EffectiveFeeRate { get; }
 
+	public Func<IReadOnlyCollection<OutPoint>> ForeignInputs => () => Transaction.Transaction.Inputs.Select(x => x.PrevOut).ToArray();
+	public IReadOnlyCollection<SmartCoin> WalletInputs => Transaction.WalletInputs;
+	public Func<IReadOnlyCollection<OutPoint>> ForeignOutputs => () => Transaction.ForeignOutputs.Select(x => new OutPoint(GetHash(), x.N)).ToArray();
+	public IReadOnlyCollection<SmartCoin> WalletOutputs => Transaction.WalletOutputs;
 	public DateTimeOffset FirstSeen => Transaction.FirstSeen;
 	public LabelsArray Labels => Transaction.Labels;
 	public Height Height => Transaction.Height;

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -20,7 +20,7 @@ public class TransactionSummary
 	public Money Amount { get; set; }
 	public FeeRate? EffectiveFeeRate { get; }
 
-	public Func<IReadOnlyCollection<OutPoint>> ForeignInputs => () => Transaction.Transaction.Inputs.Select(x => x.PrevOut).ToArray();
+	public Func<IReadOnlyCollection<OutPoint>> ForeignInputs => () => Transaction.ForeignInputs.Select(x => x.PrevOut).ToArray();
 	public IReadOnlyCollection<SmartCoin> WalletInputs => Transaction.WalletInputs;
 	public Func<IReadOnlyCollection<OutPoint>> ForeignOutputs => () => Transaction.ForeignOutputs.Select(x => new OutPoint(GetHash(), x.N)).ToArray();
 	public IReadOnlyCollection<SmartCoin> WalletOutputs => Transaction.WalletOutputs;


### PR DESCRIPTION
Built on top of #13468

After what felt like an infinite amount of pain, I am glad to present this feature that has been requested since forever.

For CoinJoinsDetails, it only shows the inputs that don't come from a coinjoin of this group. For the outputs it's the same, it only shows outputs that are not remixed in this group. Same goes for the total: it doesn't account for the foreign coins that were remixed in one of the transaction of this group. This is the best way to do it because that way it really gives insightful info, but maybe I can add a tooltip to explain it.

It is final. As always my Avalonia code is pitiful, sorry for that, but I believe that the feature is really slick.

I additionally thoght about showing the total amount but it provided really little value as this info is available in the fee right below.
I also tried to show the script type but same, very little value and using space for nothing

![CleanShot 2024-09-30 at 01 11 54@2x](https://github.com/user-attachments/assets/23bd02f6-5f05-4eb3-b019-dbfa11c1eb66)

![CleanShot 2024-09-30 at 01 12 07@2x](https://github.com/user-attachments/assets/774848cd-b7be-4b17-9bf5-7795955b8e58)
