### PR TITLE
CJ profile: disable NonPrivateCoinIsolation for default strategy

### DIFF
--- a/WalletWasabi/CoinJoinProfiles/PrivacyProfiles.cs
+++ b/WalletWasabi/CoinJoinProfiles/PrivacyProfiles.cs
@@ -20,7 +20,7 @@ public static class PrivacyProfiles
 	public record Default : IPrivacyProfile
 	{
 		public int AnonScoreTarget => 10;
-		public bool NonPrivateCoinIsolation => true;
+		public bool NonPrivateCoinIsolation => false;
 		public TimeFrameItem TimeFrame => TimeFrames[0];
 	}
 


### PR DESCRIPTION
_NonPrivateCoinIsolation_  should not be enabled for the default coinjoin strategy.
Only for the private profile.

maybe I missed a discussion about this the past few days, but I don't see why this should be changed and it seems it slipped through, here https://github.com/WalletWasabi/WalletWasabi/pull/13714
