### PR TITLE
Synchronize using Bitcoin RPC

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -132,7 +132,7 @@ public class Global
 			var supportsBlockFilters = BitcoinRpcClient.SupportsBlockFiltersAsync(CancellationToken.None).GetAwaiter().GetResult();
 			if (supportsBlockFilters)
 			{
-				filtersProvider = new BitcoinRpcFilterProvider(BitcoinRpcClient, EventBus);
+				filtersProvider = new BitcoinRpcFilterProvider(BitcoinRpcClient);
 			}
 
 			var rpcFeeProvider = FeeRateProviders.RpcAsync(BitcoinRpcClient);

--- a/WalletWasabi.Fluent/Converters/StatusConverters.cs
+++ b/WalletWasabi.Fluent/Converters/StatusConverters.cs
@@ -30,5 +30,5 @@ public static class StatusConverters
 		new FuncValueConverter<uint, string>(x => x == 0 ? "No data" : $"{x:N0}");
 
 	public static readonly IValueConverter RpcStatusStringConverter =
-		new FuncValueConverter<RpcStatus?, string>(status => status is null ? RpcStatus.Unresponsive.ToString() : status.ToString());
+		new FuncValueConverter<RpcStatus?, string>(status => status is null ? new RpcStatus.Unresponsive().ToString() : status.ToString());
 }

--- a/WalletWasabi.Fluent/Models/Wallets/WalletLoadWorkflow.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletLoadWorkflow.cs
@@ -30,9 +30,9 @@ public partial class WalletLoadWorkflow
 		_progress = new();
 		_progress.OnNext((0, 0, 0, 0));
 
-		Services.EventBus.AsObservable<BackendAvailabilityStateChanged>()
+		Services.EventBus.AsObservable<ServerTipHeightChanged>()
 			.ObserveOn(RxApp.MainThreadScheduler)
-			.Select(e => e.IsBackendAvailable)
+			.Select(e => true)
 			.Take(1)
 			.Subscribe(b => InitialRequestTcs.TrySetResult(b))
 			.DisposeWith(_disposables);

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -102,7 +102,8 @@ public class P2pTests
 
 		KeyManager keyManager = KeyManager.CreateNew(out _, "password", network);
 		var httpClientFactory = new CoordinatorHttpClientFactory(new Uri("http://localhost:12345"), new HttpClientFactory());
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory, eventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, eventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, eventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), eventBus);
 
 		using MemoryCache cache = new(new MemoryCacheOptions

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
@@ -60,7 +60,8 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.BackendHttpClientFactory;
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new(TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
@@ -56,7 +56,8 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, RegTestFixture.BackendHttpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.BackendHttpClientFactory,  setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/CancelTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CancelTests.cs
@@ -57,7 +57,8 @@ public class CancelTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.BackendHttpClientFactory;
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
@@ -31,7 +31,8 @@ public class FilterDownloaderTest : IClassFixture<RegTestFixture>
 		IRPCClient rpc = setup.RpcClient;
 		BitcoinStore bitcoinStore = setup.BitcoinStore;
 
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(1), 1000, bitcoinStore, RegTestFixture.BackendHttpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.BackendHttpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(1), filterProvider, bitcoinStore, setup.EventBus);
 		try
 		{
 			await synchronizer.StartAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
@@ -60,9 +60,9 @@ public class MaxFeeTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.BackendHttpClientFactory;
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
-
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
@@ -59,7 +59,8 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.BackendHttpClientFactory;
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
@@ -67,9 +67,8 @@ public class ReorgTest : IClassFixture<RegTestFixture>
 
 		await rpc.GenerateAsync(2); // Generate two, so we can test for two reorg
 
-		var node = RegTestFixture.BackendRegTestNode;
-
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 1000, bitcoinStore, RegTestFixture.BackendHttpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.BackendHttpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 
 		try
 		{

--- a/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
@@ -51,7 +51,8 @@ public class ReplaceByFeeTxTest : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 3. Create wasabi synchronizer service.
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, RegTestFixture.BackendHttpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.BackendHttpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
@@ -60,7 +60,8 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.BackendHttpClientFactory;
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
@@ -60,7 +60,8 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.BackendHttpClientFactory;
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -61,7 +61,8 @@ public class SendTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.BackendHttpClientFactory;
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
@@ -60,7 +60,8 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.BackendHttpClientFactory;
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 10000, bitcoinStore, httpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 4. Create key manager service.

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -49,7 +49,8 @@ public class WalletTests : IClassFixture<RegTestFixture>
 		node.Behaviors.Add(bitcoinStore.CreateUntrustedP2pBehavior());
 
 		// 2. Create wasabi synchronizer service.
-		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), 1000, bitcoinStore, RegTestFixture.BackendHttpClientFactory, setup.EventBus);
+		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.BackendHttpClientFactory, setup.EventBus);
+		using WasabiSynchronizer synchronizer = new(period: TimeSpan.FromSeconds(3), filterProvider, bitcoinStore, setup.EventBus);
 		using FeeRateEstimationUpdater feeProvider = new (TimeSpan.Zero, FeeRateProviders.BlockstreamAsync(new HttpClientFactory()), setup.EventBus);
 
 		// 3. Create key manager service.

--- a/WalletWasabi.Tests/UnitTests/Mocks/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/Mocks/MockRpcClient.cs
@@ -213,4 +213,9 @@ public class MockRpcClient : IRPCClient
 	{
 		throw new NotImplementedException();
 	}
+
+	public Task<bool> SupportsBlockFiltersAsync(CancellationToken cancellationToken)
+	{
+		throw new NotImplementedException();
+	}
 }

--- a/WalletWasabi.Tests/UnitTests/Stores/BlockFilterSqliteStorageTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Stores/BlockFilterSqliteStorageTests.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Blockchain.BlockFilters;
+using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Stores;
 using Xunit;
 
@@ -16,8 +17,8 @@ public class BlockFilterSqliteStorageTests
 	[Fact]
 	public void TryAppend()
 	{
-		FilterModel filter0 = FilterModel.Create(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, prevBlockHash: uint256.Zero, blockTime: 1231006505);
-		FilterModel filter1 = FilterModel.Create(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, prevBlockHash: uint256.One, blockTime: 1231006506);
+		FilterModel filter0 = CreateFilterModel(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, headerOrPrevBlockHash: uint256.Zero, blockTime: 1231006505);
+		FilterModel filter1 = CreateFilterModel(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, headerOrPrevBlockHash: uint256.One, blockTime: 1231006506);
 
 		using BlockFilterSqliteStorage indexStorage = BlockFilterSqliteStorage.FromFile(dataSource: SqliteStorageHelper.InMemoryDatabase, filter0);
 
@@ -49,8 +50,8 @@ public class BlockFilterSqliteStorageTests
 	[Fact]
 	public void AppendAndRemove()
 	{
-		FilterModel filter0 = FilterModel.Create(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, prevBlockHash: uint256.Zero, blockTime: 1231006505);
-		FilterModel filter1 = FilterModel.Create(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, prevBlockHash: uint256.One, blockTime: 1231006506);
+		FilterModel filter0 = CreateFilterModel(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, headerOrPrevBlockHash: uint256.Zero, blockTime: 1231006505);
+		FilterModel filter1 = CreateFilterModel(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, headerOrPrevBlockHash: uint256.One, blockTime: 1231006506);
 
 		using BlockFilterSqliteStorage indexStorage = BlockFilterSqliteStorage.FromFile(dataSource: SqliteStorageHelper.InMemoryDatabase, filter0);
 
@@ -80,10 +81,10 @@ public class BlockFilterSqliteStorageTests
 	[Fact]
 	public void TryRemoveLastIfNewerThan()
 	{
-		FilterModel filter0 = FilterModel.Create(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, prevBlockHash: uint256.Zero, blockTime: 1231006505);
-		FilterModel filter1 = FilterModel.Create(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, prevBlockHash: uint256.One, blockTime: 1231006506);
-		FilterModel filter2 = FilterModel.Create(blockHeight: 2, blockHash: new uint256(3), filterData: DummyFilterData, prevBlockHash: new uint256(2), blockTime: 1231006507);
-		FilterModel filter3 = FilterModel.Create(blockHeight: 3, blockHash: new uint256(4), filterData: DummyFilterData, prevBlockHash: new uint256(3), blockTime: 1231006508);
+		FilterModel filter0 = CreateFilterModel(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, headerOrPrevBlockHash: uint256.Zero, blockTime: 1231006505);
+		FilterModel filter1 = CreateFilterModel(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, headerOrPrevBlockHash: uint256.One, blockTime: 1231006506);
+		FilterModel filter2 = CreateFilterModel(blockHeight: 2, blockHash: new uint256(3), filterData: DummyFilterData, headerOrPrevBlockHash: new uint256(2), blockTime: 1231006507);
+		FilterModel filter3 = CreateFilterModel(blockHeight: 3, blockHash: new uint256(4), filterData: DummyFilterData, headerOrPrevBlockHash: new uint256(3), blockTime: 1231006508);
 
 		using BlockFilterSqliteStorage indexStorage = BlockFilterSqliteStorage.FromFile(dataSource: SqliteStorageHelper.InMemoryDatabase, filter0);
 
@@ -114,8 +115,8 @@ public class BlockFilterSqliteStorageTests
 	[Fact]
 	public void Clear()
 	{
-		FilterModel filter0 = FilterModel.Create(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, prevBlockHash: uint256.Zero, blockTime: 1231006505);
-		FilterModel filter1 = FilterModel.Create(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, prevBlockHash: uint256.One, blockTime: 1231006506);
+		FilterModel filter0 = CreateFilterModel(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, headerOrPrevBlockHash: uint256.Zero, blockTime: 1231006505);
+		FilterModel filter1 = CreateFilterModel(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, headerOrPrevBlockHash: uint256.One, blockTime: 1231006506);
 
 		using BlockFilterSqliteStorage indexStorage = BlockFilterSqliteStorage.FromFile(dataSource: SqliteStorageHelper.InMemoryDatabase, filter0);
 
@@ -131,4 +132,9 @@ public class BlockFilterSqliteStorageTests
 		removedRows = indexStorage.Clear();
 		Assert.False(removedRows);
 	}
+
+	private static FilterModel CreateFilterModel(uint blockHeight, uint256 blockHash, byte[] filterData, uint256 headerOrPrevBlockHash, long blockTime) =>
+		new (
+			new SmartHeader(blockHash, headerOrPrevBlockHash, blockHeight, blockTime),
+			new GolombRiceFilter(filterData, 20, 1 << 20));
 }

--- a/WalletWasabi.Tests/UnitTests/Wallet/FilterProcessor/BlockFilterIteratorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/FilterProcessor/BlockFilterIteratorTests.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
+using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Tests.UnitTests.Mocks;
 using WalletWasabi.Wallets.FilterProcessor;
 using Xunit;
@@ -23,10 +24,10 @@ public class BlockFilterIteratorTests
 	{
 		using CancellationTokenSource testCts = new(TimeSpan.FromMinutes(1));
 
-		FilterModel filter1 = FilterModel.Create(blockHeight: 610_001, blockHash: uint256.One, filterData: DummyFilterData, prevBlockHash: uint256.Zero, blockTime: 1231006505);
-		FilterModel filter2 = FilterModel.Create(blockHeight: 610_002, blockHash: new uint256(2), filterData: DummyFilterData, prevBlockHash: uint256.One, blockTime: 1231006506);
-		FilterModel filter3 = FilterModel.Create(blockHeight: 610_003, blockHash: new uint256(3), filterData: DummyFilterData, prevBlockHash: new uint256(2), blockTime: 1231006506);
-		FilterModel filter4 = FilterModel.Create(blockHeight: 610_004, blockHash: new uint256(4), filterData: DummyFilterData, prevBlockHash: new uint256(3), blockTime: 1231006506);
+		FilterModel filter1 = CreateFilterModel(blockHeight: 610_001, blockHash: uint256.One, filterData: DummyFilterData, headerOrPrevBlockHash: uint256.Zero, blockTime: 1231006505);
+		FilterModel filter2 = CreateFilterModel(blockHeight: 610_002, blockHash: new uint256(2), filterData: DummyFilterData, headerOrPrevBlockHash: uint256.One, blockTime: 1231006506);
+		FilterModel filter3 = CreateFilterModel(blockHeight: 610_003, blockHash: new uint256(3), filterData: DummyFilterData, headerOrPrevBlockHash: new uint256(2), blockTime: 1231006506);
+		FilterModel filter4 = CreateFilterModel(blockHeight: 610_004, blockHash: new uint256(4), filterData: DummyFilterData, headerOrPrevBlockHash: new uint256(3), blockTime: 1231006506);
 
 		var indexStore = new TesteableIndexStore
 		{
@@ -79,4 +80,9 @@ public class BlockFilterIteratorTests
 			Assert.Empty(filterIterator.Cache);
 		}
 	}
+
+	private static FilterModel CreateFilterModel(uint blockHeight, uint256 blockHash, byte[] filterData, uint256 headerOrPrevBlockHash, long blockTime) =>
+		new (
+			new SmartHeader(blockHash, headerOrPrevBlockHash, blockHeight, blockTime),
+			new GolombRiceFilter(filterData, 20, 1 << 20));
 }

--- a/WalletWasabi.Tests/UnitTests/Wallet/MockNode.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/MockNode.cs
@@ -105,18 +105,16 @@ public class MockNode
 				.Select(output => output.ScriptPubKey);
 
 			var scripts = inputScriptPubKeys.Union(outputScriptPubKeys);
-			var entries = scripts.Select(x => x.ToCompressedBytes()).DefaultIfEmpty(IndexBuilderService.DummyScript[0]);
+			var entries = scripts.Select(x => x.ToBytes()).DefaultIfEmpty(IndexBuilderService.DummyScript[0]);
 
 			var filter = new GolombRiceFilterBuilder()
-				.SetP(20)
-				.SetM(1 << 20)
 				.SetKey(block.GetHash())
 				.AddEntries(entries)
 				.Build();
 
 			var tipFilter = filters.Last();
-
-			var smartHeader = new SmartHeader(block.GetHash(), tipFilter.Header.BlockHash, tipFilter.Header.Height + 1, DateTimeOffset.UtcNow);
+			var header = filter.GetHeader(tipFilter.Header.HeaderOrPrevBlockHash);
+			var smartHeader = new SmartHeader(block.GetHash(), header, tipFilter.Header.Height + 1, DateTimeOffset.UtcNow);
 			filters.Add(new FilterModel(smartHeader, filter));
 		}
 

--- a/WalletWasabi/Backend/Models/FilterModel.cs
+++ b/WalletWasabi/Backend/Models/FilterModel.cs
@@ -2,7 +2,6 @@ using NBitcoin;
 using System.Text;
 using System.Threading;
 using WalletWasabi.Blockchain.Blocks;
-using WalletWasabi.Helpers;
 
 namespace WalletWasabi.Backend.Models;
 
@@ -10,20 +9,20 @@ public class FilterModel
 {
 	private readonly Lazy<GolombRiceFilter> _filter;
 
-	public FilterModel(SmartHeader header, GolombRiceFilter filter, bool isBip158 = false)
+	private static readonly uint256 MinimunValidBlockHash =
+		uint256.Parse("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+	public FilterModel(SmartHeader header, GolombRiceFilter filter)
 	{
 		Header = header;
 		_filter = new(filter);
-		FilterData = isBip158
-			? ByteHelpers.Combine(filter.ToBytes(), [0x86, 0x68])
-			: filter.ToBytes();
+		FilterData = filter.ToBytes();
 	}
 
 	private FilterModel(SmartHeader header, byte[] filterData)
 	{
 		Header = header;
 		FilterData = filterData;
-		var isBip158 = filterData is [.., 0x86, 0x68];
+		var isBip158 = header.HeaderOrPrevBlockHash > MinimunValidBlockHash;
 		_filter = new(() => isBip158
 			? new GolombRiceFilter(filterData)
 			: new GolombRiceFilter(filterData, 20, 1 << 20)

--- a/WalletWasabi/BitcoinRpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinRpc/RpcClientBase.cs
@@ -264,6 +264,5 @@ public class RpcClientBase : IRPCClient
 	{
 		return Rpc.CreateWalletAsync(walletNameOrPath, options, cancellationToken);
 	}
-
 	#endregion For Testing Only
 }

--- a/WalletWasabi/BitcoinRpc/RpcMonitor.cs
+++ b/WalletWasabi/BitcoinRpc/RpcMonitor.cs
@@ -1,39 +1,42 @@
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Bases;
-using WalletWasabi.Extensions;
+using WalletWasabi.Logging;
+using WalletWasabi.Services;
 
 namespace WalletWasabi.BitcoinRpc;
 
 public class RpcMonitor : PeriodicRunner
 {
-	private RpcStatus _rpcStatus;
+	private readonly EventBus _eventBus;
+	private readonly IRPCClient _rpcClient;
 
-	public RpcMonitor(TimeSpan period, IRPCClient rpcClient) : base(period)
+	public RpcMonitor(TimeSpan period, IRPCClient rpcClient, EventBus eventBus) : base(period)
 	{
-		_rpcStatus = RpcStatus.Connecting;
-		RpcClient = rpcClient;
+		_eventBus = eventBus;
+		_rpcClient = rpcClient;
 	}
 
-	public event EventHandler<RpcStatus>? RpcStatusChanged;
-
-	public IRPCClient RpcClient { get; set; }
-
-	public RpcStatus RpcStatus
-	{
-		get => _rpcStatus;
-		private set
-		{
-			if (value != _rpcStatus)
-			{
-				_rpcStatus = value;
-				RpcStatusChanged?.Invoke(this, value);
-			}
-		}
-	}
 
 	protected override async Task ActionAsync(CancellationToken cancel)
 	{
-		RpcStatus = await RpcClient.GetRpcStatusAsync(cancel).ConfigureAwait(false);
+		var rpcStatus = await GetRpcStatusAsync(cancel).ConfigureAwait(false);
+		_eventBus.Publish(new RpcStatusChanged(rpcStatus));
+	}
+
+
+	private async Task<RpcStatus> GetRpcStatusAsync(CancellationToken cancel)
+	{
+		try
+		{
+			var bci = await _rpcClient.GetBlockchainInfoAsync(cancel).ConfigureAwait(false);
+			var pi = await _rpcClient.GetPeersInfoAsync(cancel).ConfigureAwait(false);
+			return new RpcStatus.Responsive(bci.Headers, bci.Blocks, pi.Length, bci.BestBlockHash, bci.Pruned, bci.InitialBlockDownload);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException and not TimeoutException)
+		{
+			Logger.LogTrace(ex);
+			return new RpcStatus.Unresponsive();
+		}
 	}
 }

--- a/WalletWasabi/BitcoinRpc/RpcStatus.cs
+++ b/WalletWasabi/BitcoinRpc/RpcStatus.cs
@@ -4,22 +4,28 @@ namespace WalletWasabi.BitcoinRpc;
 
 public abstract record RpcStatus
 {
-	public record Unresponsive : RpcStatus;
+	public record Unresponsive : RpcStatus
+	{
+		public override string? ToString() => "is unresponsive";
+	}
 
-	public record Responsive(ulong Headers, ulong Blocks, int PeersCount, uint256 BestBlockHash, bool Pruned, bool InitialBlockDownload) : RpcStatus;
+	public record Responsive(
+		ulong Headers,
+		ulong Blocks,
+		int PeersCount,
+		uint256 BestBlockHash,
+		bool Pruned,
+		bool InitialBlockDownload) : RpcStatus
+	{
+		public override string? ToString() =>
+			(PeersCount, Synchronized) switch
+			{
+				(0, _) => "is connecting...",
+				(_, true) => "is synchronized",
+				(_, false) => "is synchronizing..."
+			};
+	}
+
 	public bool Synchronized => this is Responsive r && r.Blocks == r.Headers;
 
-	public override string ToString()
-	{
-		if (this is Responsive r)
-		{
-			if (r.PeersCount == 0)
-			{
-				return "is connecting...";
-			}
-
-			return Synchronized ? "is synchronized" : "is synchronizing...";
-		}
-		return "is unresponsive";
-	}
 }

--- a/WalletWasabi/Services/EventBus.cs
+++ b/WalletWasabi/Services/EventBus.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using System.Collections.Generic;
+using WalletWasabi.BitcoinRpc;
 using WalletWasabi.FeeRateEstimation;
-using WalletWasabi.Models;
 using WalletWasabi.Tor.StatusChecker;
 
 namespace WalletWasabi.Services;
@@ -99,4 +99,4 @@ public record TorConnectionStateChanged(bool IsTorRunning);
 public record TorNetworkStatusChanged(Issue[] ReportedIssues);
 public record BackendIncompatibilityDetected();
 
-
+public record RpcStatusChanged(RpcStatus Status);

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -99,9 +99,8 @@ public class BitcoinRpcFilterProvider(IRPCClient bitcoinRpcClient, EventBus even
 			var filterResponse = await bitcoinRpcClient.GetBlockFilterAsync(blockHash, cancellationToken).ConfigureAwait(false);
 
 			var filter = new FilterModel(
-				new SmartHeader(blockHash, filterResponse.Header, (uint)height, DateTimeOffset.UtcNow),
-				filterResponse.Filter,
-				isBip158: true);
+				new SmartHeader(blockHash, filterResponse.Header, height, DateTimeOffset.UtcNow),
+				filterResponse.Filter);
 
 			filters.Add(filter);
 		}

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -1,9 +1,13 @@
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Bases;
+using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Logging;
 using WalletWasabi.Stores;
@@ -12,77 +16,33 @@ using FiltersResponse = WalletWasabi.WebClients.Wasabi.FiltersResponse;
 
 namespace WalletWasabi.Services;
 
-public class WasabiSynchronizer(
-	TimeSpan period,
-	int maxFiltersToSync,
-	BitcoinStore bitcoinStore,
-	IHttpClientFactory httpClientFactory,
-	EventBus eventBus)
-	: PeriodicRunner(period)
+
+using FilterFetchingResult = Helpers.Result<FiltersResponse,FilterFetchingError>;
+
+public enum FilterFetchingError
 {
-	private readonly SmartHeaderChain _smartHeaderChain = bitcoinStore.SmartHeaderChain;
+	Continue,
+	ContinueAfter30Seconds
+}
+
+public interface ICompactFilterProvider
+{
+	Task<FilterFetchingResult> GetFiltersAsync(uint256 fromHash, uint fromHeight, CancellationToken cancellationToken);
+}
+
+public class WebApiFilterProvider(int maxFiltersToSync, IHttpClientFactory httpClientFactory, EventBus eventBus) : ICompactFilterProvider
+{
 	private readonly HttpClient _httpClient = httpClientFactory.CreateClient("long-live-satoshi-backend");
 
-	protected override async Task ActionAsync(CancellationToken cancel)
+	public async Task<FilterFetchingResult> GetFiltersAsync(uint256 fromHash, uint fromHeight, CancellationToken cancellationToken)
 	{
-		// Don't attempt synchronization without a valid tip hash
-		if (_smartHeaderChain.TipHash is null)
-		{
-			return;
-		}
 		var wasabiClient = new WasabiClient(_httpClient, eventBus);
 		var lastUsedApiVersion = WasabiClient.ApiVersion;
 
 		try
 		{
-			var response = await wasabiClient.GetFiltersAsync(_smartHeaderChain.TipHash, maxFiltersToSync, cancel)
+			return await wasabiClient.GetFiltersAsync(fromHash, maxFiltersToSync, cancellationToken)
 				.ConfigureAwait(false);
-
-			switch (response)
-			{
-				case FiltersResponse.AlreadyOnBestBlock:
-					// Already synchronized. Nothing to do.
-					var tip = _smartHeaderChain.TipHeight;
-					_smartHeaderChain.SetServerTipHeight(tip);
-					eventBus.Publish(new ServerTipHeightChanged((int) tip));
-					return;
-				case FiltersResponse.BestBlockUnknown:
-					// Reorg happened. Rollback the latest index.
-					FilterModel reorgedFilter = await bitcoinStore.IndexStore.TryRemoveLastFilterAsync().ConfigureAwait(false)
-						?? throw new InvalidOperationException("Fatal error: Failed to remove the reorged filter.");
-
-					Logger.LogInfo($"REORG Invalid Block: {reorgedFilter.Header.BlockHash}.");
-					break;
-				case FiltersResponse.NewFiltersAvailable newFiltersAvailable:
-					var hashChain = bitcoinStore.SmartHeaderChain;
-					hashChain.SetServerTipHeight((uint)newFiltersAvailable.BestHeight);
-					eventBus.Publish(new ServerTipHeightChanged(newFiltersAvailable.BestHeight));
-					var filters = newFiltersAvailable.Filters;
-					var firstFilter = filters.First();
-					if (hashChain.TipHeight + 1 != firstFilter.Header.Height)
-					{
-						// We have a problem.
-						// We have wrong filters, the heights are not in sync with the server's.
-						Logger.LogError($"Inconsistent index state detected.{Environment.NewLine}" +
-						                FormatInconsistencyDetails(hashChain, firstFilter));
-
-						await bitcoinStore.IndexStore.RemoveAllNewerThanAsync(hashChain.TipHeight).ConfigureAwait(false);
-					}
-					else
-					{
-						await bitcoinStore.IndexStore.AddNewFiltersAsync(filters).ConfigureAwait(false);
-
-						Logger.LogInfo(filters.Length == 1
-							? $"Downloaded filter for block {firstFilter.Header.Height}."
-							: $"Downloaded filters for blocks from {firstFilter.Header.Height} to {filters.Last().Header.Height}.");
-					}
-					break;
-				default:
-					throw new ArgumentOutOfRangeException(nameof(response));
-			}
-
-			TriggerRound();
-
 		}
 		catch (HttpRequestException ex)
 		{
@@ -90,7 +50,7 @@ public class WasabiSynchronizer(
 			{
 				// Backend API version might be updated meanwhile. Trying to update the versions.
 				var backendCompatible =
-					await CheckBackendCompatibilityAsync(wasabiClient, cancel).ConfigureAwait(false);
+					await CheckBackendCompatibilityAsync(wasabiClient, cancellationToken).ConfigureAwait(false);
 				if (!backendCompatible)
 				{
 					eventBus.Publish(new BackendIncompatibilityDetected());
@@ -100,14 +60,11 @@ public class WasabiSynchronizer(
 				if (backendCompatible && lastUsedApiVersion != WasabiClient.ApiVersion)
 				{
 					// Next request will be fine, do not throw exception.
-					TriggerRound();
-					return;
+					return FilterFetchingResult.Fail(FilterFetchingError.Continue);
 				}
 			}
 
-			await Task.Delay(3000, cancel).ConfigureAwait(false); // Retry sooner in case of connection error.
-			TriggerRound();
-			throw;
+			return FilterFetchingResult.Fail(FilterFetchingError.ContinueAfter30Seconds);
 		}
 	}
 
@@ -126,6 +83,115 @@ public class WasabiSynchronizer(
 
 		return backendCompatible;
 	}
+}
+
+public class BitcoinRpcFilterProvider(IRPCClient bitcoinRpcClient, EventBus eventBus) : ICompactFilterProvider
+{
+	public async Task<FilterFetchingResult> GetFiltersAsync(uint256 fromHash, uint fromHeight, CancellationToken cancellationToken)
+	{
+		var filters = new List<FilterModel>();
+		var currentHeight = await bitcoinRpcClient.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
+		var nbOfFiltersToFetch = Math.Min(1_000, currentHeight - fromHeight);
+		var stopAtHeight = fromHeight + nbOfFiltersToFetch;
+		for (var height = fromHeight+1; height <= stopAtHeight; height++)
+		{
+			var blockHash = await bitcoinRpcClient.GetBlockHashAsync((int)height, cancellationToken).ConfigureAwait(false);
+			var filterResponse = await bitcoinRpcClient.GetBlockFilterAsync(blockHash, cancellationToken).ConfigureAwait(false);
+
+			var filter = new FilterModel(
+				new SmartHeader(blockHash, filterResponse.Header, (uint)height, DateTimeOffset.UtcNow),
+				filterResponse.Filter,
+				isBip158: true);
+
+			filters.Add(filter);
+		}
+
+		return filters.Count == 0
+			? new FiltersResponse.AlreadyOnBestBlock()
+			: new FiltersResponse.NewFiltersAvailable(currentHeight, filters.ToArray());
+	}
+}
+
+public class WasabiSynchronizer(TimeSpan period, ICompactFilterProvider filtersProvider, BitcoinStore bitcoinStore, EventBus eventBus)
+	: PeriodicRunner(period)
+{
+	private readonly SmartHeaderChain _smartHeaderChain = bitcoinStore.SmartHeaderChain;
+
+	protected override async Task ActionAsync(CancellationToken cancel)
+	{
+		// Don't attempt synchronization without a valid tip hash
+		if (_smartHeaderChain.TipHash is null)
+		{
+			return;
+		}
+
+		var response =  await filtersProvider.GetFiltersAsync(_smartHeaderChain.TipHash, _smartHeaderChain.TipHeight, cancel)
+			.ConfigureAwait(false);
+
+		if (response.IsOk)
+		{
+			var isSynchronized = await ProcessFiltersAsync(response.Value).ConfigureAwait(false);
+			if (isSynchronized)
+			{
+				return;
+			}
+		}
+		else
+		{
+			var continueAfterSeconds = response.Error == FilterFetchingError.ContinueAfter30Seconds ? 30 : 0;
+			await Task.Delay(TimeSpan.FromSeconds(continueAfterSeconds), cancel).ConfigureAwait(false);
+		}
+		TriggerRound();
+	}
+
+	private async Task<bool> ProcessFiltersAsync(FiltersResponse response)
+	{
+		switch (response)
+		{
+			case FiltersResponse.AlreadyOnBestBlock:
+				// Already synchronized. Nothing to do.
+				var tip = _smartHeaderChain.TipHeight;
+				_smartHeaderChain.SetServerTipHeight(tip);
+				eventBus.Publish(new ServerTipHeightChanged((int) tip));
+				return true;
+			case FiltersResponse.BestBlockUnknown:
+				// Reorg happened. Rollback the latest index.
+				FilterModel reorgedFilter = await bitcoinStore.IndexStore.TryRemoveLastFilterAsync().ConfigureAwait(false)
+				                            ?? throw new InvalidOperationException("Fatal error: Failed to remove the reorged filter.");
+
+				Logger.LogInfo($"REORG Invalid Block: {reorgedFilter.Header.BlockHash}.");
+				break;
+			case FiltersResponse.NewFiltersAvailable newFiltersAvailable:
+				var hashChain = bitcoinStore.SmartHeaderChain;
+				hashChain.SetServerTipHeight((uint)newFiltersAvailable.BestHeight);
+				eventBus.Publish(new ServerTipHeightChanged(newFiltersAvailable.BestHeight));
+				var filters = newFiltersAvailable.Filters;
+				var firstFilter = filters.First();
+				if (hashChain.TipHeight + 1 != firstFilter.Header.Height)
+				{
+					// We have a problem.
+					// We have wrong filters, the heights are not in sync with the server's.
+					Logger.LogError($"Inconsistent index state detected.{Environment.NewLine}" +
+					                FormatInconsistencyDetails(hashChain, firstFilter));
+
+					await bitcoinStore.IndexStore.RemoveAllNewerThanAsync(hashChain.TipHeight).ConfigureAwait(false);
+				}
+				else
+				{
+					await bitcoinStore.IndexStore.AddNewFiltersAsync(filters).ConfigureAwait(false);
+
+					Logger.LogInfo(filters.Length == 1
+						? $"Downloaded filter for block {firstFilter.Header.Height}."
+						: $"Downloaded filters for blocks from {firstFilter.Header.Height} to {filters.Last().Header.Height}.");
+				}
+				break;
+			default:
+				throw new ArgumentOutOfRangeException(nameof(response));
+		}
+
+		return false;
+	}
+
 
 	private static string FormatInconsistencyDetails(SmartHeaderChain hashChain, FilterModel firstFilter)
 	{

--- a/WalletWasabi/Services/WasabiSynchronizer.cs
+++ b/WalletWasabi/Services/WasabiSynchronizer.cs
@@ -158,7 +158,7 @@ public class WasabiSynchronizer(TimeSpan period, ICompactFilterProvider filtersP
 				FilterModel reorgedFilter = await bitcoinStore.IndexStore.TryRemoveLastFilterAsync().ConfigureAwait(false)
 				                            ?? throw new InvalidOperationException("Fatal error: Failed to remove the reorged filter.");
 
-				Logger.LogInfo($"REORG Invalid Block: {reorgedFilter.Header.BlockHash}.");
+				Logger.LogInfo($"REORG Invalid Block: {reorgedFilter.Header.BlockHash}  Height {reorgedFilter.Header.Height}.");
 				break;
 			case FiltersResponse.NewFiltersAvailable newFiltersAvailable:
 				var hashChain = bitcoinStore.SmartHeaderChain;

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -298,7 +298,7 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 
 			// In case the previous filter is Bip158-compatible it should have passed the previous condition so, the
 			// received filter did match.
-			var lastFilter = IndexStorage.FetchLast(1).First();
+			var lastFilter = IndexStorage.Fetch(tip.Height, 1).First();
 			if (lastFilter.Filter.IsBip158())
 			{
 				return false;

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -283,10 +283,6 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 		{
 			return true;
 		}
-		//if(c.Tip is not {} tip )
-		//{
-		//	return m.Header == SmartHeader.GetStartingHeader(_network);
-		//}
 		if (m.Filter.IsBip158())
 		{
 			// We received a bip158-compatible filter, and it matches the tip's header, which means the previous filter

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -313,7 +313,7 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 			var previousFilter = IndexStorage.Fetch(tip.Height, 1).First();
 			if (previousFilter.Filter.IsBip158())
 			{
-				throw new InvalidOperationException("The received filter is not Wasabi filter while the previous one is a standard bip158 and it os not possible to verify the chain.");
+				throw new InvalidOperationException("The received filter is not Wasabi filter while the previous one is a standard bip158 and it is not possible to verify the chain.");
 			}
 
 			return false;

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -294,8 +294,8 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 
 			// In case the previous filter is Bip158-compatible it should have passed the previous condition so, the
 			// received filter did match.
-			var lastFilter = IndexStorage.Fetch(tip.Height, 1).First();
-			if (lastFilter.Filter.IsBip158())
+			var previousFilter = IndexStorage.Fetch(tip.Height, 1).First();
+			if (previousFilter.Filter.IsBip158())
 			{
 				return false;
 			}
@@ -303,17 +303,17 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 			// If we received a bip158-compatible filter for first time we accept it.
 			return true;
 		}
-		else
+		else // Non-standard Wasabi Filter
 		{
 			if (m.Header.HeaderOrPrevBlockHash == tip.BlockHash)
 			{
 				return true;
 			}
 
-			var lastFilter = IndexStorage.FetchLast(1).First();
-			if (lastFilter.Filter.IsBip158())
+			var previousFilter = IndexStorage.Fetch(tip.Height, 1).First();
+			if (previousFilter.Filter.IsBip158())
 			{
-				throw new InvalidOperationException("The received filter is not compatible with bip158.");
+				throw new InvalidOperationException("The received filter is not Wasabi filter while the previous one is a standard bip158 and it os not possible to verify the chain.");
 			}
 
 			return false;


### PR DESCRIPTION
# Abstraction of Filter Providers in WasabiSynchronizer

This PR creates a more modular architecture for `WasabiSynchronizer` by introducing a `CompactFilterProvider` abstraction, allowing different sources to supply compact filters to the client.

## Implementation Details

- Created a `ICompactFilterProvider` interface to decouple filter retrieval logic
- Implemented two concrete providers:
  - `WebApiFilterProvider`: Fetches filters from the Wasabi backend (existing functionality)
  - `BitcoinRpcFilterProvider`: Fetches filters directly from a Bitcoin Core node

## Key Benefits

- The client can now continue functioning without connecting to the Wasabi backend if a local Bitcoin node is available and properly configured
- Improved separation of concerns and testability
- Lays groundwork for future sources of filters like bitcoin p2p (bip 157) and standard compact filters from external source 

## Testing Instructions

1. Configure your Bitcoin Core node by adding `blockfilterindex=1` to your `bitcoin.conf` file
2. Enable the RPC connection in Wasabi by:
   - Setting `UseBitcoinRpc` to `true` in your `Config.json` file
   - Configuring the correct RPC credentials in the same file

## Status

This PR is currently in draft status and needs additional testing to verify the seamless transition between filter providers and evaluate performance characteristics.