### PR TITLE
Remove default logging from Coordinator

### DIFF
--- a/WalletWasabi.Coordinator/StartupTask.cs
+++ b/WalletWasabi.Coordinator/StartupTask.cs
@@ -20,7 +20,7 @@ public class StartupTask
 
 	public async Task ExecuteAsync(CancellationToken cancellationToken)
 	{
-		Logger.LogInfo("Wasabi Backend");
+		Logger.LogInfo("Wasabi Coordinator");
 
 		AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
 		TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;

--- a/WalletWasabi.Coordinator/appsettings.json
+++ b/WalletWasabi.Coordinator/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning",
+        "Microsoft": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning",
+        "Microsoft": "Warning"
+      }
+    }
+  }
+}


### PR DESCRIPTION
`appsettings.json `is copied on the one for the Backend
I also quickly chenged the first line of logs as it was forgotten