### PR TITLE
PlebStop rework

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -35,8 +35,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private const string WaitingForBlameRoundMessage = "Awaiting the blame round";
 	private const string WaitingRoundMessage = "Awaiting a round";
 	private const string PlebStopMessage = "Coinjoin may be uneconomical";
-	private const string PlebStopMessageBelow = "Add more funds or press Play to bypass";
-	private const string PlebStopMessageBelowUnconfirmed = "Wait confirmation or press Play to bypass";
+	private const string PlebStopMessageBelow = "Add more funds or click to continue";
+	private const string PlebStopMessageBelowUnconfirmed = "Wait for confirmation or click to continue";
 	private const string NoCoinsEligibleToMixMessage = "Insufficient funds eligible for coinjoin";
 	private const string UserInSendWorkflowMessage = "Awaiting closure of send dialog";
 	private const string AllPrivateMessage = "Hurray! All your funds are private!";

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
@@ -94,7 +94,7 @@
       </PathIcon>
     </DockPanel>
 
-    <DockPanel ToolTip.Tip="Coinjoin will automatically stop if the wallet balance is less than this.">
+    <DockPanel ToolTip.Tip="Coinjoin will automatically stop if the confirmed wallet balance is below this.">
       <TextBlock Text="Stop coinjoin threshold" />
       <CurrencyEntryBox Classes="standalone" Text="{Binding PlebStopThreshold}" CurrencyCode="BTC" />
     </DockPanel>

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -175,7 +175,7 @@ public class KeyManager
 	public bool AutoCoinJoin { get; set; } = DefaultAutoCoinjoin;
 
 	/// <summary>
-	/// Won't coinjoin automatically if the wallet balance is less than this.
+	/// Won't coinjoin automatically if the confirmed wallet balance is below this.
 	/// </summary>
 	[JsonProperty(PropertyName = "PlebStopThreshold")]
 	[JsonConverter(typeof(MoneyBtcJsonConverter))]

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -81,9 +81,9 @@ public class CoinJoinManager : BackgroundService
 
 		if (overridePlebStop && !IsUnderPlebStop(coinCandidates, wallet.PlebStopThreshold))
 		{
-			// Turn off overriding if we went above the threshold meanwhile.
+			// Turn off overriding if we reached or exceeded the threshold meanwhile.
 			overridePlebStop = false;
-			wallet.LogDebug("Do not override PlebStop anymore we are above the threshold.");
+			wallet.LogDebug("Do not override PlebStop anymore, confirmed balance no longer below the threshold.");
 		}
 
 		await _commandChannel.Writer.WriteAsync(new StartCoinJoinCommand(wallet, outputWallet, stopWhenAllMixed, overridePlebStop), cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/StatusChangedEvents/StatusChangedEventArgs.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/StatusChangedEvents/StatusChangedEventArgs.cs
@@ -31,7 +31,8 @@ public enum CoinjoinError
 	UneconomicalRound,
 	MiningFeeRateTooHigh,
 	MinInputCountTooLow,
-	CoordinatorLiedAboutInputs
+	CoordinatorLiedAboutInputs,
+	NotEnoughConfirmedUnprivateBalance
 }
 
 public class StatusChangedEventArgs : EventArgs

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Models;
@@ -12,7 +13,7 @@ public interface IWallet
 {
 	string WalletName { get; }
 	WalletId WalletId { get; }
-	bool IsUnderPlebStop { get; }
+	Money PlebStopThreshold { get; }
 	bool IsMixable { get; }
 
 	/// <summary>

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -125,7 +125,7 @@ public class Wallet : BackgroundService, IWallet
 
 	public TimeSpan FeeRateMedianTimeFrame => TimeSpan.FromHours(KeyManager.FeeRateMedianTimeFrameHours);
 
-	public bool IsUnderPlebStop => Coins.Confirmed().TotalAmount() <= KeyManager.PlebStopThreshold;
+	public Money PlebStopThreshold => KeyManager.PlebStopThreshold;
 
 	public ICoinsView GetAllCoins() => Coins.AsAllCoinsView();
 


### PR DESCRIPTION
Supersedes #13768

This PR makes 3 important changes:
- It unifies `IsUnderPlebStop` with the actual `coinCandidates` computation. That way, both are always strictly the same. To do so, `IsUnderPlebStop` is moved in `CoinjoinManager`. Also improves the code.

- It removes the requirement for backend synchronization to coinjoin. This change has a negative consequence: If some coins are immatures (Coinbase < 101 confirmations) and we are not connected to the backend then we will try to coinjoin those funds. I think this alignement of stars is so rare that it never happened to an actual user, and will never happen. So I believe it's better to let users coinjoin when backend is not connected. @lontivero are you ok with that?

- It displays a new message on the bottom line of the MusicBox if the PlebStop was activated due to lack of confirmed funds: `Wait confirmation or press Play to bypass `. Feel free to suggest another message but make sure before suggesting that it fits in the MusicBox (my message is already close to max)

Everything is made in such way that it can't affect behavior in any way