### PR TITLE
Change default FeeRateProvider to mempool.space

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -137,7 +137,7 @@ public class Config
 				"The BTC/USD exchange rate provider. Available providers are MempoolSpace (default), Gemini, BlockchainInfo, CoinGecko",
 				GetStringValue("ExchangeRateProvider", PersistentConfig.ExchangeRateProvider, cliArgs)),
 			[ nameof(FeeRateEstimationProvider) ] = (
-				"The mining fee rate estimation provider. Available providers are BlockstreamInfo (default) and MempoolSpace",
+				"The mining fee rate estimation provider. Available providers are (default) MempoolSpace and BlockstreamInfo",
 				GetStringValue("FeeRateEstimationProvider", PersistentConfig.FeeRateEstimationProvider, cliArgs))
 		};
 

--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -66,7 +66,7 @@ public record PersistentConfig
 
 	public string ExchangeRateProvider { get; init; } = "MempoolSpace";
 
-	public string  FeeRateEstimationProvider { get; init; } = "BlockstreamInfo";
+	public string  FeeRateEstimationProvider { get; init; } = "MempoolSpace";
 
 	public decimal MaxCoinJoinMiningFeeRate { get; init; } = Constants.DefaultMaxCoinJoinMiningFeeRate;
 

--- a/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/ConfigManagerNgTests.cs
@@ -76,7 +76,7 @@ public class ConfigManagerNgTests
 			  "EnableGpu": true,
 			  "CoordinatorIdentifier": "CoinJoinCoordinatorIdentifier",
 			  "ExchangeRateProvider": "MempoolSpace",
-			  "FeeRateEstimationProvider": "BlockstreamInfo",
+			  "FeeRateEstimationProvider": "MempoolSpace",
 			  "MaxCoinJoinMiningFeeRate": 150.0,
 			  "AbsoluteMinInputCount": 21,
 			  "ConfigVersion": 0


### PR DESCRIPTION
It is better for both providers (Exchange Rate and Fee Rate) to be on the same provider to avoid breaking more often. Estimations were the same when I checked.