### PR TITLE
Better error reporting for fee and exchange rate request errors

### DIFF
--- a/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
+++ b/WalletWasabi/Extensions/HttpResponseMessageExtensions.cs
@@ -66,4 +66,20 @@ public static class HttpResponseMessageExtensions
 
 		throw new HttpRequestException($"{me.StatusCode.ToReasonString()}{errorMessage}");
 	}
+
+	public static void EnsureSuccessStatusCode(this HttpResponseMessage me, string contextMessage)
+	{
+		if (!me.IsSuccessStatusCode)
+		{
+			var error = (int) me.StatusCode switch
+			{
+				429 => "The server rejected the request because it is getting too many request from the same IP address",
+				>= 400 and < 500 => "The server could not understand the request. This means that the API changed",
+				>= 500 and < 600 => "The server is failing and cannot handle the request",
+				_ => ""
+			};
+
+			throw new HttpRequestException($"{contextMessage}. {error}. {(int)me.StatusCode} {me.ReasonPhrase}");
+		}
+	}
 }

--- a/WalletWasabi/Helpers/Result.cs
+++ b/WalletWasabi/Helpers/Result.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using WalletWasabi.Userfacing.Bip21;
 
 namespace WalletWasabi.Helpers;
 
@@ -83,6 +82,18 @@ public record Result<TValue,TError>
 		Match(
 			_ => throw new InvalidOperationException("Successful result don't have error."),
 			e => e);
+
+	public static Result<T, Exception> Catch<T>(Func<T> func)
+	{
+		try
+		{
+			return func();
+		}
+		catch (Exception e)
+		{
+			return Result<T, Exception>.Fail(e);
+		}
+	}
 }
 
 public record Result<TError> : Result<Unit, TError>


### PR DESCRIPTION
This is how it was before:

```
2025-02-05 22:16:49.630 [6] ERROR	PeriodicRunner.ExecuteAsync (114)	System.ArgumentException: The xpath .[0].current_price was not found. (Parameter 'xpath')
```

and this is how it is now:
```
2025-02-06 02:50:28.870 [15] WARNING    PeriodicRunner.ExecuteAsync (110)       System.Net.Http.HttpRequestException: Error requesting exchange rate to 'coingecko'. The server could not understand the request. This means that the API changed. 404 Not Found
```