### PR TITLE
[UI] Increase button's border thickness

### DIFF
--- a/WalletWasabi.Fluent/Controls/Button.axaml
+++ b/WalletWasabi.Fluent/Controls/Button.axaml
@@ -19,7 +19,7 @@
     </Style>
     <Style Selector="^.bordered">
       <Setter Property="BorderBrush" Value="Yellow"/>
-      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="BorderThickness" Value="2"/>
     </Style>
   </ControlTheme>
 


### PR DESCRIPTION
To make it obvious which coinjoin strategy is selected.

Master:

![1](https://github.com/user-attachments/assets/c7b79852-dc27-4dc6-a4cb-597858518cc1)

PR:

![2](https://github.com/user-attachments/assets/8673b6f9-dc0d-417d-9c16-33dda72924a2)