### PR TITLE
[BugFix] Fix version number in MacOs plist

### DIFF
--- a/Contrib/release.sh
+++ b/Contrib/release.sh
@@ -25,7 +25,7 @@ fi
 LATEST_TAG=$(git describe --tags --abbrev=0)
 # Extract the version number (strip the first character)
 VERSION=${LATEST_TAG:1}
-SHORT_VERSION=${VERSION:0:-2}
+SHORT_VERSION=${VERSION:0:${#VERSION}-2}
 
 # Define project names
 DESKTOP="WalletWasabi.Fluent.Desktop"


### PR DESCRIPTION
The issue is that in the specific bash version bundled in MacOs 14.6.1, the string substitution raises an error:
`./Contrib/release.sh: line 30: -2: substring expression < 0`

Interestingly, on MacOs v15.1 it works without particular issue.
To avoid further problems we might want to use a specific version instead of latest in the yml