### PR TITLE
Plebstop include only confirmed coins amount

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -125,7 +125,7 @@ public class Wallet : BackgroundService, IWallet
 
 	public TimeSpan FeeRateMedianTimeFrame => TimeSpan.FromHours(KeyManager.FeeRateMedianTimeFrameHours);
 
-	public bool IsUnderPlebStop => Coins.TotalAmount() <= KeyManager.PlebStopThreshold;
+	public bool IsUnderPlebStop => Coins.Confirmed().TotalAmount() <= KeyManager.PlebStopThreshold;
 
 	public ICoinsView GetAllCoins() => Coins.AsAllCoinsView();
 


### PR DESCRIPTION
Fixes: #13754

> When an incoming transaction is detected in the mempool that causes the threshold to be met, input registration begins immediately before the tx is confirmed. This effectively bypasses the efficiency safeguard since only confirmed coins are eligible to register to the round.