### PR TITLE
[UI] settings: add tooltip to backend URI box

### DIFF
--- a/WalletWasabi.Fluent/Views/Settings/AdvancedSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/AdvancedSettingsTabView.axaml
@@ -14,7 +14,7 @@
       <ToggleSwitch IsChecked="{Binding Settings.EnableGpu}" />
     </DockPanel>
 
-    <DockPanel>
+    <DockPanel ToolTip.Tip="The client will connect to this backend. The backend provides the block filters to synchronize the wallet.">
       <TextBlock Text="Backend URI" />
       <TextBox Text="{Binding BackendUri}">
         <Interaction.Behaviors>


### PR DESCRIPTION
Adds a tooltip to the backend URI box with explanation.

> The backend provides the block filters to synchronize the wallet.

the backend provides more than just the filters, but I'd go with this to keep it simple

---

![](https://github.com/user-attachments/assets/138094ec-a1a6-41e2-aa20-abb7fbb1e270)
