### PR TITLE
Fix exchange rate tile update

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/Amount.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/Amount.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using NBitcoin;
 using WalletWasabi.Fluent.Helpers;
@@ -31,7 +32,9 @@ public class Amount
 	public Amount(Money money, IAmountProvider exchangeRateProvider)
 	{
 		Btc = money;
-		Usd = exchangeRateProvider.BtcToUsdExchangeRate.Select(x => x * Btc.ToDecimal(MoneyUnit.BTC));
+		Usd = exchangeRateProvider.BtcToUsdExchangeRate
+			.StartWith(exchangeRateProvider.UsdExchangeRate)
+			.Select(x => x * Btc.ToDecimal(MoneyUnit.BTC));
 		HasUsdBalance = Usd.Select(x => x != 0m);
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/BtcPriceTileViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/Tiles/BtcPriceTileViewModel.cs
@@ -1,13 +1,18 @@
+using System.Reactive.Linq;
+using ReactiveUI;
 using WalletWasabi.Fluent.Models.Wallets;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Home.Tiles;
 
-public class BtcPriceTileViewModel : ActivatableViewModel
+public partial class BtcPriceTileViewModel : ActivatableViewModel
 {
+	[AutoNotify] private decimal _usdPerBtc;
+
 	public BtcPriceTileViewModel(IAmountProvider amountProvider)
 	{
-		UsdPerBtc = amountProvider.BtcToUsdExchangeRate;
+		amountProvider.BtcToUsdExchangeRate
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.StartWith(amountProvider.UsdExchangeRate)
+			.Subscribe(x => UsdPerBtc = x);
 	}
-
-	public IObservable<decimal> UsdPerBtc { get; }
 }

--- a/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/BtcPriceTileView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/Tiles/BtcPriceTileView.axaml
@@ -13,6 +13,6 @@
                Classes="h2 monoSpaced bold"
                VerticalAlignment="Center" HorizontalAlignment="Center"
                TextAlignment="Center"
-               Text="{Binding UsdPerBtc^, Converter={x:Static converters:MoneyConverters.ToUsdFormatted}}" />
+               Text="{Binding UsdPerBtc, Converter={x:Static converters:MoneyConverters.ToUsdFormatted}}" />
   </TileControl>
 </UserControl>

--- a/WalletWasabi.Tests/UnitTests/ViewModels/AmountTests.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/AmountTests.cs
@@ -35,6 +35,6 @@ public class AmountTests
 		rates.Inject(exchangeRates);
 
 		// ASSERT
-		Assert.Equal(exchangeRates.Select(rate => rate * sut.Btc.ToDecimal(MoneyUnit.BTC)), destination);
+		Assert.Equal([0, 2, 4, 6], destination);
 	}
 }


### PR DESCRIPTION
Fix a bug introduced in https://github.com/WalletWasabi/WalletWasabi/pull/13793

> The exchange rate tile does not update after the logs say a new price has been fetched.

Ping @Kruwed could you confirm the fix works?