### PR TITLE
[BugFix] Make client to compute `RoundId`

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -67,7 +67,7 @@ public class MultipartyTransactionStateTests
 		var diff21 = state2.GetStateFrom(1);
 		var diff32 = state3.GetStateFrom(2);
 		var clientState1 = state1;
-		var clientState3 = state3.GetStateFrom(2).AddPreviousStates(clientState1);
+		var clientState3 = state3.GetStateFrom(2).AddPreviousStates(clientState1, round.Id);
 		Assert.Equal(state3.Inputs, clientState3.Inputs);
 		Assert.Equal(state3.Outputs, clientState3.Outputs);
 		Assert.Equal(clientState3.Inputs, state3.Inputs);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -32,8 +32,8 @@ public class RoundStateUpdaterTests
 		// Each line represents a response for each request.
 		var mockHttpClientFactory = CreateMockHttpClientFactory([
 			RoundStateResponseBuilder(roundState1 with { Phase = Phase.InputRegistration }),
-			RoundStateResponseBuilder(roundState1 with { Phase = Phase.OutputRegistration }),
-			RoundStateResponseBuilder(roundState1 with { Phase = Phase.OutputRegistration }, roundState2 with { Phase = Phase.InputRegistration }),
+			RoundStateResponseBuilder(roundState1 with { Phase = Phase.OutputRegistration, CoinjoinState = roundState1.CoinjoinState.GetStateFrom(1)}),
+			RoundStateResponseBuilder(roundState1 with { Phase = Phase.OutputRegistration, CoinjoinState = roundState1.CoinjoinState.GetStateFrom(2)}, roundState2 with { Phase = Phase.InputRegistration }),
 			RoundStateResponseBuilder(roundState2 with { Phase = Phase.OutputRegistration }),
 			RoundStateResponseBuilder()
 		]);

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -65,6 +65,12 @@ public class RoundStateUpdater : PeriodicRunner
 		var newRoundStates = roundStates
 			.Where(rs => !RoundStates.ContainsKey(rs.Id));
 
+		if (newRoundStates.Any(r => !r.IsRoundIdMatching()))
+		{
+			throw new InvalidOperationException(
+				"Coordinator is cheating by creating rounds that do not match the parameters.");
+		}
+
 		// Don't use ToImmutable dictionary, because that ruins the original order and makes the server unable to suggest a round preference.
 		// ToDo: ToDictionary doesn't guarantee the order by design so .NET team might change this out of our feet, so there's room for improvement here.
 		RoundStates = newRoundStates.Concat(updatedRoundStates).ToDictionary(x => x.Id, x => x);

--- a/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
+++ b/WalletWasabi/WabiSabi/Client/RoundStateAwaiters/RoundStateUpdater.cs
@@ -59,7 +59,7 @@ public class RoundStateUpdater : PeriodicRunner
 		var updatedRoundStates = roundStates
 			.Where(rs => RoundStates.ContainsKey(rs.Id))
 			.Select(rs => (NewRoundState: rs, CurrentRoundState: RoundStates[rs.Id]))
-			.Select(x => x.NewRoundState with { CoinjoinState = x.NewRoundState.CoinjoinState.AddPreviousStates(x.CurrentRoundState.CoinjoinState) })
+			.Select(x => x.NewRoundState with { CoinjoinState = x.NewRoundState.CoinjoinState.AddPreviousStates(x.CurrentRoundState.CoinjoinState, x.NewRoundState.Id) })
 			.ToList();
 
 		var newRoundStates = roundStates

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/MultipartyTransactionState.cs
@@ -66,9 +66,25 @@ public abstract record MultipartyTransactionState
 			Events = Events.AddRange(diff.Events)
 		};
 
-	public MultipartyTransactionState AddPreviousStates(MultipartyTransactionState origin) =>
-		this with
+	public MultipartyTransactionState AddPreviousStates(MultipartyTransactionState origin, uint256 roundId)
+	{
+		VerifyOwnershipProofs(origin, Events, roundId);
+		return this with
 		{
 			Events = origin.Events.AddRange(Events)
 		};
+	}
+
+	private void VerifyOwnershipProofs(MultipartyTransactionState state, ImmutableList<IEvent> events, uint256 roundId)
+	{
+		var coinJoinInputCommitData = new CoinJoinInputCommitmentData(state.Parameters.CoordinationIdentifier, roundId);
+		var anyInvalidInput =
+			events.OfType<InputAdded>().Any(x => !OwnershipProof.VerifyCoinJoinInputProof(x.OwnershipProof, x.Coin.ScriptPubKey, coinJoinInputCommitData));
+
+		if (anyInvalidInput)
+		{
+			throw new InvalidOperationException(
+				"The coordinator is cheating by adding inputs to rounds that were created to be registered in different rounds.");
+		}
+	}
 }

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using WabiSabi.Crypto;
 using WabiSabi.Crypto.Randomness;
 using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using CredentialIssuerParameters = WabiSabi.Crypto.CredentialIssuerParameters;
 
@@ -17,6 +18,29 @@ public record RoundState(uint256 Id,
 	TimeSpan InputRegistrationTimeout,
 	MultipartyTransactionState CoinjoinState)
 {
+	private readonly Lazy<uint256> _calculatedRoundId = new(() => RoundHasher.CalculateHash(
+		InputRegistrationStart,
+		InputRegistrationTimeout,
+		CoinjoinState.Parameters.ConnectionConfirmationTimeout,
+		CoinjoinState.Parameters.OutputRegistrationTimeout,
+		CoinjoinState.Parameters.TransactionSigningTimeout,
+		CoinjoinState.Parameters.AllowedInputAmounts,
+		CoinjoinState.Parameters.AllowedInputTypes,
+		CoinjoinState.Parameters.AllowedOutputAmounts,
+		CoinjoinState.Parameters.AllowedOutputTypes,
+		CoinjoinState.Parameters.Network,
+		CoinjoinState.Parameters.MiningFeeRate.FeePerK,
+		CoinjoinState.Parameters.MaxTransactionSize,
+		CoinjoinState.Parameters.MinRelayTxFee.FeePerK,
+		CoinjoinState.Parameters.MaxAmountCredentialValue,
+		CoinjoinState.Parameters.MaxVsizeCredentialValue,
+		CoinjoinState.Parameters.MaxVsizeAllocationPerAlice,
+		CoinjoinState.Parameters.MaxSuggestedAmount,
+		CoinjoinState.Parameters.CoordinationIdentifier,
+		AmountCredentialIssuerParameters,
+		VsizeCredentialIssuerParameters));
+
+	public bool IsRoundIdMatching() => Id == _calculatedRoundId.Value;
 	public DateTimeOffset InputRegistrationEnd => InputRegistrationStart + InputRegistrationTimeout;
 	public bool IsBlame => BlameOf != uint256.Zero;
 


### PR DESCRIPTION
Client was trusting on the coordinator round id instead of computing it by itself. This PR is for fixing that and also to verify that all inputs registered in a round were created for that round only, this is done by verifying their ownership proofs.