### PR TITLE
Settings for Default Receive Script Type / Send Workflow

### DIFF
--- a/WalletWasabi.Fluent/Converters/ScriptTypeConverters.cs
+++ b/WalletWasabi.Fluent/Converters/ScriptTypeConverters.cs
@@ -7,4 +7,5 @@ public static class ScriptTypeConverters
 {
 	public static readonly IValueConverter IsSegwit = new FuncValueConverter<ScriptType, bool>(x => x == ScriptType.SegWit);
 	public static readonly IValueConverter IsTaproot = new FuncValueConverter<ScriptType, bool>(x => x == ScriptType.Taproot);
+	public static readonly IValueConverter ToName = new FuncValueConverter<ScriptType, string>(x => x is null ? "" : x.Name);
 }

--- a/WalletWasabi.Fluent/Models/Wallets/ScriptType.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/ScriptType.cs
@@ -48,4 +48,16 @@ public record ScriptType(string Name, string ShortName)
 			_ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
 		};
 	}
+
+	public static ScriptType FromEnum(ScriptPubKeyType type)
+	{
+		return type switch
+		{
+			ScriptPubKeyType.Legacy => Unknown,
+			ScriptPubKeyType.Segwit => SegWit,
+			ScriptPubKeyType.SegwitP2SH => Unknown,
+			ScriptPubKeyType.TaprootBIP86 => Taproot,
+			_ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+		};
+	}
 }

--- a/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Reactive.Linq;
 using NBitcoin;
 using ReactiveUI;
@@ -98,6 +99,8 @@ public partial class WalletModel : ReactiveObject
 	public Network Network => Wallet.Network;
 
 	public IEnumerable<ScriptPubKeyType> AvailableScriptPubKeyTypes => Wallet.KeyManager.AvailableScriptPubKeyTypes;
+
+	public bool SeveralReceivingScriptTypes => AvailableScriptPubKeyTypes.Contains(ScriptPubKeyType.TaprootBIP86);
 
 	public IWalletTransactionsModel Transactions { get; }
 

--- a/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
@@ -25,6 +25,8 @@ public partial class WalletSettingsModel : ReactiveObject
 	[AutoNotify] private bool _redCoinIsolation;
 	[AutoNotify] private int _feeRateMedianTimeFrameHours;
 	[AutoNotify] private WalletId? _outputWalletId;
+	[AutoNotify] private string _defaultReceiveScriptType;
+	[AutoNotify] private string _defaultSendWorkflow;
 
 	public WalletSettingsModel(KeyManager keyManager, bool isNewWallet = false, bool isCoinJoinPaused = false)
 	{
@@ -47,6 +49,9 @@ public partial class WalletSettingsModel : ReactiveObject
 			_outputWalletId = Services.WalletManager.GetWalletByName(_keyManager.WalletName).WalletId;
 		}
 
+		_defaultReceiveScriptType = _keyManager.DefaultReceiveScriptType;
+		_defaultSendWorkflow = _keyManager.DefaultSendWorkflow;
+
 		WalletType = WalletHelpers.GetType(_keyManager);
 
 		this.WhenAnyValue(
@@ -57,6 +62,13 @@ public partial class WalletSettingsModel : ReactiveObject
 				x => x.AnonScoreTarget,
 				x => x.RedCoinIsolation,
 				x => x.FeeRateMedianTimeFrameHours)
+			.Skip(1)
+			.Do(_ => SetValues())
+			.Subscribe();
+
+		this.WhenAnyValue(
+				x => x.DefaultSendWorkflow,
+				x => x.DefaultReceiveScriptType)
 			.Skip(1)
 			.Do(_ => SetValues())
 			.Subscribe();
@@ -98,6 +110,8 @@ public partial class WalletSettingsModel : ReactiveObject
 		_keyManager.AnonScoreTarget = AnonScoreTarget;
 		_keyManager.RedCoinIsolation = RedCoinIsolation;
 		_keyManager.SetFeeRateMedianTimeFrame(FeeRateMedianTimeFrameHours);
+		_keyManager.DefaultSendWorkflow = DefaultSendWorkflow;
+		_keyManager.DefaultReceiveScriptType = DefaultReceiveScriptType;
 		_isDirty = true;
 	}
 }

--- a/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
@@ -1,10 +1,10 @@
-using System.Reactive;
 using NBitcoin;
 using ReactiveUI;
 using System.Reactive.Linq;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Infrastructure;
+using WalletWasabi.Models;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.Models.Wallets;
@@ -25,8 +25,8 @@ public partial class WalletSettingsModel : ReactiveObject
 	[AutoNotify] private bool _redCoinIsolation;
 	[AutoNotify] private int _feeRateMedianTimeFrameHours;
 	[AutoNotify] private WalletId? _outputWalletId;
-	[AutoNotify] private string _defaultReceiveScriptType;
-	[AutoNotify] private string _defaultSendWorkflow;
+	[AutoNotify] private ScriptType _defaultReceiveScriptType;
+	[AutoNotify] private WalletWasabi.Models.SendWorkflow _defaultSendWorkflow;
 
 	public WalletSettingsModel(KeyManager keyManager, bool isNewWallet = false, bool isCoinJoinPaused = false)
 	{
@@ -49,7 +49,7 @@ public partial class WalletSettingsModel : ReactiveObject
 			_outputWalletId = Services.WalletManager.GetWalletByName(_keyManager.WalletName).WalletId;
 		}
 
-		_defaultReceiveScriptType = _keyManager.DefaultReceiveScriptType;
+		_defaultReceiveScriptType = ScriptType.FromEnum(_keyManager.DefaultReceiveScriptType);
 		_defaultSendWorkflow = _keyManager.DefaultSendWorkflow;
 
 		WalletType = WalletHelpers.GetType(_keyManager);
@@ -111,7 +111,7 @@ public partial class WalletSettingsModel : ReactiveObject
 		_keyManager.RedCoinIsolation = RedCoinIsolation;
 		_keyManager.SetFeeRateMedianTimeFrame(FeeRateMedianTimeFrameHours);
 		_keyManager.DefaultSendWorkflow = DefaultSendWorkflow;
-		_keyManager.DefaultReceiveScriptType = DefaultReceiveScriptType;
+		_keyManager.DefaultReceiveScriptType = ScriptType.ToScriptPubKeyType(DefaultReceiveScriptType);
 		_isDirty = true;
 	}
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletSettingsViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -27,6 +28,10 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 	[AutoNotify] private bool _preferPsbtWorkflow;
 	[AutoNotify] private string _walletName;
 	[AutoNotify] private int _selectedTab;
+	[AutoNotify] private string _defaultReceiveScriptType;
+	[AutoNotify] private bool _isSegWitDefaultReceiveScriptType;
+	[AutoNotify] private string _defaultSendWorkflow;
+	[AutoNotify] private bool _isAutomaticDefaultSendWorkflow;
 
 	public WalletSettingsViewModel(UiContext uiContext, IWalletModel walletModel)
 	{
@@ -38,6 +43,14 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 		IsHardwareWallet = walletModel.IsHardwareWallet;
 		IsWatchOnly = walletModel.IsWatchOnlyWallet;
 
+		DefaultReceiveScriptType = walletModel.Settings.DefaultReceiveScriptType;
+		this.WhenAnyValue(x => x.DefaultReceiveScriptType)
+			.Subscribe(value => IsSegWitDefaultReceiveScriptType = value == "SegWit");
+
+		DefaultSendWorkflow = walletModel.Settings.DefaultSendWorkflow;
+		this.WhenAnyValue(x => x.DefaultSendWorkflow)
+			.Subscribe(value => IsAutomaticDefaultSendWorkflow = value == "Automatic");
+
 		WalletCoinJoinSettings = new WalletCoinJoinSettingsViewModel(UiContext, walletModel);
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
@@ -45,6 +58,22 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 		NextCommand = CancelCommand;
 
 		VerifyRecoveryWordsCommand = ReactiveCommand.Create(() => Navigate().To().WalletVerifyRecoveryWords(walletModel));
+
+		this.WhenAnyValue(x => x.DefaultSendWorkflow)
+			.Skip(1)
+			.Subscribe(value =>
+			{
+				walletModel.Settings.DefaultSendWorkflow = value;
+				walletModel.Settings.Save();
+			});
+
+		this.WhenAnyValue(x => x.DefaultReceiveScriptType)
+			.Skip(1)
+			.Subscribe(value =>
+			{
+				walletModel.Settings.DefaultReceiveScriptType = value;
+				walletModel.Settings.Save();
+			});
 
 		this.WhenAnyValue(x => x.PreferPsbtWorkflow)
 			.Skip(1)
@@ -64,6 +93,11 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 	public bool IsHardwareWallet { get; }
 
 	public bool IsWatchOnly { get; }
+
+	public bool SeveralReceivingScriptTypes => _wallet.SeveralReceivingScriptTypes;
+
+	public IEnumerable<string> ReceiveScriptTypes { get; } = ["SegWit", "Taproot"];
+	public IEnumerable<string> SendWorkflows { get; } = ["Automatic", "Manual"];
 
 	public WalletCoinJoinSettingsViewModel WalletCoinJoinSettings { get; private set; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletSettingsViewModel.cs
@@ -96,6 +96,7 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 	public bool IsWatchOnly { get; }
 
 	public bool SeveralReceivingScriptTypes => _wallet.SeveralReceivingScriptTypes;
+	public bool IsDefaultSendWorkflowSettingVisible => !(IsWatchOnly || IsHardwareWallet);
 
 	public IEnumerable<ScriptType> ReceiveScriptTypes { get; } = [ScriptType.SegWit, ScriptType.Taproot];
 	public IEnumerable<SendWorkflow> SendWorkflows { get; } = Enum.GetValues<SendWorkflow>();

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletSettingsViewModel.cs
@@ -8,6 +8,7 @@ using WalletWasabi.Fluent.Models.UI;
 using WalletWasabi.Fluent.Infrastructure;
 using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.ViewModels.Navigation;
+using WalletWasabi.Models;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Settings;
 
@@ -28,9 +29,9 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 	[AutoNotify] private bool _preferPsbtWorkflow;
 	[AutoNotify] private string _walletName;
 	[AutoNotify] private int _selectedTab;
-	[AutoNotify] private string _defaultReceiveScriptType;
+	[AutoNotify] private ScriptType _defaultReceiveScriptType;
 	[AutoNotify] private bool _isSegWitDefaultReceiveScriptType;
-	[AutoNotify] private string _defaultSendWorkflow;
+	[AutoNotify] private WalletWasabi.Models.SendWorkflow _defaultSendWorkflow;
 	[AutoNotify] private bool _isAutomaticDefaultSendWorkflow;
 
 	public WalletSettingsViewModel(UiContext uiContext, IWalletModel walletModel)
@@ -45,11 +46,11 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 
 		DefaultReceiveScriptType = walletModel.Settings.DefaultReceiveScriptType;
 		this.WhenAnyValue(x => x.DefaultReceiveScriptType)
-			.Subscribe(value => IsSegWitDefaultReceiveScriptType = value == "SegWit");
+			.Subscribe(value => IsSegWitDefaultReceiveScriptType = value == ScriptType.SegWit);
 
 		DefaultSendWorkflow = walletModel.Settings.DefaultSendWorkflow;
 		this.WhenAnyValue(x => x.DefaultSendWorkflow)
-			.Subscribe(value => IsAutomaticDefaultSendWorkflow = value == "Automatic");
+			.Subscribe(value => IsAutomaticDefaultSendWorkflow = value == SendWorkflow.Automatic);
 
 		WalletCoinJoinSettings = new WalletCoinJoinSettingsViewModel(UiContext, walletModel);
 
@@ -96,8 +97,8 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 
 	public bool SeveralReceivingScriptTypes => _wallet.SeveralReceivingScriptTypes;
 
-	public IEnumerable<string> ReceiveScriptTypes { get; } = ["SegWit", "Taproot"];
-	public IEnumerable<string> SendWorkflows { get; } = ["Automatic", "Manual"];
+	public IEnumerable<ScriptType> ReceiveScriptTypes { get; } = [ScriptType.SegWit, ScriptType.Taproot];
+	public IEnumerable<SendWorkflow> SendWorkflows { get; } = Enum.GetValues<SendWorkflow>();
 
 	public WalletCoinJoinSettingsViewModel WalletCoinJoinSettings { get; private set; }
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -6,8 +6,6 @@ using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using DynamicData;
-using DynamicData.Binding;
 using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Fluent.Extensions;
@@ -21,7 +19,7 @@ using WalletWasabi.Fluent.ViewModels.SearchBar.Sources;
 using WalletWasabi.Fluent.ViewModels.Wallets.Home.History;
 using WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles;
 using WalletWasabi.Fluent.ViewModels.Wallets.Settings;
-using WalletWasabi.Logging;
+using WalletWasabi.Models;
 using WalletWasabi.Wallets;
 using ScriptType = WalletWasabi.Fluent.Models.Wallets.ScriptType;
 
@@ -137,7 +135,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 		SendManualControlCommand = ReactiveCommand.Create(() => Navigate().To().ManualControlDialog(walletModel, wallet));
 
 		this.WhenAnyValue(x => x.Settings.DefaultSendWorkflow)
-			.Subscribe(value => DefaultSendCommand = value == "Automatic" ? SendCommand : SendManualControlCommand);
+			.Subscribe(value => DefaultSendCommand = value == SendWorkflow.Automatic ? SendCommand : SendManualControlCommand);
 
 		SegwitReceiveCommand = ReactiveCommand.Create(() => Navigate().To().Receive(WalletModel, ScriptType.SegWit));
 		TaprootReceiveCommand = SeveralReceivingScriptTypes ?
@@ -146,7 +144,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 
 		this.WhenAnyValue(x => x.Settings.DefaultReceiveScriptType)
 			.Subscribe(value =>
-				DefaultReceiveCommand = value == "SegWit" || TaprootReceiveCommand is null
+				DefaultReceiveCommand = value == ScriptType.SegWit || TaprootReceiveCommand is null
 					? SegwitReceiveCommand
 					: TaprootReceiveCommand);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -287,7 +287,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 	{
 		return new ISearchItem[]
 		{
-			new ActionableItem("Receive", "Display wallet receive dialog", () => { SegwitReceiveCommand.ExecuteIfCan(); return Task.CompletedTask; }, "Wallet", new[] { "Wallet", "Receive", "Action", }) { Icon = "wallet_action_receive", IsDefault = true, Priority = 2 },
+			new ActionableItem("Receive", "Display wallet receive dialog", () => { DefaultReceiveCommand.ExecuteIfCan(); return Task.CompletedTask; }, "Wallet", new[] { "Wallet", "Receive", "Action", }) { Icon = "wallet_action_receive", IsDefault = true, Priority = 2 },
 			new ActionableItem("Coinjoin Settings", "Display wallet coinjoin settings", () => { CoinJoinSettingsCommand.ExecuteIfCan(); return Task.CompletedTask; }, "Wallet", new[] { "Wallet", "Settings", }) { Icon = "wallet_action_coinjoin", IsDefault = true, Priority = 3 },
 			new ActionableItem("Wallet Settings", "Display wallet settings", () => { WalletSettingsCommand.ExecuteIfCan(); return Task.CompletedTask; }, "Wallet", new[] { "Wallet", "Settings", }) { Icon = "settings_wallet_regular", IsDefault = true, Priority = 4 },
 			new ActionableItem("Exclude Coins", "Display exclude coins", () => { NavigateToExcludedCoinsCommand.ExecuteIfCan(); return Task.CompletedTask; }, "Wallet", new[] { "Wallet", "Exclude", "Coins", "Coinjoin", "Freeze", "UTXO", }) { Icon = "exclude_coins", IsDefault = true, Priority = 5 },

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletGeneralSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletGeneralSettingsView.axaml
@@ -34,7 +34,7 @@
       <ToggleSwitch IsChecked="{Binding PreferPsbtWorkflow}" />
     </DockPanel>
 
-    <DockPanel>
+    <DockPanel IsVisible="{Binding IsDefaultSendWorkflowSettingVisible}">
       <TextBlock Text="Default Send Workflow" />
       <ComboBox ItemsSource="{Binding SendWorkflows}"
                 SelectedItem="{Binding DefaultSendWorkflow}">

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletGeneralSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletGeneralSettingsView.axaml
@@ -4,6 +4,9 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              xmlns:vm="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Settings"
+             xmlns:conv="clr-namespace:WalletWasabi.Fluent.Converters"
+             xmlns:models="clr-namespace:WalletWasabi.Models;assembly=WalletWasabi"
+             xmlns:wallets="clr-namespace:WalletWasabi.Fluent.Models.Wallets"
              x:DataType="vm:WalletSettingsViewModel"
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Settings.WalletGeneralSettingsView">
@@ -34,13 +37,25 @@
     <DockPanel>
       <TextBlock Text="Default Send Workflow" />
       <ComboBox ItemsSource="{Binding SendWorkflows}"
-                SelectedItem="{Binding DefaultSendWorkflow}" />
+                SelectedItem="{Binding DefaultSendWorkflow}">
+        <ComboBox.ItemTemplate>
+          <DataTemplate x:DataType="models:SendWorkflow">
+            <TextBlock Text="{Binding Converter={x:Static conv:EnumConverters.ToFriendlyName}}" />
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
     </DockPanel>
 
     <DockPanel IsVisible="{Binding SeveralReceivingScriptTypes}">
       <TextBlock Text="Default Receive Script Type" />
       <ComboBox ItemsSource="{Binding ReceiveScriptTypes}"
-                SelectedItem="{Binding DefaultReceiveScriptType}" />
+                SelectedItem="{Binding DefaultReceiveScriptType}">
+        <ComboBox.ItemTemplate>
+          <DataTemplate x:DataType="wallets:ScriptType">
+            <TextBlock Text="{Binding Converter={x:Static conv:ScriptTypeConverters.ToName}}" />
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
     </DockPanel>
 
   </StackPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletGeneralSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletGeneralSettingsView.axaml
@@ -31,6 +31,18 @@
       <ToggleSwitch IsChecked="{Binding PreferPsbtWorkflow}" />
     </DockPanel>
 
+    <DockPanel>
+      <TextBlock Text="Default Send Workflow" />
+      <ComboBox ItemsSource="{Binding SendWorkflows}"
+                SelectedItem="{Binding DefaultSendWorkflow}" />
+    </DockPanel>
+
+    <DockPanel IsVisible="{Binding SeveralReceivingScriptTypes}">
+      <TextBlock Text="Default Receive Script Type" />
+      <ComboBox ItemsSource="{Binding ReceiveScriptTypes}"
+                SelectedItem="{Binding DefaultReceiveScriptType}" />
+    </DockPanel>
+
   </StackPanel>
 
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -39,18 +39,22 @@
             </Button>
 
             <SubActionButton Content="Send"
-                             Command="{Binding SendCommand}"
+                             Command="{Binding DefaultSendCommand}"
                              IsVisible="{Binding IsSendButtonVisible}"
                              Icon="{StaticResource wallet_action_send}">
               <SubActionButton.SubCommands>
                 <UICommandCollection>
-                  <UICommand Name="Automatic" Command="{Binding SendCommand}" IsDefault="True">
+                  <UICommand Name="Automatic"
+                             Command="{Binding SendCommand}"
+                             IsDefault="{Binding Settings.IsAutomaticDefaultSendWorkflow}">
                     <UICommand.Icon>
                       <PathIcon Data="{StaticResource automatic_control}"
                                 Classes="Icon"/>
                     </UICommand.Icon>
                   </UICommand>
-                  <UICommand Name="Manual Control" Command="{Binding SendManualControlCommand}">
+                  <UICommand Name="Manual Control"
+                             Command="{Binding SendManualControlCommand}"
+                             IsDefault="{Binding Settings.IsAutomaticDefaultSendWorkflow, Converter={x:Static BoolConverters.Not}}">
                     <UICommand.Icon>
                       <PathIcon Data="{StaticResource manual_control}"
                                 Classes="Icon" />
@@ -70,20 +74,24 @@
             </Button>
 
             <SubActionButton Content="Receive"
-                             Command="{Binding SegwitReceiveCommand}"
+                             Command="{Binding DefaultReceiveCommand}"
                              VerticalAlignment="Bottom"
                              HorizontalAlignment="Right"
                              Icon="{StaticResource wallet_action_receive}"
                              IsVisible="{Binding SeveralReceivingScriptTypes}">
               <SubActionButton.SubCommands>
                 <UICommandCollection>
-                  <UICommand Name="SegWit Address" Command="{Binding SegwitReceiveCommand}" IsDefault="True">
+                  <UICommand Name="SegWit Address"
+                             Command="{Binding SegwitReceiveCommand}"
+                             IsDefault="{Binding Settings.IsSegWitDefaultReceiveScriptType}">
                     <UICommand.Icon>
                       <PathIcon Data="{StaticResource segwit_short}"
                                 Classes="Icon"/>
                     </UICommand.Icon>
                   </UICommand>
-                  <UICommand Name="Taproot Address" Command="{Binding TaprootReceiveCommand}">
+                  <UICommand Name="Taproot Address"
+                             Command="{Binding TaprootReceiveCommand}"
+                             IsDefault="{Binding Settings.IsSegWitDefaultReceiveScriptType, Converter={x:Static BoolConverters.Not}}">
                     <UICommand.Icon>
                       <PathIcon Data="{StaticResource taproot_short}"
                                 Classes="Icon" />

--- a/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/ReceiveAddressViewModelTests.cs
@@ -54,6 +54,7 @@ public class ReceiveAddressViewModelTests
 
 		public WalletId Id => throw new NotSupportedException();
 		public IEnumerable<ScriptPubKeyType> AvailableScriptPubKeyTypes => throw new NotSupportedException();
+		public bool SeveralReceivingScriptTypes { get; }
 
 		public string Name
 		{

--- a/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/SuggestionLabelsViewModelTests.cs
@@ -185,6 +185,7 @@ public class SuggestionLabelsViewModelTests
 
 		public WalletId Id => throw new NotSupportedException();
 		public IEnumerable<ScriptPubKeyType> AvailableScriptPubKeyTypes => throw new NotSupportedException();
+		public bool SeveralReceivingScriptTypes { get; }
 
 		public string Name
 		{

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -38,7 +38,9 @@ public class KeyManager
 		new HDFingerprintJsonConverter(),
 		new ExtPubKeyJsonConverter(),
 		new KeyPathJsonConverter(),
-		new MoneyBtcJsonConverter()
+		new MoneyBtcJsonConverter(),
+		new ScriptPubKeyTypeJsonConverter(),
+		new SendWorkflowJsonConverter()
 	};
 
 	[JsonConstructor]
@@ -200,10 +202,10 @@ public class KeyManager
 	public bool RedCoinIsolation { get; set; } = DefaultRedCoinIsolation;
 
 	[JsonProperty(PropertyName = "DefaultReceiveScriptType")]
-	public string DefaultReceiveScriptType { get; set; } = "SegWit";
+	public ScriptPubKeyType DefaultReceiveScriptType { get; set; } = ScriptPubKeyType.Segwit;
 
 	[JsonProperty(PropertyName = "DefaultSendWorkflow")]
-	public string DefaultSendWorkflow { get; set; } = "Automatic";
+	public SendWorkflow DefaultSendWorkflow { get; set; } = SendWorkflow.Automatic;
 
 	[JsonProperty(Order = 999, PropertyName = "HdPubKeys")]
 	private readonly List<HdPubKey> _hdPubKeys = new();

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -199,6 +199,12 @@ public class KeyManager
 	[JsonProperty(PropertyName = "RedCoinIsolation")]
 	public bool RedCoinIsolation { get; set; } = DefaultRedCoinIsolation;
 
+	[JsonProperty(PropertyName = "DefaultReceiveScriptType")]
+	public string DefaultReceiveScriptType { get; set; } = "SegWit";
+
+	[JsonProperty(PropertyName = "DefaultSendWorkflow")]
+	public string DefaultSendWorkflow { get; set; } = "Automatic";
+
 	[JsonProperty(Order = 999, PropertyName = "HdPubKeys")]
 	private readonly List<HdPubKey> _hdPubKeys = new();
 

--- a/WalletWasabi/JsonConverters/ScriptPubKeyTypeJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/ScriptPubKeyTypeJsonConverter.cs
@@ -1,0 +1,39 @@
+using NBitcoin;
+using Newtonsoft.Json;
+using WalletWasabi.Extensions;
+
+namespace WalletWasabi.JsonConverters;
+
+/// <summary>
+/// Converter used to convert <see cref="ScriptPubKeyType"/> to and from JSON.
+/// </summary>
+/// <seealso cref="JsonConverter" />
+public class ScriptPubKeyTypeJsonConverter : JsonConverter<ScriptPubKeyType>
+{
+	/// <inheritdoc />
+	public override ScriptPubKeyType ReadJson(JsonReader reader, Type objectType, ScriptPubKeyType existingValue, bool hasExistingValue, JsonSerializer serializer)
+	{
+		var scriptPubKeyString = ((string?)reader.Value)?.Trim();
+
+		if (scriptPubKeyString is null)
+		{
+			throw new ArgumentNullException(nameof(scriptPubKeyString));
+		}
+
+		if (Enum.TryParse(scriptPubKeyString, true, out ScriptPubKeyType result))
+		{
+			return result;
+		}
+
+		throw new JsonSerializationException($"Invalid ScriptPubKeyType: {scriptPubKeyString}");
+	}
+
+	/// <inheritdoc />
+	public override void WriteJson(JsonWriter writer, ScriptPubKeyType value, JsonSerializer serializer)
+	{
+		string scriptPubKeyType = value.FriendlyName()
+		                 ?? throw new ArgumentNullException(nameof(value));
+
+		writer.WriteValue(scriptPubKeyType);
+	}
+}

--- a/WalletWasabi/JsonConverters/SendWorkflowJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/SendWorkflowJsonConverter.cs
@@ -1,0 +1,40 @@
+using NBitcoin;
+using Newtonsoft.Json;
+using WalletWasabi.Extensions;
+using WalletWasabi.Models;
+
+namespace WalletWasabi.JsonConverters;
+
+/// <summary>
+/// Converter used to convert <see cref="SendWorkflow"/> to and from JSON.
+/// </summary>
+/// <seealso cref="JsonConverter" />
+public class SendWorkflowJsonConverter : JsonConverter<SendWorkflow>
+{
+	/// <inheritdoc />
+	public override SendWorkflow ReadJson(JsonReader reader, Type objectType, SendWorkflow existingValue, bool hasExistingValue, JsonSerializer serializer)
+	{
+		var sendWorkflowString = ((string?)reader.Value)?.Trim();
+
+		if (sendWorkflowString is null)
+		{
+			throw new ArgumentNullException(nameof(sendWorkflowString));
+		}
+
+		if (Enum.TryParse(sendWorkflowString, true, out SendWorkflow result))
+		{
+			return result;
+		}
+
+		throw new JsonSerializationException($"Invalid Send Workflow: {sendWorkflowString}");
+	}
+
+	/// <inheritdoc />
+	public override void WriteJson(JsonWriter writer, SendWorkflow value, JsonSerializer serializer)
+	{
+		string sendWorkflow = value.FriendlyName()
+		                          ?? throw new ArgumentNullException(nameof(value));
+
+		writer.WriteValue(sendWorkflow);
+	}
+}

--- a/WalletWasabi/Models/SendWorkflow.cs
+++ b/WalletWasabi/Models/SendWorkflow.cs
@@ -1,0 +1,7 @@
+namespace WalletWasabi.Models;
+
+public enum SendWorkflow
+{
+	Automatic,
+	Manual
+}

--- a/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
+++ b/WalletWasabi/WabiSabi/Models/Serialization/JsonSerializationOptions.cs
@@ -36,7 +36,8 @@ public class JsonSerializationOptions
 				new IssuanceRequestJsonConverter(),
 				new CredentialPresentationJsonConverter(),
 				new ProofJsonConverter(),
-				new MacJsonConverter()
+				new MacJsonConverter(),
+				new ScriptPubKeyTypeJsonConverter()
 			}
 	};
 


### PR DESCRIPTION
Fixes #13462 
This PR goes into the continuation of my goal for this week: Quality of life features

In the end, the Default Receive Script Type has to be wallet specific because some wallets don't have Taproot.
Default Send Workflow would be better as a global setting but I prefer for both settings to be at the same spot.

A wallet without Taproot won't see the Default Receive Script Type setting
A wallet that will never be able to send (Hardware or WatchOnly) cannot see Default Send Workflow
A wallet that cannot send now but might in the future (Balance = 0) can see Default Send Workflow