### PR TITLE
update Dust Threshold text and tooltip

### DIFF
--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -47,8 +47,8 @@
         </TextBox>
     </DockPanel>
 
-    <DockPanel ToolTip.Tip="Coins received from others to already used addresses won't appear below this amount. To prevent potential dust attacks.">
-      <TextBlock Text="Dust Threshold" />
+    <DockPanel ToolTip.Tip="Payments (from others) below this value won't appear if you have already received coins to the same address.">
+      <TextBlock Text="Dust Attack Limit" />
       <CurrencyEntryBox Classes="standalone" Text="{Binding DustThreshold}" CurrencyCode="BTC" />
     </DockPanel>
   </StackPanel>


### PR DESCRIPTION
closes https://github.com/WalletWasabi/WalletWasabi/issues/13760

![image](https://github.com/user-attachments/assets/20838e73-d667-45b3-89cd-dd71250650e8)

