### PR TITLE
[Feature] Use TestNet4 as testnet

### DIFF
--- a/WalletWasabi.Daemon/README.md
+++ b/WalletWasabi.Daemon/README.md
@@ -17,7 +17,7 @@ A few examples:
 
 | Config file                | Command line                | Environment variable             |
 |----------------------------|-----------------------------|----------------------------------|
-| Network: "TestNet4"        | --network=testnet4          | WASABI-NETWORK=testnet4          |
+| Network: "TestNet"         | --network=testnet           | WASABI-NETWORK=testnet           |
 | JsonRpcServerEnabled: true | --jsonrpcserverenabled=true | WASABI-JSONRPCSERVERENABLED=true |
 | UseTor: true               | --usetor=true               | WASABI-USETOR=true               |
 | DustThreshold: "0.00005"   | --dustthreshold=0.00005     | WASABI-DUSTTHRESHOLD=0.00005     |

--- a/WalletWasabi.Daemon/README.md
+++ b/WalletWasabi.Daemon/README.md
@@ -15,12 +15,12 @@ All configuration options available via `Config.json` file are also available as
 
 A few examples:
 
-| Config file | Command line | Environment variable |
-|-------------|--------------|----------------------|
-| Network: "TestNet" | --network=testnet | WASABI-NETWORK=testnet |
-| JsonRpcServerEnabled: true| --jsonrpcserverenabled=true | WASABI-JSONRPCSERVERENABLED=true |
-| UseTor: true | --usetor=true | WASABI-USETOR=true |
-| DustThreshold: "0.00005" | --dustthreshold=0.00005 | WASABI-DUSTTHRESHOLD=0.00005 |
+| Config file                | Command line                | Environment variable             |
+|----------------------------|-----------------------------|----------------------------------|
+| Network: "TestNet4"        | --network=testnet4          | WASABI-NETWORK=testnet4          |
+| JsonRpcServerEnabled: true | --jsonrpcserverenabled=true | WASABI-JSONRPCSERVERENABLED=true |
+| UseTor: true               | --usetor=true               | WASABI-USETOR=true               |
+| DustThreshold: "0.00005"   | --dustthreshold=0.00005     | WASABI-DUSTTHRESHOLD=0.00005     |
 
 ### Values precedence
 

--- a/WalletWasabi.Documentation/Ports.md
+++ b/WalletWasabi.Documentation/Ports.md
@@ -3,28 +3,28 @@
 A reference of common local ports used by Wasabi and related software.
 HiddenWallet's ports (3712x) are chosen within a long range of unassigned IANA ports, based on [this](https://stackoverflow.com/a/28369841/2061103) statistic, but also checked against [Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml).
 
-|Port  | Application |
-|----  | ---- |
-|37120 | HiddenWallet API |
-|37121 | Tor socks port used by HiddenWallet |
-|37122 | Tor control port used by HiddenWallet |
-|37123 | NTumbleBit server |
-|37124 | Tor socks port used by NTumbleBit |
-|37125 | Tor control port used by NTumbleBit |
-|37126 | Chaumian Tumbler |
-|37127 | Wallet Wasabi Backend |
-|37128 | Wallet Wasabi RPC Server |
-|37129 | Wallet Wasabi Local Client TCPListener on MainNet |
-|37130 | Wallet Wasabi Local Client TCPListener on TestNet |
-|37131 | Wallet Wasabi Local Client TCPListener on RegTest |
-|37150 | Tor socks port used by Wallet Wasabi |
-|37151 | Tor control port used by Wallet Wasabi |
-|9050  | Default Tor socks port |
-|9051  | Default Tor control port |
-|9150  | Tor socks port used by Tor Browser |
-|9151  | Tor control port used by Tor Browser |
-|8333  | Bitcoin Core Mainnet RPC |
-|18333  | Bitcoin Core Testnet RPC |
-|18444  | Bitcoin Core Regtest RPC |
-|5000  | Stratis: Bitcoin node and Breeze Wallet API |
-|5105  | Stratis: Stratis node and Stratis Wallet API |
+| Port  | Application                                       |
+|-------|---------------------------------------------------|
+| 37120 | HiddenWallet API                                  |
+| 37121 | Tor socks port used by HiddenWallet               |
+| 37122 | Tor control port used by HiddenWallet             |
+| 37123 | NTumbleBit server                                 |
+| 37124 | Tor socks port used by NTumbleBit                 |
+| 37125 | Tor control port used by NTumbleBit               |
+| 37126 | Chaumian Tumbler                                  |
+| 37127 | Wallet Wasabi Backend                             |
+| 37128 | Wallet Wasabi RPC Server                          |
+| 37129 | Wallet Wasabi Local Client TCPListener on MainNet |
+| 37130 | Wallet Wasabi Local Client TCPListener on TestNet |
+| 37131 | Wallet Wasabi Local Client TCPListener on RegTest |
+| 37150 | Tor socks port used by Wallet Wasabi              |
+| 37151 | Tor control port used by Wallet Wasabi            |
+| 9050  | Default Tor socks port                            |
+| 9051  | Default Tor control port                          |
+| 9150  | Tor socks port used by Tor Browser                |
+| 9151  | Tor control port used by Tor Browser              |
+| 8333  | Bitcoin Core Mainnet RPC                          |
+| 48333 | Bitcoin Core Testnet4 RPC                         |
+| 18444 | Bitcoin Core Regtest RPC                          |
+| 5000  | Stratis: Bitcoin node and Breeze Wallet API       |
+| 5105  | Stratis: Stratis node and Stratis Wallet API      |

--- a/WalletWasabi.Documentation/WasabiSetupRegtest.md
+++ b/WalletWasabi.Documentation/WasabiSetupRegtest.md
@@ -17,19 +17,19 @@ Todo:
      Windows x64:
     ```
     "C:\Program Files\Bitcoin\bitcoin-qt.exe" -regtest -blockfilterindex -txindex -datadir=c:\Bitcoin
-    ```        
-    macOS: 
+    ```
+    macOS:
     ```
     "/Applications/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt" -regtest -blockfilterindex -txindex -datadir=$HOME/Library/Application Support/Bitcoin"
     ```
-    Linux: 
+    Linux:
     ```
      ~/bitcoin-[version number]/bin/bitcoin-qt -regtest -blockfilterindex -txindex -datadir=$HOME/.bitcoin/
     ```
 4. Go to Bitcoin Knots data directory. If the directory is missing run core bitcoin-qt, then quit immediately. In this way the data directory and the config files will be generated.
-    
+
     There may be differences if you used the "-datadir" parameter before.
-    
+
     Defaults:
     Windows
     ```
@@ -92,7 +92,7 @@ Todo:
       "Network": "RegTest",
       "BitcoinRpcConnectionString": "7c9b6473600fbc9be1120ae79f1622f42c32e5c78d:309bc9961d01f388aed28b630ae834379296a8c8e3",
       "MainNetBitcoinP2pEndPoint": "127.0.0.1:8333",
-      "TestNetBitcoinP2pEndPoint": "127.0.0.1:18333",
+      "TestNetBitcoinP2pEndPoint": "127.0.0.1:48333",
       "RegTestBitcoinP2pEndPoint": "127.0.0.1:18444",
       "MainNetBitcoinCoreRpcEndPoint": "127.0.0.1:8332",
       "TestNetBitcoinCoreRpcEndPoint": "127.0.0.1:18332",
@@ -107,7 +107,7 @@ Todo:
     ```
 7. Start Bitcoin Knots in RegTest (command to run is explained above).
 8. Go to WalletWasabi folder
-9. Open the command line and enter. This will build all the projects under this directory. 
+9. Open the command line and enter. This will build all the projects under this directory.
 `dotnet build`
 10. Go to WalletWasabi\WalletWasabi.Backend folder.
 `dotnet run --no-build`

--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
@@ -63,7 +63,7 @@ public class ConfigManagerNgTests
 			  "StopLocalBitcoinCoreOnShutdown": true,
 			  "LocalBitcoinCoreDataDir": "{{localBitcoinCoreDataDir}}",
 			  "MainNetBitcoinP2pEndPoint": "127.0.0.1:8333",
-			  "TestNetBitcoinP2pEndPoint": "127.0.0.1:18333",
+			  "TestNetBitcoinP2pEndPoint": "127.0.0.1:48333",
 			  "RegTestBitcoinP2pEndPoint": "127.0.0.1:18444",
 			  "JsonRpcServerEnabled": false,
 			  "JsonRpcUser": "",

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/RpcBasedTests.cs
@@ -191,12 +191,9 @@ public class RpcBasedTests
 		var coreNode = await TestNodeBuilder.CreateAsync();
 		try
 		{
-			var rpc = coreNode.RpcClient;
+			var rpc = await coreNode.RpcClient.CreateWalletAsync("wallet");
+
 			var network = rpc.Network;
-
-			var walletName = "wallet";
-			await rpc.CreateWalletAsync(walletName);
-
 			using var k1 = new Key();
 			var blockId = await rpc.GenerateToAddressAsync(1, k1.PubKey.WitHash.GetAddress(network));
 			var block = await rpc.GetBlockAsync(blockId[0]);

--- a/WalletWasabi.Tests/UnitTests/JsonConverters/EndPointJsonConverterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/JsonConverters/EndPointJsonConverterTests.cs
@@ -21,7 +21,7 @@ public class EndPointJsonConverterTests
 		TestData testObject = new();
 
 		string json = AssertSerializedEqually(testObject);
-		Assert.Equal("""{"DefaultMainNet":"127.0.0.1:8333","DefaultTestNet":"127.0.0.1:18333","DefaultRegTest":"127.0.0.1:18443","None":null,"NotAnnotated":null}""", json);
+		Assert.Equal("""{"DefaultMainNet":"127.0.0.1:8333","DefaultTestNet":"127.0.0.1:48333","DefaultRegTest":"127.0.0.1:18443","None":null,"NotAnnotated":null}""", json);
 	}
 
 	/// <summary>
@@ -141,7 +141,7 @@ public class EndPointJsonConverterTests
 		[Newtonsoft.Json.JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultTestNetBitcoinP2pPort)]
 		[System.Text.Json.Serialization.JsonConverter(typeof(EndPointJsonConverterNg))]
 		[System.Text.Json.Serialization.JsonPropertyName(nameof(DefaultTestNet))]
-		public EndPoint DefaultTestNet { get; set; } = new IPEndPoint(IPAddress.Loopback, 18333);
+		public EndPoint DefaultTestNet { get; set; } = new IPEndPoint(IPAddress.Loopback, 48333);
 
 		[Newtonsoft.Json.JsonProperty(PropertyName = nameof(DefaultRegTest))]
 		[Newtonsoft.Json.JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBitcoinCoreRpcPort)]

--- a/WalletWasabi.Tests/UnitTests/JsonConverters/NetworkJsonConverterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/JsonConverters/NetworkJsonConverterTests.cs
@@ -21,7 +21,7 @@ public class NetworkJsonConverterTests
 		TestData testObject = new();
 
 		string json = AssertSerializedEqually(testObject);
-		Assert.Equal("""{"Main":"Main","Test":"TestNet","RegTest":"RegTest","Default":null,"NotAnnotated":null}""", json);
+		Assert.Equal("""{"Main":"Main","Test":"TestNet4","RegTest":"RegTest","Default":null,"NotAnnotated":null}""", json);
 	}
 
 	/// <summary>

--- a/WalletWasabi.Tests/UnitTests/SmartHeaderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartHeaderTests.cs
@@ -32,10 +32,10 @@ public class SmartHeaderTests
 		uint expectedHeightMain = 481824;
 		var expectedTimeMain = DateTimeOffset.FromUnixTimeSeconds(1503539857);
 
-		var expectedHashTest = new uint256("00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a");
-		var expectedPrevHashTest = new uint256("0000000000211a4d54bceb763ea690a4171a734c48d36f7d8e30b51d6df6ea85");
-		uint expectedHeightTest = 828575;
-		var expectedTimeTest = DateTimeOffset.FromUnixTimeSeconds(1463079943);
+		var expectedHashTest = new uint256("00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043");
+		var expectedPrevHashTest = uint256.Zero;
+		uint expectedHeightTest = 0;
+		var expectedTimeTest = DateTimeOffset.FromUnixTimeSeconds(1714777860);
 
 		var expectedHashReg = Network.RegTest.GenesisHash;
 		var expectedPrevHashReg = uint256.Zero;

--- a/WalletWasabi.Tests/UnitTests/Userfacing/AddressStringParserTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Userfacing/AddressStringParserTests.cs
@@ -81,22 +81,22 @@ public class AddressStringParserTests
 		Assert.Equal("Invalid amount value.", errorMessage);
 
 		Assert.False(AddressStringParser.TryParse("bitcoin:mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP?amount=", Network.Main, out _, out errorMessage));
-		Assert.Equal("Bitcoin address is valid for TestNet and not for Main.", errorMessage);
+		Assert.Equal("Bitcoin address is valid for TestNet4 and not for Main.", errorMessage);
 
 		Assert.False(AddressStringParser.TryParse("bitcoin:mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP?amount=XYZ", Network.Main, out _, out errorMessage));
-		Assert.Equal("Bitcoin address is valid for TestNet and not for Main.", errorMessage);
+		Assert.Equal("Bitcoin address is valid for TestNet4 and not for Main.", errorMessage);
 
 		Assert.False(AddressStringParser.TryParse("bitcoin:mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP?amount=100'000", Network.Main, out _, out errorMessage));
-		Assert.Equal("Bitcoin address is valid for TestNet and not for Main.", errorMessage);
+		Assert.Equal("Bitcoin address is valid for TestNet4 and not for Main.", errorMessage);
 
 		Assert.False(AddressStringParser.TryParse("bitcoin:mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP?amount=100000", Network.Main, out _, out errorMessage));
-		Assert.Equal("Bitcoin address is valid for TestNet and not for Main.", errorMessage);
+		Assert.Equal("Bitcoin address is valid for TestNet4 and not for Main.", errorMessage);
 
 		Assert.False(AddressStringParser.TryParse("bitcoin:18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999", Network.Main, out _, out errorMessage));
 		Assert.Equal("Unsupported required parameter found.", errorMessage);
 
 		Assert.False(AddressStringParser.TryParse("bitcoin:mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP?req-somethingyoudontunderstand=50&req-somethingelseyoudontget=999", Network.Main, out _, out errorMessage));
-		Assert.Equal("Bitcoin address is valid for TestNet and not for Main.", errorMessage);
+		Assert.Equal("Bitcoin address is valid for TestNet4 and not for Main.", errorMessage);
 
 		// Success cases.
 		Assert.True(AddressStringParser.TryParse("bitcoin:18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX", Network.Main, out Bip21UriParser.Result? result));

--- a/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WalletDirTests.cs
@@ -53,8 +53,8 @@ public class WalletDirTests
 
 		var testWd = new WalletDirectories(Network.TestNet, baseDir);
 		Assert.Equal(Network.TestNet, testWd.Network);
-		Assert.Equal(Path.Combine(baseDir, "Wallets", "TestNet"), testWd.WalletsDir);
-		Assert.Equal(Path.Combine(baseDir, "WalletBackups", "TestNet"), testWd.WalletsBackupDir);
+		Assert.Equal(Path.Combine(baseDir, "Wallets", "TestNet4"), testWd.WalletsDir);
+		Assert.Equal(Path.Combine(baseDir, "WalletBackups", "TestNet4"), testWd.WalletsBackupDir);
 
 		var regWd = new WalletDirectories(Network.RegTest, baseDir);
 		Assert.Equal(Network.RegTest, regWd.Network);

--- a/WalletWasabi/BitcoinCore/Configuration/NetworkTranslator.cs
+++ b/WalletWasabi/BitcoinCore/Configuration/NetworkTranslator.cs
@@ -69,7 +69,7 @@ public static class NetworkTranslator
 		}
 		else if (network == Network.TestNet)
 		{
-			return "-regtest=0 -testnet=1";
+			return "-regtest=0 -testnet4=1";
 		}
 		else if (network == Network.RegTest)
 		{

--- a/WalletWasabi/Blockchain/Blocks/SmartHeader.cs
+++ b/WalletWasabi/Blockchain/Blocks/SmartHeader.cs
@@ -41,23 +41,11 @@ public class SmartHeader
 		481824,
 		1503539857);
 
-	private static SmartHeader StartingHeaderSegwitTestNet { get; } = new SmartHeader(
-		new uint256("00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a"),
-		new uint256("0000000000211a4d54bceb763ea690a4171a734c48d36f7d8e30b51d6df6ea85"),
-		828575,
-		1463079943);
-
-	private static SmartHeader StartingHeaderTaprootMain { get; } = new SmartHeader(
-		new uint256("0000000000000000000687bca986194dc2c1f949318629b44bb54ec0a94d8244"),
-		new uint256("000000000000000000013712fc242ee6dd28476d0e9c931c75f83e6974c6bccc"),
-		709632,
-		1636866927);
-
-	private static SmartHeader StartingHeaderTaprootTestNet { get; } = new SmartHeader(
-		new uint256("00000000000000216dc4eb2bd27764891ec0c961b0da7562fe63678e164d62a0"),
-		new uint256("0000000000000001e17cc7358ee658affcb0a23146176581a7606a15f73993e3"),
-		2007000,
-		1625103124);
+	private static SmartHeader StartingHeaderSegwitTestNet4 { get; } = new SmartHeader(
+		Network.TestNet.GenesisHash,
+		Network.TestNet.GetGenesis().Header.HashPrevBlock,
+		0,
+		Network.TestNet.GetGenesis().Header.BlockTime);
 
 	private static SmartHeader StartingHeaderRegTest { get; } = new SmartHeader(
 		Network.RegTest.GenesisHash,
@@ -69,7 +57,7 @@ public class SmartHeader
 		network.Name switch
 		{
 			"Main" => StartingHeaderSegwitMain,
-			"TestNet" => StartingHeaderSegwitTestNet,
+			"TestNet4" => StartingHeaderSegwitTestNet4,
 			"RegTest" => StartingHeaderRegTest,
 			_ => throw new NotSupportedNetworkException(network)
 		};

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -119,10 +119,10 @@ public class KeyManager
 	public static KeyPath GetAccountKeyPath(Network network, ScriptPubKeyType scriptPubKeyType) =>
 		new((network.Name, scriptPubKeyType) switch
 		{
-			("TestNet", ScriptPubKeyType.Segwit) => "m/84h/1h/0h",
+			("TestNet4", ScriptPubKeyType.Segwit) => "m/84h/1h/0h",
 			("RegTest", ScriptPubKeyType.Segwit) => "m/84h/0h/0h",
 			("Main", ScriptPubKeyType.Segwit) => "m/84h/0h/0h",
-			("TestNet", ScriptPubKeyType.TaprootBIP86) => "m/86h/1h/0h",
+			("TestNet4", ScriptPubKeyType.TaprootBIP86) => "m/86h/1h/0h",
 			("RegTest", ScriptPubKeyType.TaprootBIP86) => "m/86h/0h/0h",
 			("Main", ScriptPubKeyType.TaprootBIP86) => "m/86h/0h/0h",
 			_ => throw new ArgumentException($"Unknown account for network '{network}' and script type '{scriptPubKeyType}'.")

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -57,11 +57,11 @@ public static class Constants
 	public const int BigFileReadWriteBufferSize = 1 * 1024 * 1024;
 
 	public const int DefaultMainNetBitcoinP2pPort = 8333;
-	public const int DefaultTestNetBitcoinP2pPort = 18333;
+	public const int DefaultTestNetBitcoinP2pPort = 48333;
 	public const int DefaultRegTestBitcoinP2pPort = 18444;
 
 	public const int DefaultMainNetBitcoinCoreRpcPort = 8332;
-	public const int DefaultTestNetBitcoinCoreRpcPort = 18332;
+	public const int DefaultTestNetBitcoinCoreRpcPort = 48332;
 	public const int DefaultRegTestBitcoinCoreRpcPort = 18443;
 
 	public const decimal DefaultDustThreshold = 0.00005m;

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -67,7 +67,7 @@ public static class Constants
 	public const decimal DefaultDustThreshold = 0.00005m;
 	public const decimal DefaultMaxCoinJoinMiningFeeRate = 150.0m;
 	public const int DefaultAbsoluteMinInputCount = 21;
-	public const int AbsoluteMinInputCount = 5;
+	public const int AbsoluteMinInputCount = 2;
 
 	public const string AlphaNumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 	public const string CapitalAlphaNumericCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/WalletWasabi/ModuleInitializer.cs
+++ b/WalletWasabi/ModuleInitializer.cs
@@ -23,7 +23,16 @@ class ModuleInitializer
 		// Get the internal dictionary
 		var networks = networksField!.GetValue(bitcoinInstance) as ConcurrentDictionary<ChainName, Network>;
 
+		var testnet4 = networks[new ChainName("testnet4")];
+
 		// Replaces testnet by testnet4 network
-		networks[new ChainName("testnet")] = networks[new ChainName("testnet4")];
+		networks[new ChainName("testnet")] = testnet4;
+
+		var otherAliasesField = typeof(Network)
+			.GetField("_OtherAliases", BindingFlags.NonPublic | BindingFlags.Static);
+
+		var otherAliases = otherAliasesField!.GetValue(null) as ConcurrentDictionary<string, Network>;
+		otherAliases["test"] = testnet4;
+		otherAliases["testnet"] = testnet4;
 	}
 }

--- a/WalletWasabi/ModuleInitializer.cs
+++ b/WalletWasabi/ModuleInitializer.cs
@@ -1,0 +1,29 @@
+namespace WalletWasabi;
+using System.Collections.Concurrent;
+using System.Reflection;
+using NBitcoin;
+using System.Runtime.CompilerServices;
+
+class ModuleInitializer
+{
+	[ModuleInitializer]
+	internal static void PatchTestNet()
+	{
+		// This is necessary to force the static members to be initialized
+		RuntimeHelpers.RunClassConstructor(typeof(Network).TypeHandle);
+
+		// Access the Bitcoin.Instance
+		var bitcoinInstance = Bitcoin.Instance;
+
+		// Get the private field `_Networks` using reflection
+		var networksField = bitcoinInstance
+			.GetType()
+			.GetField("_Networks", BindingFlags.NonPublic | BindingFlags.Instance);
+
+		// Get the internal dictionary
+		var networks = networksField!.GetValue(bitcoinInstance) as ConcurrentDictionary<ChainName, Network>;
+
+		// Replaces testnet by testnet4 network
+		networks[new ChainName("testnet")] = networks[new ChainName("testnet4")];
+	}
+}


### PR DESCRIPTION
This PR replaces `TestNet3` by `TestNet4`. Given that NBitcoin's `Network.TestNet` reference the already dead TestNet3 and that the `TestNet4` network is available only through `Bitcoin.Instance`, or well we change that everywhere (rather risky imo) or we hack it as I do here (ugly).

