### PR TITLE
Fix amount decomposition when payment in CoinJoin is used

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
@@ -53,7 +53,8 @@ public class AmountDecomposerTests
 		var allowedOutputTypes = isTaprootEnabled ? new List<ScriptType>() { ScriptType.Taproot, ScriptType.P2WPKH } : new List<ScriptType>() { ScriptType.P2WPKH };
 
 		var amountDecomposer = new AmountDecomposer(feeRate, allowedOutputAmountRange.Min, allowedOutputAmountRange.Max, availableVsize, allowedOutputTypes, InsecureRandom.Instance);
-		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues);
+		var allCoinEffectiveValues = theirCoinEffectiveValues.Concat(registeredCoinEffectiveValues);
+		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues.Sum(), allCoinEffectiveValues);
 
 		var totalEffectiveValue = registeredCoinEffectiveValues.Sum(x => x);
 		var totalEffectiveCost = outputValues.Sum(x => x.EffectiveCost);

--- a/WalletWasabi/WabiSabi/Client/Batching/PaymentAwareOutputProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/Batching/PaymentAwareOutputProvider.cs
@@ -14,15 +14,12 @@ namespace WalletWasabi.WabiSabi.Client.Batching;
 public class PaymentAwareOutputProvider : OutputProvider
 {
 	public PaymentAwareOutputProvider(IDestinationProvider destinationProvider, PaymentBatch batchedPayments, WasabiRandom? random = null)
-		: base(destinationProvider)
+		: base(destinationProvider, random)
 	{
 		_batchedPayments = batchedPayments;
-		_random = random ?? SecureRandom.Instance;
 	}
 
 	private readonly PaymentBatch _batchedPayments;
-
-	private readonly WasabiRandom _random;
 
 	public override IEnumerable<TxOut> GetOutputs(
 		uint256 roundId,
@@ -75,7 +72,7 @@ public class PaymentAwareOutputProvider : OutputProvider
 			roundParameters.AllowedOutputAmounts.Max,
 			availableVsize,
 			DestinationProvider.SupportedScriptTypes,
-			_random);
+			Random);
 
 		var outputValues = amountDecomposer.Decompose(availableValues.Sum(), allCoinEffectiveValues).ToArray();
 		var decomposedOutputs = GetTxOuts(outputValues, DestinationProvider);

--- a/WalletWasabi/WabiSabi/Client/Batching/PaymentAwareOutputProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/Batching/PaymentAwareOutputProvider.cs
@@ -74,7 +74,7 @@ public class PaymentAwareOutputProvider : OutputProvider
 			DestinationProvider.SupportedScriptTypes,
 			Random);
 
-		var outputValues = amountDecomposer.Decompose(availableValues.Sum(), allCoinEffectiveValues).ToArray();
+		var outputValues = amountDecomposer.Decompose(availableValues.Sum(), allCoinEffectiveValues, bestPaymentSet.TotalAmount > 0).ToArray();
 		var decomposedOutputs = GetTxOuts(outputValues, DestinationProvider);
 		foreach (var txOut in decomposedOutputs)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/Decomposer/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/Decomposer/AmountDecomposer.cs
@@ -88,6 +88,12 @@ public class AmountDecomposer
 				"No valid output denominations found. This can occur when an insufficient number of coins are registered to participate in the coinjoin.");
 		}
 
+		// If my input sum is smaller than the smallest denomination, then participation in a coinjoin makes no sense.
+		if (denoms.Min(x => x.EffectiveCost) > myInputSum)
+		{
+			throw new InvalidOperationException("Not enough coins registered to participate in the coinjoin.");
+		}
+
 		var setCandidates = new Dictionary<int, (IEnumerable<Output> Decomposition, Money Cost)>();
 
 		// Create the most naive decomposition for starter.

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/Decomposer/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/Decomposer/AmountDecomposer.cs
@@ -74,11 +74,10 @@ public class AmountDecomposer
 		return denoms;
 	}
 
-	public IEnumerable<Output> Decompose(IEnumerable<Money> myInputCoinEffectiveValues, IEnumerable<Money> othersInputCoinEffectiveValues)
+	public IEnumerable<Output> Decompose(Money myInputSum, IEnumerable<Money> allInputCoinEffectiveValues)
 	{
-		var denoms = GetFilteredDenominations(othersInputCoinEffectiveValues.Concat(myInputCoinEffectiveValues));
-		var myInputs = myInputCoinEffectiveValues.ToArray();
-		var myInputSum = myInputs.Sum();
+		var denoms = GetFilteredDenominations(allInputCoinEffectiveValues);
+
 		var smallestScriptType = Math.Min(ScriptType.P2WPKH.EstimateOutputVsize(), ScriptType.Taproot.EstimateOutputVsize());
 		var maxNumberOfOutputsAllowed = Math.Min(AvailableVsize / smallestScriptType, 10); // The absolute max possible with the smallest script type.
 
@@ -87,12 +86,6 @@ public class AmountDecomposer
 		{
 			throw new InvalidOperationException(
 				"No valid output denominations found. This can occur when an insufficient number of coins are registered to participate in the coinjoin.");
-		}
-
-		// If my input sum is smaller than the smallest denomination, then participation in a coinjoin makes no sense.
-		if (denoms.Min(x => x.EffectiveCost) > myInputSum)
-		{
-			throw new InvalidOperationException("Not enough coins registered to participate in the coinjoin.");
 		}
 
 		var setCandidates = new Dictionary<int, (IEnumerable<Output> Decomposition, Money Cost)>();

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/Decomposer/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/Decomposer/AmountDecomposer.cs
@@ -74,7 +74,7 @@ public class AmountDecomposer
 		return denoms;
 	}
 
-	public IEnumerable<Output> Decompose(Money myInputSum, IEnumerable<Money> allInputCoinEffectiveValues)
+	public IEnumerable<Output> Decompose(Money myInputSum, IEnumerable<Money> allInputCoinEffectiveValues, bool isPerformingAPayment = false)
 	{
 		var denoms = GetFilteredDenominations(allInputCoinEffectiveValues);
 
@@ -88,8 +88,8 @@ public class AmountDecomposer
 				"No valid output denominations found. This can occur when an insufficient number of coins are registered to participate in the coinjoin.");
 		}
 
-		// If my input sum is smaller than the smallest denomination, then participation in a coinjoin makes no sense.
-		if (denoms.Min(x => x.EffectiveCost) > myInputSum)
+		// If my input sum is smaller than the smallest denomination, then participation in a coinjoin makes no sense, except if a payment is ongoing.
+		if (!isPerformingAPayment && denoms.Min(x => x.EffectiveCost) > myInputSum)
 		{
 			throw new InvalidOperationException("Not enough coins registered to participate in the coinjoin.");
 		}

--- a/WalletWasabi/WabiSabi/Client/OutputProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/OutputProvider.cs
@@ -33,7 +33,8 @@ public class OutputProvider
 			DestinationProvider.SupportedScriptTypes,
 			_random);
 
-		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues, theirCoinEffectiveValues).ToArray();
+		var allCoinEffectiveValues = theirCoinEffectiveValues.Concat(registeredCoinEffectiveValues);
+		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues.Sum(), allCoinEffectiveValues).ToArray();
 		return GetTxOuts(outputValues, DestinationProvider);
 	}
 

--- a/WalletWasabi/WabiSabi/Client/OutputProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/OutputProvider.cs
@@ -12,11 +12,11 @@ public class OutputProvider
 	public OutputProvider(IDestinationProvider destinationProvider, WasabiRandom? random = null)
 	{
 		DestinationProvider = destinationProvider;
-		_random = random ?? SecureRandom.Instance;
+		Random = random ?? SecureRandom.Instance;
 	}
 
 	internal IDestinationProvider DestinationProvider { get; }
-	private readonly WasabiRandom _random;
+	protected readonly WasabiRandom Random;
 
 	public virtual IEnumerable<TxOut> GetOutputs(
 		uint256 roundId,
@@ -31,7 +31,7 @@ public class OutputProvider
 			roundParameters.AllowedOutputAmounts.Max,
 			availableVsize,
 			DestinationProvider.SupportedScriptTypes,
-			_random);
+			Random);
 
 		var allCoinEffectiveValues = theirCoinEffectiveValues.Concat(registeredCoinEffectiveValues);
 		var outputValues = amountDecomposer.Decompose(registeredCoinEffectiveValues.Sum(), allCoinEffectiveValues).ToArray();


### PR DESCRIPTION
When payment in CoinJoin is used, the remaining amount that is decomposed to standard denominations can be decomposed into denominations not used by the other participants. Therefore, such a user doesn't get the expected level of anonymity, and the fact that the outputs are owned by someone who paid in the CoinJoin can be leaked. This issue is caused by the paying participant not considering some of his input coins when filtering the denominations while others consider all the input values.

This PR fixes that issue by considering all inputs when filtering denominations. I also removed one exception in `AmountDecomposer.cs` as it would be triggered any time when the amount remaining for mixing is too low (this issue existed even before my changes). 




