### PR TITLE
Amount credential size configurable

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -16,7 +16,7 @@ using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.UnitTests;
-using WalletWasabi.WabiSabi;
+using WalletWasabi.Tests.UnitTests.WabiSabi;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.DoSPrevention;
 using WalletWasabi.WabiSabi.Backend.Models;
@@ -25,9 +25,6 @@ using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Models;
-using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
-using WalletWasabi.Wallets;
-using WalletWasabi.WebClients.Wasabi;
 using WalletWasabi.WabiSabi.Client.CoinJoin.Client;
 
 namespace WalletWasabi.Tests.Helpers;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CredentialDependencyTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CredentialDependencyTests.cs
@@ -16,7 +16,9 @@ public class CredentialDependencyTests
 	{
 		var g = DependencyGraph.ResolveCredentialDependencies(
 			inputValues: new[] { (10000L, 1930L), (1000L, 1930L) },
-			outputValues: new[] { (5000L, 31L), (3500L, 31L), (2500L, 31L) });
+			outputValues: new[] { (5000L, 31L), (3500L, 31L), (2500L, 31L) },
+			ProtocolConstants.MaxAmountPerAlice,
+			ProtocolConstants.MaxVsizeCredentialValue);
 
 		await SimulateAsyncRequestsAsync(g);
 	}
@@ -125,7 +127,7 @@ public class CredentialDependencyTests
 		// correct
 		var inputValues = new [] { (3L, 3L)};
 		var outputValues = new [] { (1L, 1L), (1L, 1L), (1L, 1L)};
-		var g = DependencyGraph.ResolveCredentialDependencies(inputValues, outputValues);
+		var g = DependencyGraph.ResolveCredentialDependencies(inputValues, outputValues, ProtocolConstants.MaxAmountPerAlice, ProtocolConstants.MaxVsizeCredentialValue);
 
 		Assert.Equal(5, g.Vertices.Count);
 
@@ -161,7 +163,7 @@ public class CredentialDependencyTests
 	{
 		var inputValues = new [] { (1L, 0L)};
 		var outputValues = new [] { (1L, 0L)};
-		var g = DependencyGraph.ResolveCredentialDependencies(inputValues, outputValues);
+		var g = DependencyGraph.ResolveCredentialDependencies(inputValues, outputValues, ProtocolConstants.MaxAmountPerAlice, ProtocolConstants.MaxVsizeCredentialValue);
 
 		Assert.Equal(2, g.Vertices.Count);
 
@@ -267,7 +269,7 @@ public class CredentialDependencyTests
 		var inputValues = ParseTuplas(inputs);
 		var outputValues = ParseTuplas(outputs);
 
-		var g = DependencyGraph.ResolveCredentialDependencies(inputValues, outputValues);
+		var g = DependencyGraph.ResolveCredentialDependencies(inputValues, outputValues, ProtocolConstants.MaxAmountPerAlice, ProtocolConstants.MaxVsizeCredentialValue);
 
 		// Useful for debugging:
 		// File.WriteAllText("/tmp/graphs/" + inputs + " -- " + outputs + ".dot", g.Graphviz());
@@ -350,7 +352,7 @@ public class CredentialDependencyTests
 	[Fact]
 	public void EdgeConstraints()
 	{
-		var g = DependencyGraph.FromValues(new[] { ( 11L, 0L), (8L, 0L) }, new[] { (7L, 0L), (11L, 0L) });
+		var g = DependencyGraph.FromValues(new[] { ( 11L, 0L), (8L, 0L) }, new[] { (7L, 0L), (11L, 0L) }, ProtocolConstants.MaxAmountPerAlice, ProtocolConstants.MaxVsizeCredentialValue);
 
 		var i = g.GetInputs().First();
 		var o = g.GetOutputs().First();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/PaymentAwareOutputProviderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/PaymentAwareOutputProviderTests.cs
@@ -53,7 +53,7 @@ public class PaymentAwareOutputProviderTests
 
 		// Make sure this doesn't throw
 		var vsizes = Enumerable.Repeat(0L, int.MaxValue).Prepend(availableVsize);
-		DependencyGraph.ResolveCredentialDependencies(registeredCoinsEffectiveValues, outputs, roundParameters.MiningFeeRate, vsizes);
+		DependencyGraph.ResolveCredentialDependencies(registeredCoinsEffectiveValues, outputs, roundParameters.MiningFeeRate, vsizes, ProtocolConstants.MaxAmountPerAlice, ProtocolConstants.MaxVsizeCredentialValue);
 	}
 
 	[Theory]

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/ProtocolConstants.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/ProtocolConstants.cs
@@ -1,0 +1,10 @@
+namespace WalletWasabi.Tests.UnitTests.WabiSabi;
+
+using RealProtocolConstants = WalletWasabi.WabiSabi.ProtocolConstants;
+
+public class ProtocolConstants
+{
+	public const int CredentialNumber = RealProtocolConstants.CredentialNumber;
+	public const long MaxVsizeCredentialValue = RealProtocolConstants.MaxVsizeCredentialValue;
+	public const long MaxAmountPerAlice = 4_300_000_000_000L;
+}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -490,7 +490,7 @@ public partial class Arena : PeriodicRunner
 
 				// 0.75 to bias towards larger numbers as larger input owners often have many smaller inputs too.
 				var smallSuggestion = allInputs.Skip((int)(allInputs.Length * _config.WW200CompatibleLoadBalancingInputSplit)).First();
-				var largeSuggestion = MaxSuggestedAmountProvider.AbsoluteMaximumInput;
+				var largeSuggestion = round.Parameters.AllowedInputAmounts.Max;
 
 				var roundWithoutThis = Rounds.Except(new[] { round });
 				RoundParameters parameters = _roundParameterFactory.CreateRoundParameter(feeRate, largeSuggestion);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
@@ -17,7 +17,6 @@ public class MaxSuggestedAmountProvider
 	private WabiSabiConfig Config { get; init; }
 	private int Counter { get; set; }
 	public Money MaxSuggestedAmount { get; private set; }
-	public Money AbsoluteMaximumInput { get; } = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice);
 
 	private void CheckOrGenerateRoundCounterDividerAndMaxAmounts()
 	{
@@ -36,9 +35,9 @@ public class MaxSuggestedAmountProvider
 		{
 			var roundDivider = (int)Math.Pow(2, level);
 			var maxValue = maxSuggestedAmountBase * (long)Math.Pow(10, level);
-			if (maxValue >= AbsoluteMaximumInput)
+			if (maxValue >= Config.MaxRegistrableAmount)
 			{
-				maxValue = AbsoluteMaximumInput;
+				maxValue = Config.MaxRegistrableAmount;
 				end = true;
 			}
 			roundCounterDividerAndMaxAmounts.Insert(0, new(roundDivider, maxValue));
@@ -81,7 +80,7 @@ public class MaxSuggestedAmountProvider
 		if (!isInputRegistrationSuccessful)
 		{
 			// We will keep this on the maximum - let everyone join.
-			MaxSuggestedAmount = AbsoluteMaximumInput;
+			MaxSuggestedAmount = Config.MaxRegistrableAmount;
 			return;
 		}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -760,7 +760,7 @@ public class CoinJoinClient
 
 		var outputTxOuts = _outputProvider.GetOutputs(roundId, roundParameters, registeredCoinEffectiveValues, theirCoinEffectiveValues, (int)availableVsizes.Sum()).ToArray();
 
-		DependencyGraph dependencyGraph = DependencyGraph.ResolveCredentialDependencies(registeredCoinEffectiveValues, outputTxOuts, roundParameters.MiningFeeRate, availableVsizes);
+		DependencyGraph dependencyGraph = DependencyGraph.ResolveCredentialDependencies(registeredCoinEffectiveValues, outputTxOuts, roundParameters.MiningFeeRate, availableVsizes, roundParameters.MaxAmountCredentialValue, roundParameters.MaxVsizeCredentialValue);
 		DependencyGraphTaskScheduler scheduler = new(dependencyGraph);
 
 		var combinedToken = linkedCts.Token;

--- a/WalletWasabi/WabiSabi/Client/CredentialDependencies/CredentialEdgeSet.cs
+++ b/WalletWasabi/WabiSabi/Client/CredentialDependencies/CredentialEdgeSet.cs
@@ -1,27 +1,23 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using WalletWasabi.Helpers;
 
 namespace WalletWasabi.WabiSabi.Client.CredentialDependencies;
 
-public record AmountCredentialEdgeSet : CredentialEdgeSet
+public record AmountCredentialEdgeSet(long MaxCredentialValue) : CredentialEdgeSet(MaxCredentialValue)
 {
-	public override long MaxCredentialValue => ProtocolConstants.MaxAmountPerAlice;
 	public override long Balance(RequestNode node) => node.Amount + EdgeBalances[node];
 }
 
-public record VsizeCredentialEdgeSet : CredentialEdgeSet
+public record VsizeCredentialEdgeSet(long MaxCredentialValue) : CredentialEdgeSet(MaxCredentialValue)
 {
-	public override long MaxCredentialValue => ProtocolConstants.MaxVsizeCredentialValue;
 	public override long Balance(RequestNode node) => node.Vsize + EdgeBalances[node];
 }
 
-public abstract record CredentialEdgeSet
+public abstract record CredentialEdgeSet(long MaxCredentialValue)
 {
-
-	public abstract long MaxCredentialValue { get; }
+	public long MaxCredentialValue { get; } = MaxCredentialValue;
 	public ImmutableDictionary<RequestNode, ImmutableHashSet<CredentialDependency>> InEdges { get; init; } = ImmutableDictionary.Create<RequestNode, ImmutableHashSet<CredentialDependency>>();
 	public ImmutableDictionary<RequestNode, ImmutableHashSet<CredentialDependency>> OutEdges { get; init; } = ImmutableDictionary.Create<RequestNode, ImmutableHashSet<CredentialDependency>>();
 	public ImmutableDictionary<RequestNode, long> EdgeBalances { get; init; } = ImmutableDictionary.Create<RequestNode, long>();

--- a/WalletWasabi/WabiSabi/ProtocolConstants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolConstants.cs
@@ -3,7 +3,6 @@ namespace WalletWasabi.WabiSabi;
 public static class ProtocolConstants
 {
 	public const int CredentialNumber = 2;
-	public const long MaxAmountPerAlice = 4_300_000_000_000L;
 	public const long MaxVsizeCredentialValue = 255;
 
 	public const string WabiSabiProtocolIdentifier = "WabiSabi_v1.0";


### PR DESCRIPTION
The amount credential size was always configurable, however, later in time hardcoded values were added to the `MuxSuggestedMountProvider`   and `DependencyGraph` classes. This PR makes sure hardcoded values are not used anymore.