### PR TITLE
Separate coordinator from backend

### DIFF
--- a/WalletWasabi.Backend/Config.cs
+++ b/WalletWasabi.Backend/Config.cs
@@ -76,9 +76,6 @@ public class Config : ConfigBase
 	[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultRegTestBitcoinCoreRpcPort)]
 	public EndPoint RegTestBitcoinCoreRpcEndPoint { get; internal set; } = Constants.DefaultRegTestBitcoinCoreRpcEndPoint;
 
-	[JsonProperty(PropertyName = "AnnouncerConfig")]
-	public AnnouncerConfig AnnouncerConfig { get; internal set; } = new();
-
 	public EndPoint GetBitcoinP2pEndPoint()
 	{
 		if (Network == Network.Main)

--- a/WalletWasabi.Backend/Startup.cs
+++ b/WalletWasabi.Backend/Startup.cs
@@ -114,27 +114,7 @@ public class Startup
 		var network = config.Network;
 
 		services.AddSingleton(_ => network);
-		WabiSabiConfig wabisabiConfig = new(Path.Combine(dataDir, "WabiSabiConfig.json"));
-		wabisabiConfig.LoadFile(createIfMissing: true);
-		services.AddSingleton(wabisabiConfig);
-		services.AddSingleton<Prison>(s => s.GetRequiredService<Warden>().Prison);
-		services.AddSingleton<Warden>(s =>
-			new Warden(
-				Path.Combine(dataDir, "WabiSabi", "Prison.txt"),
-				s.GetRequiredService<WabiSabiConfig>()));
-		services.AddSingleton<CoinJoinFeeRateStatStore>(s =>
-			CoinJoinFeeRateStatStore.LoadFromFile(
-				Path.Combine(dataDir, "WabiSabi", "CoinJoinFeeRateStatStore.txt"),
-				s.GetRequiredService<WabiSabiConfig>(),
-				s.GetRequiredService<IRPCClient>()
-				));
-		services.AddSingleton<RoundParameterFactory>();
-		services.AddBackgroundService<Arena>();
 		services.AddBackgroundService<BlockNotifier>();
-
-		services.AddSingleton<AnnouncerConfig>(_ => config.AnnouncerConfig);
-		services.AddBackgroundService<CoordinatorAnnouncer>();
-
 		services.AddSingleton<MempoolService>();
 		services.AddSingleton<P2pNode>(s =>
 			new P2pNode(

--- a/WalletWasabi.Coordinator/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Coordinator/Controllers/WabiSabiController.cs
@@ -1,16 +1,16 @@
 using System.Linq;
-using Microsoft.AspNetCore.Mvc;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using NBitcoin;
-using WalletWasabi.Backend.Filters;
 using WalletWasabi.Cache;
+using WalletWasabi.Coordinator.Filters;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Statistics;
 using WalletWasabi.WabiSabi.Models;
 
-namespace WalletWasabi.Backend.Controllers;
+namespace WalletWasabi.Coordinator.Controllers;
 
 [ApiController]
 [ExceptionTranslate]

--- a/WalletWasabi.Coordinator/Extensions.cs
+++ b/WalletWasabi.Coordinator/Extensions.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace WalletWasabi.Coordinator;
+
+public static class Extensions
+{
+	public static IServiceCollection AddStartupTask<T>(this IServiceCollection services)
+		where T : class
+		=> services.AddTransient<StartupTask>();
+
+	public static async Task RunWithTasksAsync(this IHost host, CancellationToken cancellationToken = default)
+	{
+		await Task.WhenAll(host.Services.GetServices<StartupTask>().Select(t => t.ExecuteAsync(cancellationToken)));
+		await host.RunAsync(cancellationToken);
+	}
+}

--- a/WalletWasabi.Coordinator/Filters/ExceptionTranslateFilter.cs
+++ b/WalletWasabi.Coordinator/Filters/ExceptionTranslateFilter.cs
@@ -6,7 +6,7 @@ using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Models;
 
-namespace WalletWasabi.Backend.Filters;
+namespace WalletWasabi.Coordinator.Filters;
 
 public class ExceptionTranslateAttribute : ExceptionFilterAttribute
 {

--- a/WalletWasabi.Coordinator/Filters/LateResponseLoggerFilter.cs
+++ b/WalletWasabi.Coordinator/Filters/LateResponseLoggerFilter.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Backend.Models;
 
-namespace WalletWasabi.Backend.Filters;
+namespace WalletWasabi.Coordinator.Filters;
 
 public class LateResponseLoggerFilter : ExceptionFilterAttribute
 {

--- a/WalletWasabi.Coordinator/GlobalUsings.cs
+++ b/WalletWasabi.Coordinator/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using System;

--- a/WalletWasabi.Coordinator/Program.cs
+++ b/WalletWasabi.Coordinator/Program.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using WalletWasabi.Backend;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Coordinator;
+
+public static class Program
+{
+	public static async Task Main(string[] args)
+	{
+		try
+		{
+			using var host = CreateHostBuilder(args).Build();
+			await host.RunWithTasksAsync();
+		}
+		catch (Exception ex)
+		{
+			Logger.LogCritical(ex);
+		}
+	}
+
+	public static IHostBuilder CreateHostBuilder(string[] args) =>
+		Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder => webBuilder
+			.UseStartup<Startup>()
+			.UseUrls(Environment.GetEnvironmentVariable("WASABI_BIND") ?? "http://localhost:37128/"));
+}

--- a/WalletWasabi.Coordinator/Startup.cs
+++ b/WalletWasabi.Coordinator/Startup.cs
@@ -1,0 +1,110 @@
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Timeouts;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NBitcoin;
+using NBitcoin.RPC;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Cache;
+using WalletWasabi.Discoverability;
+using WalletWasabi.Extensions;
+using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
+using WalletWasabi.WabiSabi.Backend;
+using WalletWasabi.WabiSabi.Backend.DoSPrevention;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Backend.Statistics;
+using WalletWasabi.WabiSabi.Models.Serialization;
+using WalletWasabi.Userfacing;
+
+[assembly: ApiController]
+
+namespace WalletWasabi.Coordinator;
+
+public class Startup(IConfiguration configuration)
+{
+	public IConfiguration Configuration { get; } = configuration;
+
+	// This method gets called by the runtime. Use this method to add services to the container.
+	public void ConfigureServices(IServiceCollection services)
+	{
+		string dataDir = Configuration["datadir"] ?? EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Coordinator"));
+		Logger.InitializeDefaults(Path.Combine(dataDir, "Logs.txt"));
+
+		services.AddMemoryCache();
+
+		services.AddMvc(options =>
+			{
+				options.ModelMetadataDetailsProviders.Add(new SuppressChildValidationMetadataProvider(typeof(Script)));
+			})
+			.AddControllersAsServices();
+
+		services.AddMvc()
+			.AddNewtonsoftJson();
+
+		services.AddControllers().AddNewtonsoftJson(x => x.SerializerSettings.Converters = JsonSerializationOptions.Default.Settings.Converters);
+
+		WabiSabiConfig config = new(Path.Combine(dataDir, "Config.json"));
+		config.LoadFile(createIfMissing: true);
+		services.AddSingleton(config);
+
+		services.AddSingleton<IdempotencyRequestCache>();
+		services.AddSingleton<IRPCClient>(provider =>
+		{
+			string host = config.BitcoinCoreRpcEndPoint.ToString(config.Network.RPCPort);
+			RPCClient rpcClient = new(
+					authenticationString: config.BitcoinRpcConnectionString,
+					hostOrUri: host,
+					network: config.Network);
+
+			IMemoryCache memoryCache = provider.GetRequiredService<IMemoryCache>();
+			CachedRpcClient cachedRpc = new(rpcClient, memoryCache);
+			return cachedRpc;
+		});
+
+		var network = config.Network;
+		services.AddSingleton(_ => network);
+
+		services.AddSingleton<Prison>(s => s.GetRequiredService<Warden>().Prison);
+		services.AddSingleton<Warden>(s =>
+			new Warden(
+				Path.Combine(dataDir, "Prison.txt"),
+				s.GetRequiredService<WabiSabiConfig>()));
+		services.AddSingleton<CoinJoinFeeRateStatStore>(s =>
+			CoinJoinFeeRateStatStore.LoadFromFile(
+				Path.Combine(dataDir, "CoinJoinFeeRateStatStore.txt"),
+				s.GetRequiredService<WabiSabiConfig>(),
+				s.GetRequiredService<IRPCClient>()
+				));
+		services.AddSingleton<RoundParameterFactory>();
+		services.AddBackgroundService<Arena>();
+
+		services.AddSingleton<AnnouncerConfig>(_ => config.AnnouncerConfig);
+		services.AddBackgroundService<CoordinatorAnnouncer>();
+
+		services.AddSingleton<IdempotencyRequestCache>();
+		services.AddStartupTask<StartupTask>();
+		services.AddResponseCompression();
+		services.AddRequestTimeouts(options =>
+			options.DefaultPolicy =
+				new RequestTimeoutPolicy
+				{
+					Timeout = TimeSpan.FromSeconds(5)
+				});
+	}
+
+	[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "This method gets called by the runtime. Use this method to configure the HTTP request pipeline")]
+	public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+	{
+		app.UseRouting();
+		app.UseResponseCompression();
+		app.UseEndpoints(endpoints => endpoints.MapControllers());
+		app.UseRequestTimeouts();
+	}
+}

--- a/WalletWasabi.Coordinator/StartupTask.cs
+++ b/WalletWasabi.Coordinator/StartupTask.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using WalletWasabi.BitcoinCore.Rpc;
+using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
+
+
+namespace WalletWasabi.Coordinator;
+
+public class StartupTask
+{
+	private IRPCClient RpcClient { get; }
+
+	public StartupTask(IRPCClient rpc)
+	{
+		RpcClient = rpc;
+	}
+
+	public async Task ExecuteAsync(CancellationToken cancellationToken)
+	{
+		Logger.LogInfo("Wasabi Backend");
+
+		AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+		TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
+
+		// Make sure RPC works.
+		await AssertRpcNodeFullyInitializedAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	private async Task AssertRpcNodeFullyInitializedAsync(CancellationToken cancellationToken)
+	{
+		try
+		{
+			var blockchainInfo = await RpcClient.GetBlockchainInfoAsync(cancellationToken);
+
+			var blocks = blockchainInfo.Blocks;
+			if (blocks == 0 && RpcClient.Network != Network.RegTest)
+			{
+				throw new NotSupportedException($"{nameof(blocks)} == 0");
+			}
+
+			var headers = blockchainInfo.Headers;
+			if (headers == 0 && RpcClient.Network != Network.RegTest)
+			{
+				throw new NotSupportedException($"{nameof(headers)} == 0");
+			}
+
+			if (blocks != headers)
+			{
+				throw new NotSupportedException($"{Constants.BuiltinBitcoinNodeName} is not fully synchronized.");
+			}
+
+			Logger.LogInfo($"{Constants.BuiltinBitcoinNodeName} is fully synchronized.");
+
+			if (RpcClient.Network == Network.RegTest) // Make sure there's at least 101 block, if not generate it
+			{
+				if (blocks < 101)
+				{
+					using Key key = new();
+					var generateBlocksResponse = await RpcClient.GenerateToAddressAsync(101, key.GetAddress(ScriptPubKeyType.Segwit, Network.RegTest), cancellationToken);
+					if (generateBlocksResponse is null)
+					{
+						throw new NotSupportedException($"{Constants.BuiltinBitcoinNodeName} cannot generate blocks on the {Network.RegTest}.");
+					}
+
+					blockchainInfo = await RpcClient.GetBlockchainInfoAsync(cancellationToken);
+					blocks = blockchainInfo.Blocks;
+					if (blocks == 0)
+					{
+						throw new NotSupportedException($"{nameof(blocks)} == 0");
+					}
+					Logger.LogInfo($"Generated 101 block on {Network.RegTest}. Number of blocks {blocks}.");
+				}
+			}
+		}
+		catch (WebException)
+		{
+			Logger.LogError($"{Constants.BuiltinBitcoinNodeName} is not running, or incorrect RPC credentials, or network is given in the config file.");
+			throw;
+		}
+	}
+
+	private void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+	{
+		Logger.LogWarning(e.Exception, "Unexpected unobserved task exception.");
+	}
+
+	private void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
+	{
+		if (e.ExceptionObject is Exception ex)
+		{
+			Logger.LogWarning(ex, "Unhandled exception.");
+		}
+	}
+}

--- a/WalletWasabi.Coordinator/WalletWasabi.Coordinator.csproj
+++ b/WalletWasabi.Coordinator/WalletWasabi.Coordinator.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
+		<Product>WalletWasabiCoordinatorApi</Product>
+		<Copyright>MIT</Copyright>
+		<PackageTags>walletwasabi, wasabiwallet, wasabi, wallet, bitcoin, nbitcoin, tor, zerolink, wabisabi, coinjoin, fungibility, privacy, anonymity</PackageTags>
+		<RepositoryType>Git</RepositoryType>
+		<RepositoryUrl>https://github.com/WalletWasabi/WalletWasabi/</RepositoryUrl>
+		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Coordinator</PathMap>
+		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+    </PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\WalletWasabi\WalletWasabi.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+	</ItemGroup>
+
+</Project>

--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerTests.cs
@@ -6,6 +6,7 @@ using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Models;
 using Xunit;
+using Key = Avalonia.Remote.Protocol.Input.Key;
 
 namespace WalletWasabi.Tests.UnitTests.Bases;
 
@@ -24,7 +25,11 @@ public class ConfigManagerTests
 		string configPath = Path.Combine(workDirectory, $"{nameof(CheckFileChangeTestAsync)}.json");
 
 		// Create config and store it.
-		WabiSabiConfig config = new();
+		WabiSabiConfig config = new ();
+		config.AnnouncerConfig = config.AnnouncerConfig with
+		{
+			Key = "nsec13zprl2n0acj9cgrteyfgwcuhrk3xgac775zqyflhxxsfvwjvfe9qrg9l0v"
+		};
 		config.SetFilePath(configPath);
 		config.ToFile();
 
@@ -42,6 +47,9 @@ public class ConfigManagerTests
 		static string GetVanillaConfigString()
 				=> $$"""
 			{
+			  "Network": "Main",
+			  "BitcoinCoreRpcEndPoint": "127.0.0.1:8332",
+			  "BitcoinRpcConnectionString": "user:password",
 			  "ConfirmationTarget": 108,
 			  "DoSSeverity": "0.10",
 			  "DoSMinTimeForFailedToVerify": "31d 0h 0m 0s",
@@ -81,7 +89,18 @@ public class ConfigManagerTests
 			  "AllowP2shOutputs": false,
 			  "AllowP2wshOutputs": false,
 			  "DelayTransactionSigning": false,
-			  "IsCoordinationEnabled": true
+			  "AnnouncerConfig": {
+			    "CoordinatorName": "Coordinator",
+			    "IsEnabled": false,
+			    "CoordinatorDescription": "WabiSabi Coinjoin Coordinator",
+			    "CoordinatorUri": "https://api.example.com/",
+			    "AbsoluteMinInputCount": 21,
+			    "ReadMoreUri": "https://api.example.com/",
+			    "RelayUris": [
+			      "wss://relay.primal.net"
+			    ],
+			    "Key": "nsec13zprl2n0acj9cgrteyfgwcuhrk3xgac775zqyflhxxsfvwjvfe9qrg9l0v"
+			  }
 			}
 			""".ReplaceLineEndings("\n");
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -8,6 +8,7 @@ using WabiSabi.Crypto;
 using WabiSabi.Crypto.ZeroKnowledge;
 using WalletWasabi.Backend.Controllers;
 using WalletWasabi.Cache;
+using WalletWasabi.Coordinator.Controllers;
 using WalletWasabi.Crypto;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Extensions;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/BobClientTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Backend.Controllers;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Cache;
+using WalletWasabi.Coordinator.Controllers;
 using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Startup.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Startup.cs
@@ -6,8 +6,8 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NBitcoin;
-using WalletWasabi.Backend.Controllers;
 using WalletWasabi.Cache;
+using WalletWasabi.Coordinator.Controllers;
 using WalletWasabi.WabiSabi.Models.Serialization;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration;

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -34,6 +34,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\WalletWasabi.Backend\WalletWasabi.Backend.csproj" />
+		<ProjectReference Include="..\WalletWasabi.Coordinator\WalletWasabi.Coordinator.csproj" />
 		<ProjectReference Include="..\WalletWasabi.Fluent.Generators\WalletWasabi.Fluent.Generators.csproj" />
 		<ProjectReference Include="..\WalletWasabi.Fluent\WalletWasabi.Fluent.csproj" />
 		<ProjectReference Include="..\WalletWasabi\WalletWasabi.csproj" />

--- a/WalletWasabi.sln
+++ b/WalletWasabi.sln
@@ -37,6 +37,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WalletWasabi.Fluent", "Wall
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WalletWasabi.Daemon", "WalletWasabi.Daemon\WalletWasabi.Daemon.csproj", "{29599048-B3F1-48B9-AEBB-1A32D64BC4F5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WalletWasabi.Coordinator", "WalletWasabi.Coordinator\WalletWasabi.Coordinator.csproj", "{1D23E39D-8367-4ADB-9445-76B6546096B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -106,6 +108,14 @@ Global
 		{29599048-B3F1-48B9-AEBB-1A32D64BC4F5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{29599048-B3F1-48B9-AEBB-1A32D64BC4F5}.Release|x64.ActiveCfg = Release|Any CPU
 		{29599048-B3F1-48B9-AEBB-1A32D64BC4F5}.Release|x64.Build.0 = Release|Any CPU
+		{1D23E39D-8367-4ADB-9445-76B6546096B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D23E39D-8367-4ADB-9445-76B6546096B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D23E39D-8367-4ADB-9445-76B6546096B0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1D23E39D-8367-4ADB-9445-76B6546096B0}.Debug|x64.Build.0 = Debug|Any CPU
+		{1D23E39D-8367-4ADB-9445-76B6546096B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D23E39D-8367-4ADB-9445-76B6546096B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D23E39D-8367-4ADB-9445-76B6546096B0}.Release|x64.ActiveCfg = Release|Any CPU
+		{1D23E39D-8367-4ADB-9445-76B6546096B0}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -359,10 +359,6 @@ public partial class Arena : IWabiSabiApiRequestHandler
 
 	public Task<RoundStateResponse> GetStatusAsync(RoundStateRequest request, CancellationToken cancellationToken)
 	{
-		if (_config.IsCoordinationEnabled is false)
-		{
-			return Task.FromResult(new RoundStateResponse(Array.Empty<RoundState>(), Array.Empty<CoinJoinFeeRateMedian>()));
-		}
 		var requestCheckPointDictionary = request.RoundCheckpoints.ToDictionary(r => r.RoundId, r => r);
 		var responseRoundStates = RoundStates.Select(x =>
 		{

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -4,7 +4,9 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
+using System.Net;
 using WalletWasabi.Bases;
+using WalletWasabi.Discoverability;
 using WalletWasabi.Helpers;
 using WalletWasabi.JsonConverters;
 using WalletWasabi.JsonConverters.Bitcoin;
@@ -24,6 +26,18 @@ public class WabiSabiConfig : ConfigBase
 	public WabiSabiConfig(string filePath) : base(filePath)
 	{
 	}
+
+	[JsonProperty(PropertyName = "Network")]
+	[JsonConverter(typeof(NetworkJsonConverter))]
+	public Network Network { get; private set; } = Network.Main;
+
+	[JsonProperty(PropertyName = "BitcoinCoreRpcEndPoint")]
+	[JsonConverter(typeof(EndPointJsonConverter), Constants.DefaultMainNetBitcoinCoreRpcPort)]
+	public EndPoint BitcoinCoreRpcEndPoint { get; internal set; } = Constants.DefaultMainNetBitcoinCoreRpcEndPoint;
+
+	[DefaultValue("user:password")]
+	[JsonProperty(PropertyName = "BitcoinRpcConnectionString", DefaultValueHandling = DefaultValueHandling.Populate)]
+	public string BitcoinRpcConnectionString { get; private set; } = "user:password";
 
 	[DefaultValue(108)]
 	[JsonProperty(PropertyName = "ConfirmationTarget", DefaultValueHandling = DefaultValueHandling.Populate)]
@@ -191,9 +205,8 @@ public class WabiSabiConfig : ConfigBase
 	[JsonProperty(PropertyName = "DelayTransactionSigning", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool DelayTransactionSigning { get; set; } = false;
 
-	[DefaultValue(true)]
-	[JsonProperty(PropertyName = "IsCoordinationEnabled", DefaultValueHandling = DefaultValueHandling.Populate)]
-	public bool IsCoordinationEnabled { get; set; } = true;
+	[JsonProperty(PropertyName = "AnnouncerConfig")]
+	public AnnouncerConfig AnnouncerConfig { get; internal set; } = new();
 
 	public ImmutableSortedSet<ScriptType> AllowedInputTypes => GetScriptTypes(AllowP2wpkhInputs, AllowP2trInputs, false, false, false);
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,8 +32,14 @@
         # Build all components and run tests (CI)
         buildEverything = buildWasabiModule.overrideAttrs (oldAttrs: rec {
           pname = "WalletWasabi";
-          projectFile = ["WalletWasabi.Backend/WalletWasabi.Backend.csproj" "WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj"];
-          executables = [ "WalletWasabi.Backend" "WalletWasabi.Fluent.Desktop" ];
+          projectFile = [
+             "WalletWasabi.Backend/WalletWasabi.Backend.csproj"
+             "WalletWasabi.Backend/WalletWasabi.Coordinator.csproj"
+             "WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj"];
+          executables = [
+            "WalletWasabi.Backend"
+            "WalletWasabi.Coordinator"
+            "WalletWasabi.Fluent.Desktop" ];
           runtimeDeps = with pkgs; [
              pkgs.openssl pkgs.zlib
              # for client


### PR DESCRIPTION
Creates a new project called `WalletWasabi.Coordinator` which contains the wabisabi api alone. The `WalletWasabi.Backend` project doesn't contain anything related to multiparty transaction coordination.

Separating Wallet API and Multiparty Transaction Coordination (WabiSabi) API physically simplifies the maintenance, reduce the usage of resources and makes it easier to host these APIs independently. Wasabi infrastructure operators could host these APIs in different servers and scale them accordingly, what is not so easy in a monolithic architecture.  This is because the nature of the APIs is different, while Wallet API is stateless and trivial to scale horizontally, WabiSabi is stateful and can only scale vertically.

Additionally, this PR makes contains the changes in the release system to distribute both programs (wbackend and wcoordinator) in the debian package.

