### PR TITLE
Reduce auto-start delay + disable it by default

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
@@ -170,8 +170,6 @@ public partial class WalletRepository : ReactiveObject
 				"", // Make sure it is not saved into a file yet.
 				minGapLimit.Value);
 
-			result.AutoCoinJoin = true;
-
 			// Set the filepath but we will only write the file later when the Ui workflow is done.
 			result.SetFilePath(walletFilePath);
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -147,7 +147,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 						   _stateMachine.Fire(Trigger.PlebStopChanged);
 					   });
 
-		_autoCoinJoinStartTimer = new DispatcherTimer { Interval = TimeSpan.FromMinutes(Random.Shared.Next(5, 16)) };
+		_autoCoinJoinStartTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(Random.Shared.Next(60, 180)) };
 		_autoCoinJoinStartTimer.Tick += async (_, _) =>
 		{
 			await walletCoinjoinModel.StartAsync(stopWhenAllMixed: false, false);

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -25,7 +25,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private const string CoinjoinMiningFeeRateTooHighMessage = "Mining fee rate was too high";
 	private const string MinInputCountTooLowMessage = "Min input count was too low";
 	private const string PauseMessage = "Coinjoin is paused";
-	private const string StoppedMessage = "Coinjoin has stopped";
+	private const string StoppedMessage = "Coinjoin is stopped";
 	private const string PressPlayToStartMessage = "Press Play to start";
 	private const string RoundSucceedMessage = "Coinjoin successful! Continuing...";
 	private const string RoundFinishedMessage = "Round ended, awaiting next round";

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -35,7 +35,6 @@ public class WalletGenerator
 		var km = mnemonic is null
 			? KeyManager.CreateNew(out mnemonic, password, Network)
 			: KeyManager.CreateNew(mnemonic, password, Network);
-		km.AutoCoinJoin = true;
 		km.SetBestHeights(height: new Height(TipHeight), turboSyncHeight: new Height(TipHeight));
 		km.SetFilePath(walletFilePath);
 		return (km, mnemonic);


### PR DESCRIPTION
Fixes #13328

I set new delay to 1-3 min.
I think it's good to keep it to give some time to disable. 
I kept the randomization because... IDK.

Auto-Cj to false by default is obvious to me now.

This PR also changes the text "Coinjoin has stopped" to "Coinjoin is stopped" because it fits better with usage.