### PR TITLE
Smarter AnonScoreTarget in PrivateCoinJoinProfile

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/CoinJoinProfiles/PrivateCoinJoinProfileViewModel.cs
@@ -3,12 +3,12 @@ using WalletWasabi.Models;
 
 namespace WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
 
-internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
+// TODO: All of this should be moved outside the Fluent project.
+public class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 {
-	// https://github.com/WalletWasabi/WalletWasabi/pull/10468#issuecomment-1506284198
-	public const int MinAnonScore = 27;
-
-	public const int MaxAnonScore = 76;
+	// TODO: Safety coinjoins should be moved here & be configurable.
+	public const int MinAnonScore = 23;
+	public const int MaxAnonScore = 50;
 
 	public PrivateCoinJoinProfileViewModel(int anonScoreTarget)
 	{
@@ -17,7 +17,7 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 
 	public PrivateCoinJoinProfileViewModel()
 	{
-		AnonScoreTarget = GetRandom(MinAnonScore, MaxAnonScore);
+		AnonScoreTarget = GetAnonScoreTarget(MinAnonScore, MaxAnonScore);
 	}
 
 	public override string Title => "Maximize Privacy";
@@ -31,11 +31,33 @@ internal class PrivateCoinJoinProfileViewModel : CoinJoinProfileViewModelBase
 
 	public override int FeeRateMedianTimeFrameHours => 0;
 
-	private static int GetRandom(int minInclusive, int maxExclusive)
+	/// <summary>
+	/// This algo linearly decreases the probability of increasing the anonset target, starting from minExclusive.
+	/// The goal is to have a good distribution around a specific target with hard min and max.
+	/// (minExclusive + 1) has 100% chance of being selected, (maxExclusive) has a 0% chance (hard limit).
+	/// Average of results is never more than minExclusive + (maxExclusive - minExclusive) * (1.0/3.0).
+	/// </summary>
+	public static int GetAnonScoreTarget(int minExclusive, int maxExclusive)
 	{
-		return SecureRandom.Instance.GetInt(minInclusive, maxExclusive);
+		var ast = minExclusive;
+
+		while (ast < maxExclusive)
+		{
+			var progress = (double)(ast - minExclusive) / (maxExclusive - minExclusive);
+			var probability = 100 * (1 - progress);
+
+			if (SecureRandom.Instance.GetInt(0, 101) > probability)
+			{
+				break;
+			}
+
+			ast++;
+		}
+
+		return ast;
 	}
 
+	// This function is badly designed and creates problems with retro-compatibility.
 	public override bool Equals(object? obj)
 	{
 		if (ReferenceEquals(this, obj))

--- a/WalletWasabi.Tests/UnitTests/ViewModels/PrivateCoinJoinProfileTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/PrivateCoinJoinProfileTests.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using WalletWasabi.Fluent.ViewModels.CoinJoinProfiles;
+using Xunit;
+namespace WalletWasabi.Tests.UnitTests.ViewModels;
+
+public class PrivacyCoinJoinProfileTests
+{
+	[Fact]
+	public void AddressPropertiesAreExposedCorrectly()
+	{
+		var minExclusive = PrivateCoinJoinProfileViewModel.MinAnonScore;
+		var maxExclusive = PrivateCoinJoinProfileViewModel.MaxAnonScore;
+
+		List<int> results = [];
+		Enumerable.Range(0, 10_000).ToList().ForEach(_ => results.Add(PrivateCoinJoinProfileViewModel.GetAnonScoreTarget(minExclusive, maxExclusive)));
+
+		Assert.True(results.Min() > minExclusive);
+		Assert.True(results.Max() < maxExclusive);
+
+		double sanityLimitAverage = minExclusive + (maxExclusive - minExclusive) * (1.0/3.0);
+		double actualAverage = results.Average();
+
+		Assert.True(actualAverage <= sanityLimitAverage);
+	}
+}


### PR DESCRIPTION
Currently the value makes no sense. It averages a min and max but the best value is actually close to the min, going too high has no point.

This new algo distributes values between a min and a max, but closer to the min.
The distribution for min 23 max 50 is this (value, percentage)
![CleanShot 2025-01-15 at 23 35 48@2x](https://github.com/user-attachments/assets/e83348ce-c48b-4026-8e2a-5777f2080b46)

It is still spread enough so it's hard to predict, but around the best value.
I don't want to spend a lot of time on this because the profiles by themselves are really questionable, this is a quick improvement.