### PR TITLE
[Feature] Coinlist: add address as tooltip when hover over amount

### DIFF
--- a/WalletWasabi.Fluent/Views/CoinControl/Core/Cells/AmountCellView.axaml
+++ b/WalletWasabi.Fluent/Views/CoinControl/Core/Cells/AmountCellView.axaml
@@ -12,7 +12,8 @@
                          VerticalAlignment="Center"
                          UseOpacity="True"
                          MaxPrivacyChars="14"
-                         ForceShow="{Binding IgnorePrivacyMode}">
+                         ForceShow="{Binding IgnorePrivacyMode}"
+                         ToolTip.Tip="{Binding BtcAddress}">
     <AmountControl Amount="{Binding Amount}"/>
   </PrivacyContentControl>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Coinjoins/Cells/AmountCellView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Coinjoins/Cells/AmountCellView.axaml
@@ -13,7 +13,8 @@
                          HorizontalAlignment="Center"
                          UseOpacity="True"
                          MaxPrivacyChars="14"
-                         Margin="10 0 0 0">
+                         Margin="10 0 0 0"
+                         ToolTip.Tip="{Binding BtcAddress}">
     <AmountControl MinWidth="140" Amount="{Binding Amount}"/>
   </PrivacyContentControl>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Transactions/Inputs/Cells/AmountCellView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Transactions/Inputs/Cells/AmountCellView.axaml
@@ -13,7 +13,8 @@
                          HorizontalAlignment="Center"
                          UseOpacity="True"
                          MaxPrivacyChars="14"
-                         Margin="5 0 0 0">
+                         Margin="5 0 0 0"
+                         ToolTip.Tip="{Binding BtcAddress}">
     <AmountControl MinWidth="140" Amount="{Binding Amount}"/>
   </PrivacyContentControl>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Transactions/Outputs/Cells/AmountCellView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Transactions/Outputs/Cells/AmountCellView.axaml
@@ -13,7 +13,8 @@
                          HorizontalAlignment="Center"
                          UseOpacity="True"
                          MaxPrivacyChars="14"
-                         Margin="5 0 0 0">
+                         Margin="5 0 0 0"
+                         ToolTip.Tip="{Binding BtcAddress}">
     <AmountControl MinWidth="140" Amount="{Binding Amount}"/>
   </PrivacyContentControl>
 </UserControl>


### PR DESCRIPTION
as follow up to https://github.com/WalletWasabi/WalletWasabi/pull/13534/
If you'd want to know the related address, the user can now see it with a tooltip after right clicking.

Otherwise the user would need to copy the address, and then paste it somewhere (so either close the dialog, or copy outside of Wasabi) to see the address.