### PR TITLE
[Misc] Disable BuyAnythingButton

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -269,7 +269,6 @@ public class Global
 				HostedServices.Register<BuyAnythingManager>(() => new BuyAnythingManager(DataDir, TimeSpan.FromSeconds(5), buyAnythingClient), "BuyAnythingManager");
 				var buyAnythingManager = HostedServices.Get<BuyAnythingManager>();
 				await buyAnythingManager.EnsureConversationsAreLoadedAsync(cancel).ConfigureAwait(false);
-				await buyAnythingManager.EnsureCountriesAreLoadedAsync(cancel).ConfigureAwait(false);
 
 				await HostedServices.StartAllAsync(cancel).ConfigureAwait(false);
 

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -261,13 +261,12 @@ public class Global
 					}
 				}
 
-				bool useTestApi = Network != Network.Main;
-				var apiKey = useTestApi ? "SWSCVTGZRHJOZWF0MTJFTK9ZSG" : "SWSCU3LIYWVHVXRVYJJNDLJZBG";
-				var uri = useTestApi ? new Uri("https://shopinbit.solution360.dev/store-api/") : new Uri("https://shopinbit.com/store-api/");
+				var apiKey = "SWSCU3LIYWVHVXRVYJJNDLJZBG";
+				var uri = new Uri("https://shopinbit.com/store-api/");
 				ShopWareApiClient shopWareApiClient = new(ExternalSourcesHttpClientFactory.CreateClient("long-live-shopinbit"), uri, apiKey);
 
-				BuyAnythingClient buyAnythingClient = new(shopWareApiClient, useTestApi);
-				HostedServices.Register<BuyAnythingManager>(() => new BuyAnythingManager(DataDir, TimeSpan.FromSeconds(5), buyAnythingClient, useTestApi), "BuyAnythingManager");
+				BuyAnythingClient buyAnythingClient = new(shopWareApiClient);
+				HostedServices.Register<BuyAnythingManager>(() => new BuyAnythingManager(DataDir, TimeSpan.FromSeconds(5), buyAnythingClient), "BuyAnythingManager");
 				var buyAnythingManager = HostedServices.Get<BuyAnythingManager>();
 				await buyAnythingManager.EnsureConversationsAreLoadedAsync(cancel).ConfigureAwait(false);
 				await buyAnythingManager.EnsureCountriesAreLoadedAsync(cancel).ConfigureAwait(false);

--- a/WalletWasabi.Fluent/Models/Wallets/BuyAnythingModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/BuyAnythingModel.cs
@@ -23,11 +23,6 @@ public partial class BuyAnythingModel(Wallet wallet)
 		return workflow;
 	}
 
-	public Conversation NewConversation()
-	{
-		return new Conversation(ConversationId.Empty, Chat.Empty, OrderStatus.Open, ConversationStatus.Started, new ConversationMetaData(NewOrderTitle));
-	}
-
 	public async Task<Conversation[]> GetConversationsAsync(CancellationToken cancellationToken)
 	{
 		return await BuyAnythingManager.GetConversationsAsync(wallet, cancellationToken);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Buy/OrderViewModel.cs
@@ -74,8 +74,6 @@ public partial class OrderViewModel : ViewModelBase, IDisposable
 				 .Select(id => id == ConversationId.Empty)
 				 .CombineLatest(hasUserMessages, (a, b) => a && b);
 
-		ResetOrderCommand = ReactiveCommand.Create(ResetOrder, CanResetObs);
-
 		// TODO: Remove this once we use newer version of DynamicData
 		HasUnreadMessagesObs
 			.BindTo(this, x => x.HasUnreadMessages)
@@ -126,8 +124,6 @@ public partial class OrderViewModel : ViewModelBase, IDisposable
 
 	public ICommand RemoveOrderCommand { get; }
 
-	public ICommand ResetOrderCommand { get; }
-
 	public int OrderNumber { get; }
 
 	public async Task MarkAsReadAsync()
@@ -160,17 +156,6 @@ public partial class OrderViewModel : ViewModelBase, IDisposable
 	private async Task ShowErrorAsync(string message)
 	{
 		await UiContext.Navigate().To().ShowErrorDialog(message, "Send Failed", "Wasabi was unable to send your message", NavigationTarget.CompactDialogScreen).GetResultAsync();
-	}
-
-	private void ResetOrder()
-	{
-		_cts.Cancel();
-		_cts.Dispose();
-		_cts = new CancellationTokenSource();
-		ClearMessageList();
-
-		Workflow.Conversation = new Conversation(ConversationId.Empty, Chat.Empty, OrderStatus.Open, ConversationStatus.Started, new ConversationMetaData("New Order"));
-		StartWorkflow(_cts.Token);
 	}
 
 	private void RefreshMessageList(Conversation conversation)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -176,10 +176,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 
 		Tiles = GetTiles().ToList();
 
-		CanBuy =
-			walletModel.HasBalance
-				.CombineLatest(BuyViewModel.HasNonEmptyOrder)
-				.Select(x => GetIsBuyButtonVisible(x.First, x.Second));
+		CanBuy = BuyViewModel.HasRelevantOrder;
 
 		HasUnreadConversations = BuyViewModel.Orders
 			.ToObservableChangeSet(x => x.OrderNumber)
@@ -285,20 +282,6 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 		WalletModel.State
 			.BindTo(this, x => x.WalletState)
 			.DisposeWith(disposables);
-	}
-
-	private bool GetIsBuyButtonVisible(bool hasBalance, bool hasNonEmptyOrder)
-	{
-#if DEBUG
-		return true;
-#endif
-
-		if (hasBalance || hasNonEmptyOrder)
-		{
-			return true;
-		}
-
-		return false;
 	}
 
 	private ISearchItem[] CreateSearchItems()

--- a/WalletWasabi.Fluent/Views/Wallets/Buy/BuyView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Buy/BuyView.axaml
@@ -15,7 +15,7 @@
                  NextContent="Continue"
                  EnableCancel="{Binding EnableCancel}"
                  IsBusy="{Binding IsBusy}"
-                 Caption="Tell us what you want, and we'll handle the rest from start to finish."
+                 Caption="IMPORTANT: This feature will be disabled in the next release. Finish your ongoing orders."
                  ScrollViewer.VerticalScrollBarVisibility="Disabled">
 
     <DockPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Buy/OrdersListView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Buy/OrdersListView.axaml
@@ -28,12 +28,6 @@
       <Setter Property="Opacity" Value="0.6" />
       <Setter Property="ToolTip.Tip" Value="Remove order" />
     </Style>
-    <Style Selector="PathIcon.ResetOrderIcon">
-      <Setter Property="Data" Value="{StaticResource arrow_reset}" />
-      <Setter Property="Height" Value="16" />
-      <Setter Property="Opacity" Value="0.6" />
-      <Setter Property="ToolTip.Tip" Value="Reset order" />
-    </Style>
   </UserControl.Styles>
 
   <DockPanel>
@@ -63,17 +57,6 @@
                   </MultiBinding>
                 </Button.IsVisible>
                 <PathIcon Classes="RemoveOrderIcon" />
-              </Button>
-              <Button Classes="plain"
-                      ToolTip.Tip="Reset order"
-                      Command="{Binding ResetOrderCommand}">
-                <Button.IsVisible>
-                  <MultiBinding Converter="{x:Static BoolConverters.And}">
-                    <Binding Path="CanResetObs^" />
-                    <Binding Path="!IsBusy" />
-                  </MultiBinding>
-                </Button.IsVisible>
-                <PathIcon Classes="ResetOrderIcon" />
               </Button>
             </StackPanel>
             <TextBlock Text="{Binding Title}"

--- a/WalletWasabi/BuyAnything/BuyAnythingManager.cs
+++ b/WalletWasabi/BuyAnything/BuyAnythingManager.cs
@@ -44,19 +44,16 @@ internal enum ServerEvent
 // Class to manage the conversation updates
 public class BuyAnythingManager : PeriodicRunner
 {
-	public BuyAnythingManager(string dataDir, TimeSpan period, BuyAnythingClient client, bool useTestApi) : base(period)
+	public BuyAnythingManager(string dataDir, TimeSpan period, BuyAnythingClient client) : base(period)
 	{
 		_client = client;
-		_filePath = Path.Combine(dataDir, "Conversations", useTestApi ? "TestConversations.json" : "Conversations.json");
+		_filePath = Path.Combine(dataDir, "Conversations", "Conversations.json");
 
 		string countriesFilePath = Path.Combine(EnvironmentHelpers.GetFullBaseDirectory(), "BuyAnything", "Data", "Countries.json");
 		string fileContent = File.ReadAllText(countriesFilePath);
 		Country[] countries = [];
-		if (!useTestApi)
-		{
-			countries = JsonConvert.DeserializeObject<Country[]>(fileContent)
-								  ?? throw new InvalidOperationException("Couldn't read the countries list.");
-		}
+		countries = JsonConvert.DeserializeObject<Country[]>(fileContent)
+							  ?? throw new InvalidOperationException("Couldn't read the countries list.");
 		Countries = countries;
 	}
 

--- a/WalletWasabi/BuyAnything/ConversationExtensions.cs
+++ b/WalletWasabi/BuyAnything/ConversationExtensions.cs
@@ -4,11 +4,6 @@ namespace WalletWasabi.BuyAnything;
 
 public static class ConversationExtensions
 {
-	public static bool IsCompleted(this Conversation conversation)
-	{
-		return conversation.OrderStatus == OrderStatus.Done;
-	}
-
 	public static bool IsUpdatable(this Conversation conversation) => conversation.ConversationStatus != ConversationStatus.Deleted;
 
 	public static Conversation AddSystemChatLine(this Conversation conversation, string message, DataCarrier data,

--- a/WalletWasabi/WebClients/BuyAnything/BuyAnythingClient.cs
+++ b/WalletWasabi/WebClients/BuyAnything/BuyAnythingClient.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Nito.AsyncEx;
 using WalletWasabi.WebClients.ShopWare;
 using WalletWasabi.WebClients.ShopWare.Models;
+using WalletWasabi.WebClients.Wasabi;
 using Country = WalletWasabi.BuyAnything.Country;
 
 namespace WalletWasabi.WebClients.BuyAnything;
@@ -21,19 +22,10 @@ public class BuyAnythingClient
 		[Product.TravelConcierge] = "018c0cf0e5fc70bc9255b0cdb4510dbd"
 	};
 
-	// Product Id mapping for Concierge services
-	private static readonly Dictionary<Product, string> ProductIdsTesting = new()
-	{
-		[Product.ConciergeRequest] = "018d313972cf7c45b5fe2af5bce6e55d",
-		[Product.FastTravelBooking] = "018d313a605e7beb9ea605542267d8f8",
-		[Product.TravelConcierge] = "018d313bc5c4744281ec5ed837cee1c5"
-	};
 
 	private static readonly string SalutationIdProduction = "018b6635785b70679f479eadf50330f3";
-	private static readonly string SalutationIdTesting = "018d18f29d347170b6cfd6466cab3c71";
 
 	private static readonly string StorefrontUrlProduction = "https://wasabi.shopinbit.com";
-	private static readonly string StorefrontUrlTesting = "https://shopinbit.solution360.dev/wasabi";
 
 	// Customer information. We need this values to update the messages
 	// we have three options:
@@ -44,12 +36,12 @@ public class BuyAnythingClient
 
 	private static readonly string LastName = "Sabimoto";
 
-	public BuyAnythingClient(IShopWareApiClient apiClient, bool useTestApi = false)
+	public BuyAnythingClient(IShopWareApiClient apiClient)
 	{
 		_apiClient = apiClient;
-		ProductIds = useTestApi ? ProductIdsTesting : ProductIdsProduction;
-		_salutationId = useTestApi ? SalutationIdTesting : SalutationIdProduction;
-		_storefrontUrl = useTestApi ? StorefrontUrlTesting : StorefrontUrlProduction;
+		ProductIds = ProductIdsProduction;
+		_salutationId = SalutationIdProduction;
+		_storefrontUrl = StorefrontUrlProduction;
 	}
 
 	// Services provided by Concierge
@@ -72,6 +64,7 @@ public class BuyAnythingClient
 	private readonly string _storefrontUrl;
 
 	private readonly IShopWareApiClient _apiClient;
+	private readonly HttpClientFactory _httpClientFactory;
 	private readonly AsyncLock _contextTokenCacheLock = new();
 
 	private Dictionary<string, (string, DateTime)> ContextTokenCache { get; } = new();


### PR DESCRIPTION
This PR disables the `BuyAnythingButton` in a way that it doesn't let users to create new conversations anymore + it hides the button except if they have a conversation ongoing or done (so users can still access the result or terminate ongoing conversations)

In the next version, we can completely remove all code related.
This PR also removes the Test Shop because it doesn't exist anymore and the endpoints return errors.

It would be great if someone with a completed order could test