### PR TITLE
Bitcoin-friendly progress in loading screen

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/LoadingViewModel.cs
@@ -54,7 +54,7 @@ public partial class LoadingViewModel : RoutableViewModel
 			_ => $"{Math.Ceiling(hoursRemaining / 8760)} years"
 		};
 
-		StatusText = $"Synchronized: {currentHeight:N0} / {chainTip:N0}";
+		StatusText = $"Synchronized: {currentHeight:N0} / {chainTip:N0} blocks";
 		TimeToCatchUp = $"{remainingTimeString} of Bitcoin history remaining";
 	}
 }

--- a/WalletWasabi.Fluent/Views/Wallets/LoadingView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/LoadingView.axaml
@@ -35,7 +35,8 @@
             TextAlignment="Center" TextWrapping="Wrap" Opacity="0.6" />
 
           <ProgressBar Value="{Binding Percent}" IsIndeterminate="{Binding !Percent}" Margin="0 20 0 0" />
-          <TextBlock Text="{Binding StatusText}" TextAlignment="Center" Opacity="0.6" />
+          <TextBlock Margin="0 10 0 0" Text="{Binding StatusText}" TextAlignment="Center" Opacity="0.6" />
+          <TextBlock Text="{Binding TimeToCatchUp}" TextAlignment="Center" Opacity="0.6" />
         </StackPanel>
 
         <Panel x:Name="WorldMap" Margin="20">


### PR DESCRIPTION
https://github.com/user-attachments/assets/68da90be-9039-48e7-b003-ffd7bb7fde72

First I display how many filters are yet to be downloaded, no progress needed, it's clear that the number goes down

Then I display `current synchronized height / current tip`, along with an estimate of how much bitcoin history remains to dl Value can be:` Less than 1h`, `X hours` if less than 1 day, `X days` if less than 1 month, `X years` if more than 1 year. It's always the Ceiling so if 1 year and 10 minutes then it will show 2 years

The progress bar still shows the current progress, it didn't change

The only problem with this is that is shows that Wasabi download blocks really slowly :D