### PR TITLE
Preview TX: remove fee rate formatting/rounding to 1 decimal

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
@@ -71,7 +71,7 @@
                      Label="Fee Rate"
                      CopyableContent="{Binding FeeRate.SatoshiPerByte}">
         <PrivacyContentControl>
-          <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:F1} sat/vByte'}" />
+         <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:0.##} sat/vByte'}" />
         </PrivacyContentControl>
       </PreviewItem>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -74,7 +74,7 @@
                      Label="Fee Rate"
                      CopyableContent="{Binding FeeRate.SatoshiPerByte}">
         <PrivacyContentControl>
-          <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:F1} sat/vByte'}" />
+          <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:0.##} sat/vByte'}" />
         </PrivacyContentControl>
       </PreviewItem>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
@@ -220,7 +220,7 @@
                 <Setter Property="FontSize" Value="{StaticResource FontSizeH8}" />
               </Style>
             </StackPanel.Styles>
-            <TextBlock Text="{Binding CurrentSatoshiPerByte, Mode=OneWay, StringFormat='Fee Rate: \{0:0\} sat/vByte'}" />
+            <TextBlock Text="{Binding CurrentSatoshiPerByte, Mode=OneWay, StringFormat='Fee Rate: {0:0.##} sat/vByte'}" />
             <TextBlock Text="{Binding CurrentConfirmationTargetString, Mode=OneWay, StringFormat='Estimated Confirmation Time: \{0\}'}" />
           </StackPanel>
         </Panel>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -137,7 +137,7 @@
                      Label="Fee Rate"
                      CopyableContent="{Binding FeeRate.SatoshiPerByte}">
           <PrivacyContentControl>
-            <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:F1} sat/vByte'}" />
+            <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0} sat/vByte'}" />
           </PrivacyContentControl>
         </PreviewItem>
       </StackPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -137,7 +137,7 @@
                      Label="Fee Rate"
                      CopyableContent="{Binding FeeRate.SatoshiPerByte}">
           <PrivacyContentControl>
-            <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0} sat/vByte'}" />
+            <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:0.##} sat/vByte'}" />
           </PrivacyContentControl>
         </PreviewItem>
       </StackPanel>


### PR DESCRIPTION
Current behavior makes no sense and is confusing.
As it is rounding the number, but for a Fee Rate the exact amount matters.
It should just display the full 2 digit decimal.

Now it will only trim the last digit if it is a 0, which makes sense.

**master**

[master.webm](https://github.com/user-attachments/assets/014ada63-c55d-42d2-8561-783d9d43cc9c)

**PR**

[PR.webm](https://github.com/user-attachments/assets/6627409b-a7ed-40de-a48b-811c2bfc0105)
