### PR TITLE
[BugFix] Duplicated p2p network messages

### DIFF
--- a/WalletWasabi/BitcoinP2p/P2pNetwork.cs
+++ b/WalletWasabi/BitcoinP2p/P2pNetwork.cs
@@ -87,7 +87,6 @@ public class P2pNetwork : BackgroundService
 			var userAgent = Constants.UserAgents.RandomElement(SecureRandom.Instance);
 			var connectionParameters = new NodeConnectionParameters { UserAgent = userAgent };
 
-			connectionParameters.TemplateBehaviors.Add(_bitcoinStore.CreateUntrustedP2pBehavior());
 			connectionParameters.TemplateBehaviors.Add(addressManagerBehavior);
 			connectionParameters.EndpointConnector = new BestEffortEndpointConnector(MaximumNodeConnections / 2);
 


### PR DESCRIPTION
All peer-to-peer messages `inv` and `getdata` where sent twice because the `Untrustedp2pBehavior` was registered twice.