### PR TITLE
Fix reading value from anon score property in Maximize Privacy Profile

### DIFF
--- a/WalletWasabi/CoinJoinProfiles/PrivacyProfiles.cs
+++ b/WalletWasabi/CoinJoinProfiles/PrivacyProfiles.cs
@@ -36,7 +36,7 @@ public static class PrivacyProfiles
 		private const int MinExclusive = 29;
 		private const int MaxExclusive = 51;
 
-		public int AnonScoreTarget => GetAnonScoreTarget();
+		public int AnonScoreTarget { get; set; } = GetAnonScoreTarget();
 		public bool NonPrivateCoinIsolation => true;
 		public TimeFrameItem TimeFrame => TimeFrames[0];
 


### PR DESCRIPTION
Fixes: https://github.com/WalletWasabi/WalletWasabi/issues/13724

Previously, we re-generated the value every time we accessed it, which lead to a mismatch between UI and the wallet file.

Nice catch @yahiheb, thanks!