### PR TITLE
replace usages of Uri.AbsolutePath with LocalPath for file system paths

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionHelpers.cs
@@ -140,7 +140,7 @@ public static class TransactionHelpers
 			return false;
 		}
 
-		var filePath = file.Path.AbsolutePath;
+		var filePath = file.Path.LocalPath;
 
 		if (!string.IsNullOrWhiteSpace(filePath))
 		{

--- a/WalletWasabi.Fluent/Screenshot/Capture.cs
+++ b/WalletWasabi.Fluent/Screenshot/Capture.cs
@@ -38,7 +38,7 @@ public static class Capture
 			Environment.GetFolderPath(Environment.SpecialFolder.MyPictures));
 		if (file is not null)
 		{
-			Save(root, root.Bounds.Size, file.Path.AbsolutePath);
+			Save(root, root.Bounds.Size, file.Path.LocalPath);
 		}
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
@@ -67,7 +67,7 @@ public partial class AddWalletPageViewModel : DialogViewModelBase<Unit>
 				return;
 			}
 
-			var filePath = file.Path.AbsolutePath;
+			var filePath = file.Path.LocalPath;
 			var walletName = Path.GetFileNameWithoutExtension(filePath);
 
 			var options = new WalletCreationOptions.ImportWallet(walletName, filePath);

--- a/WalletWasabi.Fluent/ViewModels/TransactionBroadcasting/LoadTransactionViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/TransactionBroadcasting/LoadTransactionViewModel.cs
@@ -46,7 +46,7 @@ public partial class LoadTransactionViewModel : DialogViewModelBase<SmartTransac
 			var file = await FileDialogHelper.OpenFileAsync("Import Transaction", new[] { "psbt", "txn", "*" });
 			if (file is { })
 			{
-				var filePath = file.Path.AbsolutePath;
+				var filePath = file.Path.LocalPath;
 				FinalTransaction = await UiContext.TransactionBroadcaster.LoadFromFileAsync(filePath);
 			}
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/HardwareWalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/HardwareWalletViewModel.cs
@@ -19,7 +19,7 @@ public class HardwareWalletViewModel : WalletViewModel
 				var file = await FileDialogHelper.OpenFileAsync("Import Transaction", new[] { "psbt", "txn", "*" });
 				if (file is { })
 				{
-					var path = file.Path.AbsolutePath;
+					var path = file.Path.LocalPath;
 					var txn = await walletModel.Transactions.LoadFromFileAsync(path);
 					Navigate().To().BroadcastTransaction(txn);
 				}


### PR DESCRIPTION
fixes #13475

All these usages come from either FileDialogHelper.OpenFileAsync or FileDialogHelper.SaveFileAsync.

tested importing a wallet with spaces on windows only.