### PR TITLE
[Feature] Ledger Stax support

### DIFF
--- a/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
+++ b/WalletWasabi/Hwi/Models/HardwareWalletModels.cs
@@ -37,6 +37,9 @@ public enum HardwareWalletModels
 	[FriendlyName("Ledger Nano X")]
 	Ledger_Nano_X,
 
+	[FriendlyName("Ledger Stax")]
+	Ledger_Stax,
+
 	[FriendlyName("Trezor One")]
 	Trezor_1,
 

--- a/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
+++ b/WalletWasabi/Hwi/Models/HwiEnumerateEntry.cs
@@ -45,7 +45,7 @@ public class HwiEnumerateEntry
 		Model switch
 		{
 			HardwareWalletModels.Coldcard or HardwareWalletModels.Coldcard_Simulator => WalletType.Coldcard,
-			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus => WalletType.Ledger,
+			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus or HardwareWalletModels.Ledger_Stax => WalletType.Ledger,
 			HardwareWalletModels.Trezor_1 or HardwareWalletModels.Trezor_1_Simulator or HardwareWalletModels.Trezor_T or HardwareWalletModels.Trezor_T_Simulator or HardwareWalletModels.Trezor_Safe_3 or HardwareWalletModels.Trezor_Safe_5 => WalletType.Trezor,
 			HardwareWalletModels.Jade => WalletType.Jade,
 			HardwareWalletModels.BitBox02_BTCOnly => WalletType.BitBox,
@@ -60,7 +60,7 @@ public class HwiEnumerateEntry
 		return Model switch
 		{
 			HardwareWalletModels.Coldcard => true,
-			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus => false,
+			HardwareWalletModels.Ledger_Nano_S or HardwareWalletModels.Ledger_Nano_X or HardwareWalletModels.Ledger_Nano_S_Plus or HardwareWalletModels.Ledger_Stax => false,
 			HardwareWalletModels.Trezor_1 => false,
 			HardwareWalletModels.Trezor_T => false,
 			HardwareWalletModels.Trezor_Safe_3 => false,


### PR DESCRIPTION
Ledger Stax was already detected by HWI, I simply added the relevant models to WalletWasabi. It is now correctly added and the transactions are retrieved.

<img width="846" alt="Screenshot 2024-11-23 at 20 16 32" src="https://github.com/user-attachments/assets/740a0b79-b971-42dc-8477-7d2e171e35ab">

On a personal note, the mere fact that Ledger doesn't send test devices to the maintainers of this repo, shouldn't be a reason to stop adding support for their new devices, especially when the developers of HWI already added support back in August.

[ #13582 ]

Cheers