### PR TITLE
[Trivial] Bump version to 2.3.0.0

### DIFF
--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -94,7 +94,7 @@ public static class Constants
 
 	public static readonly Money MaximumNumberOfBitcoinsMoney = Money.Coins(MaximumNumberOfBitcoins);
 
-	public static readonly Version ClientVersion = new(2, 2, 1, 0);
+	public static readonly Version ClientVersion = new(2, 3, 0, 0);
 
 	public static readonly Version HwiVersion = new("3.1.0");
 	public static readonly Version BitcoinCoreVersion = new("23.0");


### PR DESCRIPTION
Merge after release highlights and last bug fix.
Then create tag `v2.3.0.0`