### PR TITLE
Allow client to use bip158-compatible filters

### DIFF
--- a/WalletWasabi.Backend/StartupTask.cs
+++ b/WalletWasabi.Backend/StartupTask.cs
@@ -64,8 +64,9 @@ public class StartupTask
 			{
 				if (blocks < 101)
 				{
-					using Key key = new();
-					var generateBlocksResponse = await RpcClient.GenerateToAddressAsync(101, key.GetAddress(ScriptPubKeyType.Segwit, Network.RegTest), cancellationToken);
+					using var key = new Key();
+					var address = key.GetAddress(ScriptPubKeyType.TaprootBIP86, RpcClient.Network);
+					var generateBlocksResponse = await RpcClient.GenerateToAddressAsync(101, address, cancellationToken);
 					if (generateBlocksResponse is null)
 					{
 						throw new NotSupportedException($"Bitcoin Node cannot generate blocks on the {Network.RegTest}.");

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/IndexBuilderServiceTests.cs
@@ -92,7 +92,7 @@ public class IndexBuilderServiceTests
 
 		indexer.Synchronize();
 
-		await Task.Delay(TimeSpan.FromSeconds(10));
+		await Task.Delay(TimeSpan.FromSeconds(5));
 		Assert.True(indexer.IsRunning);  // It is still working
 
 		var lastFilter = indexer.GetLastFilter();

--- a/WalletWasabi.Tests/UnitTests/Blockchain/Blocks/SmartHeaderChainTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/Blocks/SmartHeaderChainTests.cs
@@ -25,7 +25,7 @@ public class SmartHeaderChainTests
 		chain.AppendTip(header);
 
 		InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => chain.AppendTip(header));
-		Assert.StartsWith("Header doesn't point to previous header.", ex.Message, StringComparison.Ordinal);
+		Assert.StartsWith("Header height isn't one more than the previous header height.", ex.Message, StringComparison.Ordinal);
 	}
 
 	/// <summary>
@@ -150,7 +150,7 @@ public class SmartHeaderChainTests
 	/// <remarks>Dummy genesis header.</remarks>
 	private static SmartHeader CreateGenesisHeader()
 	{
-		return new(new uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"), prevHash: uint256.Zero, height: 0, BlockTime);
+		return new(new uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"), header: uint256.Zero, height: 0, BlockTime);
 	}
 
 	private static SmartHeader CreateSmartHeader(uint256 blockHash, uint256 prevHash, uint height)

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -17,6 +17,7 @@ public class MockRpcClient : IRPCClient
 	public Func<uint256, Task<BlockHeader>>? OnGetBlockHeaderAsync { get; set; }
 	public Func<Task<BlockchainInfo>>? OnGetBlockchainInfoAsync { get; set; }
 	public Func<uint256, Task<VerboseBlockInfo>>? OnGetVerboseBlockAsync { get; set; }
+	public Func<uint256, Task<BlockFilter>>? OnGetBlockFilterAsync { get; set; }
 	public Func<Transaction, uint256>? OnSendRawTransactionAsync { get; set; }
 	public Func<Task<MemPoolInfo>>? OnGetMempoolInfoAsync { get; set; }
 	public Func<Task<uint256[]>>? OnGetRawMempoolAsync { get; set; }
@@ -142,6 +143,11 @@ public class MockRpcClient : IRPCClient
 	public Task<VerboseBlockInfo> GetVerboseBlockAsync(uint256 blockId, CancellationToken cancellationToken = default)
 	{
 		return OnGetVerboseBlockAsync?.Invoke(blockId) ?? NotImplementedTask<VerboseBlockInfo>(nameof(GetVerboseBlockAsync));
+	}
+
+	public Task<BlockFilter> GetBlockFilterAsync(uint256 blockId, CancellationToken cancellationToken = default)
+	{
+		return OnGetBlockFilterAsync?.Invoke(blockId) ?? NotImplementedTask<BlockFilter>(nameof(GetBlockFilterAsync));
 	}
 
 	public Task<uint256> SendRawTransactionAsync(Transaction transaction, CancellationToken cancellationToken = default)

--- a/WalletWasabi.Tests/UnitTests/SmartHeaderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SmartHeaderTests.cs
@@ -16,8 +16,7 @@ public class SmartHeaderTests
 		new SmartHeader(uint256.Zero, uint256.One, 1, blockTime);
 
 		Assert.Throws<ArgumentNullException>(() => new SmartHeader(blockHash: null!, uint256.One, 1, blockTime));
-		Assert.Throws<ArgumentNullException>(() => new SmartHeader(uint256.Zero, prevHash: null!, 1, blockTime));
-		Assert.Throws<InvalidOperationException>(() => new SmartHeader(uint256.Zero, uint256.Zero, 1, blockTime));
+		Assert.Throws<ArgumentNullException>(() => new SmartHeader(uint256.Zero, header: null!, 1, blockTime));
 	}
 
 	[Fact]
@@ -28,32 +27,32 @@ public class SmartHeaderTests
 		var startingReg = SmartHeader.GetStartingHeader(Network.RegTest);
 
 		var expectedHashMain = new uint256("0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893");
-		var expectedPrevHashMain = new uint256("000000000000000000cbeff0b533f8e1189cf09dfbebf57a8ebe349362811b80");
+		var expectedHeaderMain = new uint256("000000000000000000cbeff0b533f8e1189cf09dfbebf57a8ebe349362811b80");
 		uint expectedHeightMain = 481824;
 		var expectedTimeMain = DateTimeOffset.FromUnixTimeSeconds(1503539857);
 
 		var expectedHashTest = new uint256("00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043");
-		var expectedPrevHashTest = uint256.Zero;
+		var expectedHeaderTest = uint256.Zero;
 		uint expectedHeightTest = 0;
 		var expectedTimeTest = DateTimeOffset.FromUnixTimeSeconds(1714777860);
 
 		var expectedHashReg = Network.RegTest.GenesisHash;
-		var expectedPrevHashReg = uint256.Zero;
+		var expectedHeaderReg = uint256.Zero;
 		uint expectedHeightReg = 0;
 		var expectedTimeReg = Network.RegTest.GetGenesis().Header.BlockTime;
 
 		Assert.Equal(expectedHashMain, startingMain.BlockHash);
-		Assert.Equal(expectedPrevHashMain, startingMain.PrevHash);
+		Assert.Equal(expectedHeaderMain, startingMain.HeaderOrPrevBlockHash);
 		Assert.Equal(expectedHeightMain, startingMain.Height);
 		Assert.Equal(expectedTimeMain, startingMain.BlockTime);
 
 		Assert.Equal(expectedHashTest, startingTest.BlockHash);
-		Assert.Equal(expectedPrevHashTest, startingTest.PrevHash);
+		Assert.Equal(expectedHeaderTest, startingTest.HeaderOrPrevBlockHash);
 		Assert.Equal(expectedHeightTest, startingTest.Height);
 		Assert.Equal(expectedTimeTest, startingTest.BlockTime);
 
 		Assert.Equal(expectedHashReg, startingReg.BlockHash);
-		Assert.Equal(expectedPrevHashReg, startingReg.PrevHash);
+		Assert.Equal(expectedHeaderReg, startingReg.HeaderOrPrevBlockHash);
 		Assert.Equal(expectedHeightReg, startingReg.Height);
 		Assert.Equal(expectedTimeReg, startingReg.BlockTime);
 	}

--- a/WalletWasabi.Tests/UnitTests/Stores/BlockFilterSqliteStorageTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Stores/BlockFilterSqliteStorageTests.cs
@@ -63,7 +63,7 @@ public class BlockFilterSqliteStorageTests
 		Assert.NotSame(filter1, filterLast);
 		Assert.Equal(1u, filterLast.Header.Height);
 		Assert.Equal(new uint256(2), filterLast.Header.BlockHash);
-		Assert.Equal(uint256.One, filterLast.Header.PrevHash);
+		Assert.Equal(uint256.One, filterLast.Header.HeaderOrPrevBlockHash);
 		Assert.Equal(1231006506, filterLast.Header.EpochBlockTime);
 		Assert.Equal(DummyFilterData, filterLast.Filter.ToBytes());
 
@@ -72,7 +72,7 @@ public class BlockFilterSqliteStorageTests
 		Assert.NotNull(filterLast);
 		Assert.Equal(0u, filterLast.Header.Height);
 		Assert.Equal(uint256.One, filterLast.Header.BlockHash);
-		Assert.Equal(uint256.Zero, filterLast.Header.PrevHash);
+		Assert.Equal(uint256.Zero, filterLast.Header.HeaderOrPrevBlockHash);
 		Assert.Equal(1231006505, filterLast.Header.EpochBlockTime);
 		Assert.Equal(DummyFilterData, filterLast.Filter.ToBytes());
 	}

--- a/WalletWasabi.Tests/UnitTests/Wallet/MockNode.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/MockNode.cs
@@ -64,7 +64,6 @@ public class MockNode
 
 		var startingFilter = StartingFilters.GetStartingFilter(Network);
 		filters.Add(startingFilter);
-
 		foreach (var block in BlockChain.Values)
 		{
 			var inputScriptPubKeys = block.Transactions
@@ -80,16 +79,15 @@ public class MockNode
 			var entries = scripts.Select(x => x.ToCompressedBytes()).DefaultIfEmpty(IndexBuilderService.DummyScript[0]);
 
 			var filter = new GolombRiceFilterBuilder()
-				.SetKey(block.GetHash())
 				.SetP(20)
 				.SetM(1 << 20)
+				.SetKey(block.GetHash())
 				.AddEntries(entries)
 				.Build();
 
 			var tipFilter = filters.Last();
 
 			var smartHeader = new SmartHeader(block.GetHash(), tipFilter.Header.BlockHash, tipFilter.Header.Height + 1, DateTimeOffset.UtcNow);
-
 			filters.Add(new FilterModel(smartHeader, filter));
 		}
 

--- a/WalletWasabi/Backend/Models/FilterModel.cs
+++ b/WalletWasabi/Backend/Models/FilterModel.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System.Text;
 using System.Threading;
 using WalletWasabi.Blockchain.Blocks;
+using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Backend.Models;
 
@@ -9,18 +10,24 @@ public class FilterModel
 {
 	private readonly Lazy<GolombRiceFilter> _filter;
 
-	public FilterModel(SmartHeader header, GolombRiceFilter filter)
+	public FilterModel(SmartHeader header, GolombRiceFilter filter, bool isBip158 = false)
 	{
 		Header = header;
 		_filter = new(filter);
-		FilterData = filter.ToBytes();
+		FilterData = isBip158
+			? ByteHelpers.Combine(filter.ToBytes(), [0x86, 0x68])
+			: filter.ToBytes();
 	}
 
 	private FilterModel(SmartHeader header, byte[] filterData)
 	{
 		Header = header;
 		FilterData = filterData;
-		_filter = new(() => new GolombRiceFilter(filterData, 20, 1 << 20), LazyThreadSafetyMode.ExecutionAndPublication);
+		var isBip158 = filterData is [.., 0x86, 0x68];
+		_filter = new(() => isBip158
+			? new GolombRiceFilter(filterData)
+			: new GolombRiceFilter(filterData, 20, 1 << 20)
+			, LazyThreadSafetyMode.ExecutionAndPublication);
 	}
 
 	public SmartHeader Header { get; }
@@ -79,10 +86,16 @@ public class FilterModel
 		builder.Append(':');
 		builder.Append(Filter);
 		builder.Append(':');
-		builder.Append(Header.PrevHash);
+		builder.Append(Header.HeaderOrPrevBlockHash);
 		builder.Append(':');
 		builder.Append(Header.EpochBlockTime);
 
 		return builder.ToString();
 	}
+}
+
+public static class GolombRiceFilterExtensions
+{
+	public static bool IsBip158(this GolombRiceFilter filter) =>
+		filter is {P: 19, M: 784_931}; // Standard BIP158 filter parameters.
 }

--- a/WalletWasabi/BitcoinRpc/IRPCClient.cs
+++ b/WalletWasabi/BitcoinRpc/IRPCClient.cs
@@ -74,6 +74,8 @@ public interface IRPCClient
 
 	Task<VerboseBlockInfo> GetVerboseBlockAsync(uint256 blockId, CancellationToken cancellationToken = default);
 
+	Task<BlockFilter> GetBlockFilterAsync(uint256 blockId, CancellationToken cancellationToken = default);
+
 	Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address, CancellationToken cancellationToken = default);
 
 	Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null, CancellationToken cancellationToken = default);

--- a/WalletWasabi/BitcoinRpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinRpc/RpcClientBase.cs
@@ -159,6 +159,11 @@ public class RpcClientBase : IRPCClient
 		return RpcParser.ParseVerboseBlockResponse(resp.ResultString);
 	}
 
+	public virtual async Task<BlockFilter> GetBlockFilterAsync(uint256 blockId, CancellationToken cancellationToken = default)
+	{
+		return await Rpc.GetBlockFilterAsync(blockId, cancellationToken).ConfigureAwait(false);
+	}
+
 	public async Task<uint256[]> GenerateToAddressAsync(int nBlocks, BitcoinAddress address, CancellationToken cancellationToken = default)
 	{
 		return await Rpc.GenerateToAddressAsync(nBlocks, address, cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/Blockchain/BlockFilters/StartingFilters.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/StartingFilters.cs
@@ -12,16 +12,16 @@ public static class StartingFilters
 		var startingHeader = SmartHeader.GetStartingHeader(network);
 		if (network == Network.Main)
 		{
-			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:02832810ec08a0:{startingHeader.PrevHash}:{startingHeader.EpochBlockTime}");
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:02832810ec08a0:{startingHeader.HeaderOrPrevBlockHash}:{startingHeader.EpochBlockTime}");
 		}
 		else if (network == Network.TestNet)
 		{
-			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a:{startingHeader.PrevHash}:{startingHeader.EpochBlockTime}");
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:00000000000f0d5edcaeba823db17f366be49a80d91d15b77747c2e017b8c20a:{startingHeader.HeaderOrPrevBlockHash}:{startingHeader.EpochBlockTime}");
 		}
 		else if (network == Network.RegTest)
 		{
 			GolombRiceFilter filter = IndexBuilderService.CreateDummyEmptyFilter(startingHeader.BlockHash);
-			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:{filter}:{startingHeader.PrevHash}:{startingHeader.EpochBlockTime}");
+			return FilterModel.FromLine($"{startingHeader.Height}:{startingHeader.BlockHash}:{filter}:{startingHeader.HeaderOrPrevBlockHash}:{startingHeader.EpochBlockTime}");
 		}
 		else
 		{

--- a/WalletWasabi/Blockchain/Blocks/SmartHeader.cs
+++ b/WalletWasabi/Blockchain/Blocks/SmartHeader.cs
@@ -4,28 +4,23 @@ using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Blockchain.Blocks;
 
-public class SmartHeader
+public record SmartHeader
 {
-	public SmartHeader(uint256 blockHash, uint256 prevHash, uint height, DateTimeOffset blockTime)
-		: this(blockHash, prevHash, height, blockTime.ToUnixTimeSeconds())
+	public SmartHeader(uint256 blockHash, uint256 header, uint height, DateTimeOffset blockTime)
+		: this(blockHash, header, height, blockTime.ToUnixTimeSeconds())
 	{
 	}
 
-	public SmartHeader(uint256 blockHash, uint256 prevHash, uint height, long epochBlockTime)
+	public SmartHeader(uint256 blockHash, uint256 header, uint height, long epochBlockTime)
 	{
 		BlockHash = Guard.NotNull(nameof(blockHash), blockHash);
-		PrevHash = Guard.NotNull(nameof(prevHash), prevHash);
-		if (blockHash == prevHash)
-		{
-			throw new InvalidOperationException($"{nameof(blockHash)} cannot be equal to {nameof(prevHash)}. Value: {blockHash}.");
-		}
-
+		HeaderOrPrevBlockHash = Guard.NotNull(nameof(header), header);
 		Height = height;
 		EpochBlockTime = epochBlockTime;
 	}
 
 	public uint256 BlockHash { get; }
-	public uint256 PrevHash { get; }
+	public uint256 HeaderOrPrevBlockHash { get; }
 	public uint Height { get; }
 
 	/// <summary>Timestamp in seconds.</summary>

--- a/WalletWasabi/Blockchain/Blocks/SmartHeaderChain.cs
+++ b/WalletWasabi/Blockchain/Blocks/SmartHeaderChain.cs
@@ -132,11 +132,6 @@ public class SmartHeaderChain
 			{
 				SmartHeader lastHeader = _chain.Last!.Value;
 
-				if (lastHeader.BlockHash != tip.PrevHash)
-				{
-					throw new InvalidOperationException($"Header doesn't point to previous header. Actual: {lastHeader.PrevHash}. Expected: {tip.PrevHash}.");
-				}
-
 				if (lastHeader.Height != tip.Height - 1)
 				{
 					throw new InvalidOperationException($"Header height isn't one more than the previous header height. Actual: {lastHeader.Height}. Expected: {tip.Height - 1}.");

--- a/WalletWasabi/Blockchain/Keys/HdPubKeyInfo.cs
+++ b/WalletWasabi/Blockchain/Keys/HdPubKeyInfo.cs
@@ -9,10 +9,11 @@ public record HdPubKeyInfo
 		HdPubKey = hdPubKey;
 		ScriptPubKeyType = scriptPubKeyType;
 		ScriptPubKey = hdPubKey.PubKey.GetScriptPubKey(scriptPubKeyType);
-		CompressedScriptPubKey = ScriptPubKey.ToCompressedBytes();
+		CompressedScriptPubKeyBytes = ScriptPubKey.ToCompressedBytes();
 	}
 	public HdPubKey HdPubKey { get; }
 	public ScriptPubKeyType ScriptPubKeyType { get; set; }
 	public Script ScriptPubKey { get; }
-	public byte[] CompressedScriptPubKey { get; }
+	public byte[] ScriptPubKeyBytes => ScriptPubKey.ToBytes(@unsafe: true);
+	public byte[] CompressedScriptPubKeyBytes { get; }
 }

--- a/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
+++ b/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
@@ -292,7 +292,7 @@ public class BlockFilterSqliteStorage : IDisposable
 			insertCommand.Parameters.AddWithValue("$block_height", filter.Header.Height);
 			insertCommand.Parameters.AddWithValue("$block_hash", filter.Header.BlockHash.ToBytes(lendian: true));
 			insertCommand.Parameters.AddWithValue("$filter_data", filter.FilterData);
-			insertCommand.Parameters.AddWithValue("$previous_block_hash", filter.Header.PrevHash.ToBytes(lendian: true));
+			insertCommand.Parameters.AddWithValue("$previous_block_hash", filter.Header.HeaderOrPrevBlockHash.ToBytes(lendian: true));
 			insertCommand.Parameters.AddWithValue("$epoch_block_time", filter.Header.EpochBlockTime);
 			int result = insertCommand.ExecuteNonQuery();
 
@@ -343,7 +343,7 @@ public class BlockFilterSqliteStorage : IDisposable
 			blockHeightParameter.Value = filter.Header.Height;
 			blockHashParameter.Value = filter.Header.BlockHash.ToBytes(lendian: true);
 			filterDataParameter.Value = filter.FilterData;
-			prevBlockHashParameter.Value = filter.Header.PrevHash.ToBytes(lendian: true);
+			prevBlockHashParameter.Value = filter.Header.HeaderOrPrevBlockHash.ToBytes(lendian: true);
 			epochBlockTimeParameter.Value = filter.Header.EpochBlockTime;
 
 			command.ExecuteNonQuery();

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -252,6 +252,11 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 	{
 		try
 		{
+			if (!IsCorrect(_smartHeaderChain, filter))
+			{
+				throw new InvalidOperationException($"Header doesn't point to previous header.");
+			}
+
 			_smartHeaderChain.AppendTip(filter.Header);
 
 			if (enqueue)
@@ -267,6 +272,54 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 		catch (Exception ex)
 		{
 			Logger.LogError(ex);
+			return false;
+		}
+	}
+
+	private bool IsCorrect(SmartHeaderChain c, FilterModel m)
+	{
+		// If this is the first filter that we receive then it is correct only if it is starting one.
+		if (c.Tip is not {} tip)
+		{
+			return true;
+		}
+		//if(c.Tip is not {} tip )
+		//{
+		//	return m.Header == SmartHeader.GetStartingHeader(_network);
+		//}
+		if (m.Filter.IsBip158())
+		{
+			// We received a bip158-compatible filter, and it matches the tip's header, which means the previous filter
+			// was also a bip158-compatible one, and it is the correct one.
+			if (m.Filter.GetHeader(tip.HeaderOrPrevBlockHash) == m.Header.HeaderOrPrevBlockHash || c.HashCount == 1)
+			{
+				return true;
+			}
+
+			// In case the previous filter is Bip158-compatible it should have passed the previous condition so, the
+			// received filter did match.
+			var lastFilter = IndexStorage.FetchLast(1).First();
+			if (lastFilter.Filter.IsBip158())
+			{
+				return false;
+			}
+
+			// If we received a bip158-compatible filter for first time we accept it.
+			return true;
+		}
+		else
+		{
+			if (m.Header.HeaderOrPrevBlockHash == tip.BlockHash)
+			{
+				return true;
+			}
+
+			var lastFilter = IndexStorage.FetchLast(1).First();
+			if (lastFilter.Filter.IsBip158())
+			{
+				throw new InvalidOperationException("The received filter is not compatible with bip158.");
+			}
+
 			return false;
 		}
 	}


### PR DESCRIPTION
This is a subset of the changes in https://github.com/WalletWasabi/WalletWasabi/pull/13625 that doesn't change the index building service. This means that the filters are still being generated as before. However, the client can distinguish the legacy wasabi filters from the standard bip158 filters and used them to synchronize the wallet.

The idea is to allow the `WasabiSynchronizer` to fetch filters from the backend (legacy for the moment) or from a Bitcoin Node RPC (standard) because with this Wasabi could finally synchronize without a backend server. After that we can merge the missing parts from #13625 which allow the backend to also serve standard filters instead of building them.  