### PR TITLE
SLIP39 crypto

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Data/Slip39TestVectors.json
+++ b/WalletWasabi.Tests/UnitTests/Data/Slip39TestVectors.json
@@ -1,0 +1,406 @@
+[
+  [
+    "1. Valid mnemonic without sharing (128 bits)",
+    [
+      "duckling enlarge academic academic agency result length solution fridge kidney coal piece deal husband erode duke ajar critical decision keyboard"
+    ],
+    "bb54aac4b89dc868ba37d9cc21b2cece",
+    "xprv9s21ZrQH143K4QViKpwKCpS2zVbz8GrZgpEchMDg6KME9HZtjfL7iThE9w5muQA4YPHKN1u5VM1w8D4pvnjxa2BmpGMfXr7hnRrRHZ93awZ"
+  ],
+  [
+    "2. Mnemonic with invalid checksum (128 bits)",
+    [
+      "duckling enlarge academic academic agency result length solution fridge kidney coal piece deal husband erode duke ajar critical decision kidney"
+    ],
+    "",
+    ""
+  ],
+  [
+    "3. Mnemonic with invalid padding (128 bits)",
+    [
+      "duckling enlarge academic academic email result length solution fridge kidney coal piece deal husband erode duke ajar music cargo fitness"
+    ],
+    "",
+    ""
+  ],
+  [
+    "4. Basic sharing 2-of-3 (128 bits)",
+    [
+      "shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed",
+      "shadow pistol academic acid actress prayer class unknown daughter sweater depict flip twice unkind craft early superior advocate guest smoking"
+    ],
+    "b43ceb7e57a0ea8766221624d01b0864",
+    "xprv9s21ZrQH143K2nNuAbfWPHBtfiSCS14XQgb3otW4pX655q58EEZeC8zmjEUwucBu9dPnxdpbZLCn57yx45RBkwJHnwHFjZK4XPJ8SyeYjYg"
+  ],
+  [
+    "5. Basic sharing 2-of-3 (128 bits)",
+    [
+      "shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed"
+    ],
+    "",
+    ""
+  ],
+  [
+    "6. Mnemonics with different identifiers (128 bits)",
+    [
+      "adequate smoking academic acid debut wine petition glen cluster slow rhyme slow simple epidemic rumor junk tracks treat olympic tolerate",
+      "adequate stay academic agency agency formal party ting frequent learn upstairs remember smear leaf damage anatomy ladle market hush corner"
+    ],
+    "",
+    ""
+  ],
+  [
+    "7. Mnemonics with different iteration exponents (128 bits)",
+    [
+      "peasant leaves academic acid desert exact olympic math alive axle trial tackle drug deny decent smear dominant desert bucket remind",
+      "peasant leader academic agency cultural blessing percent network envelope medal junk primary human pumps jacket fragment payroll ticket evoke voice"
+    ],
+    "",
+    ""
+  ],
+  [
+    "8. Mnemonics with mismatching group thresholds (128 bits)",
+    [
+      "liberty category beard echo animal fawn temple briefing math username various wolf aviation fancy visual holy thunder yelp helpful payment",
+      "liberty category beard email beyond should fancy romp founder easel pink holy hairy romp loyalty material victim owner toxic custody",
+      "liberty category academic easy being hazard crush diminish oral lizard reaction cluster force dilemma deploy force club veteran expect photo"
+    ],
+    "",
+    ""
+  ],
+  [
+    "9. Mnemonics with mismatching group counts (128 bits)",
+    [
+      "average senior academic leaf broken teacher expect surface hour capture obesity desire negative dynamic dominant pistol mineral mailman iris aide",
+      "average senior academic agency curious pants blimp spew clothes slice script dress wrap firm shaft regular slavery negative theater roster"
+    ],
+    "",
+    ""
+  ],
+  [
+    "10. Mnemonics with greater group threshold than group counts (128 bits)",
+    [
+      "music husband acrobat acid artist finance center either graduate swimming object bike medical clothes station aspect spider maiden bulb welcome",
+      "music husband acrobat agency advance hunting bike corner density careful material civil evil tactics remind hawk discuss hobo voice rainbow",
+      "music husband beard academic black tricycle clock mayor estimate level photo episode exclude ecology papa source amazing salt verify divorce"
+    ],
+    "",
+    ""
+  ],
+  [
+    "11. Mnemonics with duplicate member indices (128 bits)",
+    [
+      "device stay academic always dive coal antenna adult black exceed stadium herald advance soldier busy dryer daughter evaluate minister laser",
+      "device stay academic always dwarf afraid robin gravity crunch adjust soul branch walnut coastal dream costume scholar mortgage mountain pumps"
+    ],
+    "",
+    ""
+  ],
+  [
+    "12. Mnemonics with mismatching member thresholds (128 bits)",
+    [
+      "hour painting academic academic device formal evoke guitar random modern justice filter withdraw trouble identify mailman insect general cover oven",
+      "hour painting academic agency artist again daisy capital beaver fiber much enjoy suitable symbolic identify photo editor romp float echo"
+    ],
+    "",
+    ""
+  ],
+  [
+    "13. Mnemonics giving an invalid digest (128 bits)",
+    [
+      "guilt walnut academic acid deliver remove equip listen vampire tactics nylon rhythm failure husband fatigue alive blind enemy teaspoon rebound",
+      "guilt walnut academic agency brave hamster hobo declare herd taste alpha slim criminal mild arcade formal romp branch pink ambition"
+    ],
+    "",
+    ""
+  ],
+  [
+    "14. Insufficient number of groups (128 bits, case 1)",
+    [
+      "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice"
+    ],
+    "",
+    ""
+  ],
+  [
+    "15. Insufficient number of groups (128 bits, case 2)",
+    [
+      "eraser senior decision scared cargo theory device idea deliver modify curly include pancake both news skin realize vitamins away join",
+      "eraser senior decision roster beard treat identify grumpy salt index fake aviation theater cubic bike cause research dragon emphasis counter"
+    ],
+    "",
+    ""
+  ],
+  [
+    "16. Threshold number of groups, but insufficient number of members in one group (128 bits)",
+    [
+      "eraser senior decision shadow artist work morning estate greatest pipeline plan ting petition forget hormone flexible general goat admit surface",
+      "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice"
+    ],
+    "",
+    ""
+  ],
+  [
+    "17. Threshold number of groups and members in each group (128 bits, case 1)",
+    [
+      "eraser senior decision roster beard treat identify grumpy salt index fake aviation theater cubic bike cause research dragon emphasis counter",
+      "eraser senior ceramic snake clay various huge numb argue hesitate auction category timber browser greatest hanger petition script leaf pickup",
+      "eraser senior ceramic shaft dynamic become junior wrist silver peasant force math alto coal amazing segment yelp velvet image paces",
+      "eraser senior ceramic round column hawk trust auction smug shame alive greatest sheriff living perfect corner chest sled fumes adequate",
+      "eraser senior decision smug corner ruin rescue cubic angel tackle skin skunk program roster trash rumor slush angel flea amazing"
+    ],
+    "7c3397a292a5941682d7a4ae2d898d11",
+    "xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV"
+  ],
+  [
+    "18. Threshold number of groups and members in each group (128 bits, case 2)",
+    [
+      "eraser senior decision smug corner ruin rescue cubic angel tackle skin skunk program roster trash rumor slush angel flea amazing",
+      "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice",
+      "eraser senior decision scared cargo theory device idea deliver modify curly include pancake both news skin realize vitamins away join"
+    ],
+    "7c3397a292a5941682d7a4ae2d898d11",
+    "xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV"
+  ],
+  [
+    "19. Threshold number of groups and members in each group (128 bits, case 3)",
+    [
+      "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice",
+      "eraser senior acrobat romp bishop medical gesture pumps secret alive ultimate quarter priest subject class dictate spew material endless market"
+    ],
+    "7c3397a292a5941682d7a4ae2d898d11",
+    "xprv9s21ZrQH143K3dzDLfeY3cMp23u5vDeFYftu5RPYZPucKc99mNEddU4w99GxdgUGcSfMpVDxhnR1XpJzZNXRN1m6xNgnzFS5MwMP6QyBRKV"
+  ],
+  [
+    "20. Valid mnemonic without sharing (256 bits)",
+    [
+      "theory painting academic academic armed sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips brave detect luck"
+    ],
+    "989baf9dcaad5b10ca33dfd8cc75e42477025dce88ae83e75a230086a0e00e92",
+    "xprv9s21ZrQH143K41mrxxMT2FpiheQ9MFNmWVK4tvX2s28KLZAhuXWskJCKVRQprq9TnjzzzEYePpt764csiCxTt22xwGPiRmUjYUUdjaut8RM"
+  ],
+  [
+    "21. Mnemonic with invalid checksum (256 bits)",
+    [
+      "theory painting academic academic armed sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips brave detect lunar"
+    ],
+    "",
+    ""
+  ],
+  [
+    "22. Mnemonic with invalid padding (256 bits)",
+    [
+      "theory painting academic academic campus sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips facility obtain sister"
+    ],
+    "",
+    ""
+  ],
+  [
+    "23. Basic sharing 2-of-3 (256 bits)",
+    [
+      "humidity disease academic always aluminum jewelry energy woman receiver strategy amuse duckling lying evidence network walnut tactics forget hairy rebound impulse brother survive clothes stadium mailman rival ocean reward venture always armed unwrap",
+      "humidity disease academic agency actress jacket gross physics cylinder solution fake mortgage benefit public busy prepare sharp friar change work slow purchase ruler again tricycle involve viral wireless mixture anatomy desert cargo upgrade"
+    ],
+    "c938b319067687e990e05e0da0ecce1278f75ff58d9853f19dcaeed5de104aae",
+    "xprv9s21ZrQH143K3a4GRMgK8WnawupkwkP6gyHxRsXnMsYPTPH21fWwNcAytijtfyftqNfiaY8LgQVdBQvHZ9FBvtwdjC7LCYxjYruJFuLzyMQ"
+  ],
+  [
+    "24. Basic sharing 2-of-3 (256 bits)",
+    [
+      "humidity disease academic always aluminum jewelry energy woman receiver strategy amuse duckling lying evidence network walnut tactics forget hairy rebound impulse brother survive clothes stadium mailman rival ocean reward venture always armed unwrap"
+    ],
+    "",
+    ""
+  ],
+  [
+    "25. Mnemonics with different identifiers (256 bits)",
+    [
+      "smear husband academic acid deadline scene venture distance dive overall parking bracelet elevator justice echo burning oven chest duke nylon",
+      "smear isolate academic agency alpha mandate decorate burden recover guard exercise fatal force syndrome fumes thank guest drift dramatic mule"
+    ],
+    "",
+    ""
+  ],
+  [
+    "26. Mnemonics with different iteration exponents (256 bits)",
+    [
+      "finger trash academic acid average priority dish revenue academic hospital spirit western ocean fact calcium syndrome greatest plan losing dictate",
+      "finger traffic academic agency building lilac deny paces subject threaten diploma eclipse window unknown health slim piece dragon focus smirk"
+    ],
+    "",
+    ""
+  ],
+  [
+    "27. Mnemonics with mismatching group thresholds (256 bits)",
+    [
+      "flavor pink beard echo depart forbid retreat become frost helpful juice unwrap reunion credit math burning spine black capital lair",
+      "flavor pink beard email diet teaspoon freshman identify document rebound cricket prune headset loyalty smell emission skin often square rebound",
+      "flavor pink academic easy credit cage raisin crazy closet lobe mobile become drink human tactics valuable hand capture sympathy finger"
+    ],
+    "",
+    ""
+  ],
+  [
+    "28. Mnemonics with mismatching group counts (256 bits)",
+    [
+      "column flea academic leaf debut extra surface slow timber husky lawsuit game behavior husky swimming already paper episode tricycle scroll",
+      "column flea academic agency blessing garbage party software stadium verify silent umbrella therapy decorate chemical erode dramatic eclipse replace apart"
+    ],
+    "",
+    ""
+  ],
+  [
+    "29. Mnemonics with greater group threshold than group counts (256 bits)",
+    [
+      "smirk pink acrobat acid auction wireless impulse spine sprinkle fortune clogs elbow guest hush loyalty crush dictate tracks airport talent",
+      "smirk pink acrobat agency dwarf emperor ajar organize legs slice harvest plastic dynamic style mobile float bulb health coding credit",
+      "smirk pink beard academic alto strategy carve shame language rapids ruin smart location spray training acquire eraser endorse submit peaceful"
+    ],
+    "",
+    ""
+  ],
+  [
+    "30. Mnemonics with duplicate member indices (256 bits)",
+    [
+      "fishing recover academic always device craft trend snapshot gums skin downtown watch device sniff hour clock public maximum garlic born",
+      "fishing recover academic always aircraft view software cradle fangs amazing package plastic evaluate intend penalty epidemic anatomy quarter cage apart"
+    ],
+    "",
+    ""
+  ],
+  [
+    "31. Mnemonics with mismatching member thresholds (256 bits)",
+    [
+      "evoke garden academic academic answer wolf scandal modern warmth station devote emerald market physics surface formal amazing aquatic gesture medical",
+      "evoke garden academic agency deal revenue knit reunion decrease magazine flexible company goat repair alarm military facility clogs aide mandate"
+    ],
+    "",
+    ""
+  ],
+  [
+    "32. Mnemonics giving an invalid digest (256 bits)",
+    [
+      "river deal academic acid average forbid pistol peanut custody bike class aunt hairy merit valid flexible learn ajar very easel",
+      "river deal academic agency camera amuse lungs numb isolate display smear piece traffic worthy year patrol crush fact fancy emission"
+    ],
+    "",
+    ""
+  ],
+  [
+    "33. Insufficient number of groups (256 bits, case 1)",
+    [
+      "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium"
+    ],
+    "",
+    ""
+  ],
+  [
+    "34. Insufficient number of groups (256 bits, case 2)",
+    [
+      "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
+      "wildlife deal decision smug ancestor genuine move huge cubic strategy smell game costume extend swimming false desire fake traffic vegan senior twice timber submit leader payroll fraction apart exact forward pulse tidy install"
+    ],
+    "",
+    ""
+  ],
+  [
+    "35. Threshold number of groups, but insufficient number of members in one group (256 bits)",
+    [
+      "wildlife deal decision shadow analysis adjust bulb skunk muscle mandate obesity total guitar coal gravity carve slim jacket ruin rebuild ancestor numerous hour mortgage require herd maiden public ceiling pecan pickup shadow club",
+      "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium"
+    ],
+    "",
+    ""
+  ],
+  [
+    "36. Threshold number of groups and members in each group (256 bits, case 1)",
+    [
+      "wildlife deal ceramic round aluminum pitch goat racism employer miracle percent math decision episode dramatic editor lily prospect program scene rebuild display sympathy have single mustang junction relate often chemical society wits estate",
+      "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
+      "wildlife deal ceramic scatter argue equip vampire together ruin reject literary rival distance aquatic agency teammate rebound false argue miracle stay again blessing peaceful unknown cover beard acid island language debris industry idle",
+      "wildlife deal ceramic snake agree voter main lecture axis kitchen physics arcade velvet spine idea scroll promise platform firm sharp patrol divorce ancestor fantasy forbid goat ajar believe swimming cowboy symbolic plastic spelling",
+      "wildlife deal decision shadow analysis adjust bulb skunk muscle mandate obesity total guitar coal gravity carve slim jacket ruin rebuild ancestor numerous hour mortgage require herd maiden public ceiling pecan pickup shadow club"
+    ],
+    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+    "xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c"
+  ],
+  [
+    "37. Threshold number of groups and members in each group (256 bits, case 2)",
+    [
+      "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
+      "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium",
+      "wildlife deal decision smug ancestor genuine move huge cubic strategy smell game costume extend swimming false desire fake traffic vegan senior twice timber submit leader payroll fraction apart exact forward pulse tidy install"
+    ],
+    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+    "xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c"
+  ],
+  [
+    "38. Threshold number of groups and members in each group (256 bits, case 3)",
+    [
+      "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium",
+      "wildlife deal acrobat romp anxiety axis starting require metric flexible geology game drove editor edge screw helpful have huge holy making pitch unknown carve holiday numb glasses survive already tenant adapt goat fangs"
+    ],
+    "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+    "xprv9s21ZrQH143K2UspC9FRPfQC9NcDB4HPkx1XG9UEtuceYtpcCZ6ypNZWdgfxQ9dAFVeD1F4Zg4roY7nZm2LB7THPD6kaCege3M7EuS8v85c"
+  ],
+  [
+    "39. Mnemonic with insufficient length",
+    [
+      "junk necklace academic academic acne isolate join hesitate lunar roster dough calcium chemical ladybug amount mobile glasses verify cylinder"
+    ],
+    "",
+    ""
+  ],
+  [
+    "40. Mnemonic with invalid master secret length",
+    [
+      "fraction necklace academic academic award teammate mouse regular testify coding building member verdict purchase blind camera duration email prepare spirit quarter"
+    ],
+    "",
+    ""
+  ],
+  [
+    "41. Valid mnemonics which can detect some errors in modular arithmetic",
+    [
+      "herald flea academic cage avoid space trend estate dryer hairy evoke eyebrow improve airline artwork garlic premium duration prevent oven",
+      "herald flea academic client blue skunk class goat luxury deny presence impulse graduate clay join blanket bulge survive dish necklace",
+      "herald flea academic acne advance fused brother frozen broken game ranked ajar already believe check install theory angry exercise adult"
+    ],
+    "ad6f2ad8b59bbbaa01369b9006208d9a",
+    "xprv9s21ZrQH143K2R4HJxcG1eUsudvHM753BZ9vaGkpYCoeEhCQx147C5qEcupPHxcXYfdYMwJmsKXrHDhtEwutxTTvFzdDCZVQwHneeQH8ioH"
+  ],
+  [
+    "42. Valid extendable mnemonic without sharing (128 bits)",
+    [
+      "testify swimming academic academic column loyalty smear include exotic bedroom exotic wrist lobe cover grief golden smart junior estimate learn"
+    ],
+    "1679b4516e0ee5954351d288a838f45e",
+    "xprv9s21ZrQH143K2w6eTpQnB73CU8Qrhg6gN3D66Jr16n5uorwoV7CwxQ5DofRPyok5DyRg4Q3BfHfCgJFk3boNRPPt1vEW1ENj2QckzVLQFXu"
+  ],
+  [
+    "43. Extendable basic sharing 2-of-3 (128 bits)",
+    [
+      "enemy favorite academic acid cowboy phrase havoc level response walnut budget painting inside trash adjust froth kitchen learn tidy punish",
+      "enemy favorite academic always academic sniff script carpet romp kind promise scatter center unfair training emphasis evening belong fake enforce"
+    ],
+    "48b1a4b80b8c209ad42c33672bdaa428",
+    "xprv9s21ZrQH143K4FS1qQdXYAFVAHiSAnjj21YAKGh2CqUPJ2yQhMmYGT4e5a2tyGLiVsRgTEvajXkxhg92zJ8zmWZas9LguQWz7WZShfJg6RS"
+  ],
+  [
+    "44. Valid extendable mnemonic without sharing (256 bits)",
+    [
+      "impulse calcium academic academic alcohol sugar lyrics pajamas column facility finance tension extend space birthday rainbow swimming purple syndrome facility trial warn duration snapshot shadow hormone rhyme public spine counter easy hawk album"
+    ],
+    "8340611602fe91af634a5f4608377b5235fa2d757c51d720c0c7656249a3035f",
+    "xprv9s21ZrQH143K2yJ7S8bXMiGqp1fySH8RLeFQKQmqfmmLTRwWmAYkpUcWz6M42oGoFMJRENmvsGQmunWTdizsi8v8fku8gpbVvYSiCYJTF1Y"
+  ],
+  [
+    "45. Extendable basic sharing 2-of-3 (256 bits)",
+    [
+      "western apart academic always artist resident briefing sugar woman oven coding club ajar merit pecan answer prisoner artist fraction amount desktop mild false necklace muscle photo wealthy alpha category unwrap spew losing making",
+      "western apart academic acid answer ancient auction flip image penalty oasis beaver multiple thunder problem switch alive heat inherit superior teaspoon explain blanket pencil numb lend punish endless aunt garlic humidity kidney observe"
+    ],
+    "8dc652d6d6cd370d8c963141f6d79ba440300f25c467302c1d966bff8f62300d",
+    "xprv9s21ZrQH143K2eFW2zmu3aayWWd6MJZBG7RebW35fiKcoCZ6jFi6U5gzffB9McDdiKTecUtRqJH9GzueCXiQK1LaQXdgthS8DgWfC8Uu3z7"
+  ]
+]

--- a/WalletWasabi.Tests/UnitTests/Wallets/ShamirMnemonicTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallets/ShamirMnemonicTests.cs
@@ -1,0 +1,256 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using WalletWasabi.Serialization;
+using WalletWasabi.Wallets.Slip39;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Wallets;
+
+using uint8 = byte;
+
+public class ShamirMnemonicTests
+{
+	private static readonly byte[] MS = "ABCDEFGHIJKLMNOP"u8.ToArray();
+
+	[Fact]
+	public void TestBasicSharingRandom()
+	{
+		byte[] secret = new byte[16];
+		new Random().NextBytes(secret);
+		var mnemonics = Shamir.Generate(1, [(3, 5)], secret);
+		Assert.Equal(
+			Shamir.Combine(mnemonics[..3]),
+			Shamir.Combine(mnemonics[2..])
+		);
+	}
+
+	[Fact]
+	public void TestBasicSharingFixed()
+	{
+		var mnemonics = Shamir.Generate(1, [(3, 5)], MS);
+		Assert.Equal(MS, Shamir.Combine(mnemonics[..3]));
+		Assert.Equal(MS, Shamir.Combine(mnemonics[1..4]));
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Combine(mnemonics[..2])
+		);
+	}
+
+	[Fact]
+	public void TestPassphrase()
+	{
+		var mnemonics = Shamir.Generate(1, [(3, 5)], MS, "TREZOR");
+		Assert.Equal(MS, Shamir.Combine(mnemonics[1..4], "TREZOR"));
+		Assert.NotEqual(MS, Shamir.Combine(mnemonics[1..4]));
+	}
+
+	[Fact]
+	public void TestNonExtendable()
+	{
+		var mnemonics = Shamir.Generate(1, [(3, 5)], MS, extendable: false);
+		Assert.Equal(MS, Shamir.Combine(mnemonics[1..4]));
+	}
+
+	[Fact]
+	public void TestIterationExponent()
+	{
+		var mnemonics = Shamir.Generate(1, [(3, 5)], MS, "TREZOR", iterationExponent: 1);
+		Assert.Equal(MS, Shamir.Combine(mnemonics[1..4], "TREZOR"));
+		Assert.NotEqual(MS, Shamir.Combine(mnemonics[1..4]));
+
+		mnemonics = Shamir.Generate(1, [(3, 5)], MS, "TREZOR", iterationExponent: 2);
+		Assert.Equal(MS, Shamir.Combine(mnemonics[1..4], "TREZOR"));
+		Assert.NotEqual(MS, Shamir.Combine(mnemonics[1..4]));
+	}
+
+	[Fact]
+	public void TestGroupSharing()
+	{
+		byte groupThreshold = 2;
+		byte[] groupSizes = [5, 3, 5, 1];
+		byte[] memberThresholds = [3, 2, 2, 1];
+		var shares = Shamir.Generate(groupThreshold, memberThresholds.Zip(groupSizes).ToArray(), MS);
+		var mnemonics = shares.GroupBy(x => x.GroupIndex).Select(x => x.ToArray()).ToArray();
+
+		// Test all valid combinations of mnemonics.
+		foreach (var groups in Combinations(mnemonics.Zip(memberThresholds, (a, b) => (Shares: a, MemberThreshold: b)),
+			         groupThreshold))
+		{
+			foreach (var group1Subset in Combinations(groups[0].Shares, groups[0].MemberThreshold))
+			{
+				foreach (var group2Subset in Combinations(groups[1].Shares, groups[1].MemberThreshold))
+				{
+					var mnemonicSubset = Utils.Concat(group1Subset, group2Subset);
+					mnemonicSubset = mnemonicSubset.OrderBy(x => Guid.NewGuid()).ToArray();
+					Assert.Equal(MS, Shamir.Combine(mnemonicSubset));
+				}
+			}
+		}
+
+		Assert.Equal(MS, Shamir.Combine([mnemonics[2][0], mnemonics[2][2], mnemonics[3][0]]));
+		Assert.Equal(MS, Shamir.Combine([mnemonics[2][3], mnemonics[3][0], mnemonics[2][4]]));
+
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Combine(Utils.Concat(mnemonics[0][2..], mnemonics[1][..1]))
+		);
+
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Combine(mnemonics[0][1..4])
+		);
+	}
+
+	[Fact]
+	public void TestGroupSharingThreshold1()
+	{
+		uint8 groupThreshold = 1;
+		uint8[] groupSizes = [5, 3, 5, 1];
+		uint8[] memberThresholds = [3, 2, 2, 1];
+		var shares = Shamir.Generate(groupThreshold, memberThresholds.Zip(groupSizes).ToArray(), MS);
+		var mnemonics = shares.GroupBy(x => x.GroupIndex).Select(x => x.ToArray()).ToArray();
+
+		foreach (var (group, memberThreshold) in mnemonics.Zip(memberThresholds, (g, t) => (g, t)))
+		{
+			foreach (var groupSubset in Combinations(group, memberThreshold))
+			{
+				var mnemonicSubset = groupSubset.OrderBy(_ => Guid.NewGuid()).ToArray();
+				Assert.Equal(MS, Shamir.Combine(mnemonicSubset));
+			}
+		}
+	}
+
+	[Fact]
+	public void TestAllGroupsExist()
+	{
+		foreach (var groupThreshold in new uint8[] {1, 2, 5})
+		{
+			var shares = Shamir.Generate(groupThreshold, [(3, 5), (1, 1), (2, 3), (2, 5), (3, 5)], MS);
+			var mnemonics = shares.GroupBy(x => x.GroupIndex).Select(x => x.ToArray()).ToArray();
+			Assert.Equal(5, mnemonics.Length);
+			Assert.Equal(19, mnemonics.Sum(g => g.Length));
+		}
+	}
+
+	[Fact]
+	public void TestInvalidSharing()
+	{
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Generate(1, [(2, 3)], MS.Take(14).ToArray())
+		);
+
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Generate(1, [(2, 3)], MS.Concat(new byte[] {0x58}).ToArray())
+		);
+
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Generate(3, [(3, 5), (2, 5)], MS)
+		);
+
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Generate(0, [(3, 5), (2, 5)], MS)
+		);
+
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Generate(2, [(3, 2), (2, 5)], MS)
+		);
+
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Generate(2, [(0, 2), (2, 5)], MS)
+		);
+
+		Assert.Throws<ArgumentException>(() =>
+			Shamir.Generate(2, [(3, 5), (1, 3), (2, 5)], MS)
+		);
+	}
+
+	[Theory]
+	[MemberData(nameof(Slip39TestVector.TestCasesData), MemberType = typeof(Slip39TestVector))]
+	public void TestVectors(Slip39TestVector test)
+	{
+		if (!string.IsNullOrEmpty(test.secretHex))
+		{
+			var shares = test.mnemonics.Select(Share.FromMnemonic).ToArray();
+			var secret = Shamir.Combine(shares, "TREZOR");
+			Assert.Equal(test.secretHex, Convert.ToHexString(secret).ToLower());
+
+			//Assert.Equal(new BIP32Key(secret).ExtendedKey(), xprv);
+		}
+		else
+		{
+			Assert.Throws<ArgumentException>(() =>
+			{
+				var shares = test.mnemonics.Select(Share.FromMnemonic).ToArray();
+				Shamir.Combine(shares);
+				Assert.Fail($"Failed to raise exception for test vector \"{test.description}\".");
+			});
+		}
+	}
+
+	public static T[][] Combinations<T>(IEnumerable<T> iterable, int r)
+	{
+		IEnumerable<IEnumerable<T>> InternalCombinations()
+		{
+			var pool = iterable.ToArray();
+			int n = pool.Length;
+			if (r > n)
+			{
+				yield break;
+			}
+
+			var indices = Enumerable.Range(0, r).ToArray();
+
+			yield return indices.Select(i => pool[i]);
+
+			while (true)
+			{
+				int i;
+				for (i = r - 1; i >= 0; i--)
+				{
+					if (indices[i] != i + n - r)
+					{
+						break;
+					}
+				}
+
+				if (i < 0)
+				{
+					yield break;
+				}
+
+				indices[i]++;
+				for (int j = i + 1; j < r; j++)
+				{
+					indices[j] = indices[j - 1] + 1;
+				}
+
+				yield return indices.Select(index => pool[index]);
+			}
+		}
+
+		return InternalCombinations().Select(x => x.ToArray()).ToArray();
+	}
+}
+
+public record Slip39TestVector(string description, string[] mnemonics, string secretHex, string xprv)
+{
+	private static readonly Decoder<Slip39TestVector> Slip39TestDecoder =
+		Decode.Tuple4(Decode.String, Decode.Array(Decode.String), Decode.String, Decode.String)
+			.AndThen(x => Decode.Succeed(new Slip39TestVector(x.d0, x.d1, x.d2, x.d3)));
+	private static IEnumerable<Slip39TestVector> VectorsData()
+	{
+		string vectorsJson = File.ReadAllText("./UnitTests/Data/Slip39TestVectors.json");
+		var fileDecoder = JsonDecoder.FromString(Decode.Array(Slip39TestDecoder));
+		return fileDecoder(vectorsJson).Match(
+			ts => ts,
+			e => throw new Exception($"Something went wrong: {e}")
+		);
+	}
+
+	private static readonly Slip39TestVector[] TestCases = VectorsData().ToArray();
+
+	public static IEnumerable<object[]> TestCasesData =>
+		TestCases.Select(testCase => new object[] {testCase});
+
+	public override string ToString() => description;
+
+}
+

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -59,6 +59,9 @@
 		<None Update="xunit.runner.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+		<None Update="UnitTests\Data\Slip39TestVectors.json">
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/WalletWasabi/Wallets/ShamirSecretSharing/BitStream.cs
+++ b/WalletWasabi/Wallets/ShamirSecretSharing/BitStream.cs
@@ -1,0 +1,198 @@
+namespace WalletWasabi.Wallets.Slip39;
+
+using System;
+using System.IO;
+
+class BitStream
+{
+	private byte[] _buffer;
+	private int _writePos;
+	private int _readPos;
+	private int _lengthInBits;
+
+	public BitStream(byte[] buffer)
+	{
+		var newBuffer = new byte[buffer.Length];
+		Buffer.BlockCopy(buffer, 0, newBuffer, 0, buffer.Length);
+		_buffer = newBuffer;
+		_readPos = 0;
+		_writePos = 0;
+		_lengthInBits = buffer.Length * 8;
+	}
+
+	public void WriteBit(bool bit)
+	{
+		EnsureCapacity();
+		if (bit)
+		{
+			_buffer[_writePos / 8] |= (byte)(1 << (8 - (_writePos % 8) - 1));
+		}
+		_writePos++;
+		_lengthInBits++;
+	}
+
+	public void WriteBits(ulong data, byte count)
+	{
+		data <<= (64 - count);
+		while (count >= 8)
+		{
+			var b = (byte)(data >> (64 - 8));
+			WriteByte(b);
+			data <<= 8;
+			count -= 8;
+		}
+
+		while (count > 0)
+		{
+			var bit = data >> (64 - 1);
+			WriteBit(bit == 1);
+			data <<= 1;
+			count--;
+		}
+	}
+
+	public void WriteByte(byte b)
+	{
+		EnsureCapacity();
+
+		var remainCount = (_writePos % 8);
+		var i = _writePos / 8;
+		_buffer[i] |= (byte)(b >> remainCount);
+
+		var written = (8 - remainCount);
+		_writePos += written;
+		_lengthInBits += written;
+
+		if (remainCount > 0)
+		{
+			EnsureCapacity();
+
+			_buffer[i + 1] = (byte)(b << (8 - remainCount));
+			_writePos += remainCount;
+			_lengthInBits += remainCount;
+		}
+	}
+
+	public bool TryReadBit(out bool bit)
+	{
+		bit = false;
+		if (_readPos == _lengthInBits)
+		{
+			return false;
+		}
+
+		var mask = 1 << (8 - (_readPos % 8) - 1);
+
+		bit = (_buffer[_readPos / 8] & mask) == mask;
+		_readPos++;
+		return true;
+	}
+
+	public bool TryReadBits(int count, out ulong bits)
+	{
+		var val = 0UL;
+		while (count >= 8)
+		{
+			val <<= 8;
+			if (!TryReadByte(out var readedByte))
+			{
+				bits = 0U;
+				return false;
+			}
+			val |= (ulong)readedByte;
+			count -= 8;
+		}
+
+		while (count > 0)
+		{
+			val <<= 1;
+			if (TryReadBit(out var bit))
+			{
+				val |= bit ? 1UL : 0UL;
+				count--;
+			}
+			else
+			{
+				bits = 0U;
+				return false;
+			}
+		}
+		bits = val;
+		return true;
+	}
+
+	public bool TryReadByte(out byte b)
+	{
+		b = 0;
+		if (_readPos == _lengthInBits)
+		{
+			return false;
+		}
+
+		var i = _readPos / 8;
+		var remainCount = _readPos % 8;
+		b = (byte)(_buffer[i] << remainCount);
+
+		if (remainCount > 0)
+		{
+			if (i + 1 == _buffer.Length)
+			{
+				b = 0;
+				return false;
+			}
+			b |= (byte)(_buffer[i + 1] >> (8 - remainCount));
+		}
+		_readPos += 8;
+		return true;
+	}
+
+	public byte[] ToByteArray()
+	{
+		var arraySize = (_writePos + 7) / 8;
+		var byteArray = new byte[arraySize];
+		Array.Copy(_buffer, byteArray, arraySize);
+		return byteArray;
+	}
+
+	public int Available => _lengthInBits - _readPos;
+
+	private void EnsureCapacity()
+	{
+		if (_writePos / 8 == _buffer.Length)
+		{
+			Array.Resize(ref _buffer, _buffer.Length + (4 * 1024));
+		}
+	}
+}
+
+class BitStreamReader(BitStream stream)
+{
+	public BitStreamReader(byte[] buffer)
+		: this(new BitStream(buffer))
+	{ }
+
+	public ulong Read(int count) =>
+		stream.TryReadBits(count, out var value)
+			? value
+			: throw new EndOfStreamException("There is not more bits to read.");
+
+	public byte ReadUint8(int count) => (byte)Read(count);
+
+	public ushort ReadUint16(int count) => (ushort)Read(count);
+
+	public bool CanRead(int count) => stream.Available >= count;
+	public bool EndOdStream => !CanRead(1);
+}
+
+class BitStreamWriter(BitStream stream)
+{
+	public BitStreamWriter()
+		: this(new BitStream(new byte[100]))
+	{ }
+
+	public void Write(ulong data, int count) =>
+		stream.WriteBits(data, (byte) count);
+
+	public byte[] ToByteArray() =>
+		stream.ToByteArray();
+}

--- a/WalletWasabi/Wallets/ShamirSecretSharing/Slip39.cs
+++ b/WalletWasabi/Wallets/ShamirSecretSharing/Slip39.cs
@@ -1,0 +1,655 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using uint8 = byte;
+using uint16 = ushort;
+using MemberData = (byte memberThreshold, byte memberIndex, byte[] value);
+
+namespace WalletWasabi.Wallets.Slip39;
+
+using Group = (uint8 memberThreshold, uint8 count);
+using ShareData = (uint8 memberIndex, uint8[] value);
+using CommonParameters = (uint16 id, uint8, uint8, Dictionary<uint8, List<MemberData>>);
+
+/// <summary>
+/// A class for implementing Shamir's Secret Sharing with SLIP-39 enhancements.
+/// </summary>
+public record Shamir
+{
+	private const int SECRET_INDEX = 255;
+	private const int DIGEST_INDEX = 254;
+	internal const int MIN_STRENGTH_BITS = 128;
+	private const int MAX_SHARE_COUNT = 16;
+	private const int DIGEST_LENGTH_BYTES = 4;
+	private const int BASE_ITERATION_COUNT = 10000;
+	private const int ROUND_COUNT = 4;
+
+	/// <summary>
+	/// Generates SLIP-39 shares from a given seed.
+	/// </summary>
+	/// <param name="group">A tuple that represent (groupThreshold, shareCount).</param>
+	/// <param name="seed">The secret to be split into shares.</param>
+	/// <param name="passphrase">The passphrase used for encryption.</param>
+	/// <param name="iterationExponent">Exponent to determine the number of iterations for the encryption algorithm.</param>
+	/// <param name="extendable"></param>
+	/// <returns>A list of shares that can be used to reconstruct the secret.</returns>
+	/// <exception cref="ArgumentException">Thrown when inputs do not meet the required constraints.</exception>
+	public static Share[] Generate(
+		Group group,
+		uint8[] seed,
+		string passphrase = "",
+		uint8 iterationExponent = 0,
+		bool extendable = true)
+	{
+		return Generate(1, [group], seed, passphrase, iterationExponent, extendable);
+	}
+
+	/// <summary>
+	/// Generates SLIP-39 shares from a given seed.
+	/// </summary>
+	/// <param name="groupThreshold">The number of groups required to reconstruct the secret.</param>
+	/// <param name="groups">Array of tuples where each tuple represents (groupThreshold, shareCount) for each group.</param>
+	/// <param name="seed">The secret to be split into shares.</param>
+	/// <param name="passphrase">The passphrase used for encryption.</param>
+	/// <param name="iterationExponent">Exponent to determine the number of iterations for the encryption algorithm.</param>
+	/// <param name="extendable"></param>
+	/// <returns>A list of shares that can be used to reconstruct the secret.</returns>
+	/// <exception cref="ArgumentException">Thrown when inputs do not meet the required constraints.</exception>
+	public static Share[] Generate(
+		uint8 groupThreshold,
+		Group[] groups,
+		uint8[] seed,
+		string passphrase = "",
+		uint8 iterationExponent = 0,
+		bool extendable = true)
+	{
+		var secret = seed;
+		// Validating seed strength and format
+		if (secret.Length * 8 < MIN_STRENGTH_BITS || secret.Length % 2 != 0)
+		{
+			throw new ArgumentException("master key entropy must be at least 128 bits and multiple of 16 bits");
+		}
+
+		// Validating group constraints
+		if (groupThreshold > MAX_SHARE_COUNT)
+		{
+			throw new ArgumentException("more than 16 groups are not supported");
+		}
+
+		if (groupThreshold > groups.Length)
+		{
+			throw new ArgumentException("group threshold should not exceed number of groups");
+		}
+
+		if (groups.Any(group => group is {memberThreshold: 1, count: > 1}))
+		{
+			throw new ArgumentException("can only generate one share for threshold = 1");
+		}
+
+		if (groups.Any(group => group.memberThreshold > group.count))
+		{
+			throw new ArgumentException("number of shares must not be less than threshold");
+		}
+
+		// Generate a random identifier
+		var id = (uint16) (BitConverter.ToUInt32(RandomNumberGenerator.GetBytes(4)) %
+		                   ((1 << (Share.ID_LENGTH_BITS + 1)) - 1));
+		var shares = new List<Share>();
+
+		// Encrypt the secret using the passphrase and identifier
+		var encryptedSecret = Encrypt(id, iterationExponent, secret, passphrase, extendable);
+
+		// Split the encrypted secret into group shares
+		var groupShares = SplitSecret(
+			groupThreshold,
+			(byte) groups.Length,
+			encryptedSecret);
+
+		// Split each group share into member shares and create the final share objects
+		foreach (var (groupIndex, groupShare) in groupShares)
+		{
+			var (memberThreshold, count) = groups[groupIndex];
+
+			var memberShares = SplitSecret(memberThreshold, count, groupShare);
+			foreach (var (memberIndex, value) in memberShares)
+			{
+				shares.Add(new Share(
+					id,
+					extendable,
+					iterationExponent,
+					groupIndex,
+					groupThreshold,
+					(byte) groups.Length,
+					memberIndex,
+					memberThreshold,
+					value));
+			}
+		}
+
+		return shares.ToArray();
+	}
+
+	/// <summary>
+	/// Combines shares to reconstruct the original secret.
+	/// </summary>
+	/// <param name="shares">The array of shares to combine.</param>
+	/// <param name="passphrase">The passphrase used for decrypting the shares.</param>
+	/// <param name="extendable"></param>
+	/// <returns>The reconstructed secret.</returns>
+	/// <exception cref="ArgumentException">Thrown when the shares are insufficient or invalid.</exception>
+	public static uint8[] Combine(Share[] shares, string passphrase = "")
+	{
+		// Preprocess the shares to extract group and member information
+		var (id, iterationExponent, groupThreshold, groups) = Preprocess(shares);
+
+		// Validating group constraints
+		if (groups.Count < groupThreshold)
+		{
+			throw new ArgumentException("need shares from more groups to reconstruct secret");
+		}
+
+		if (groups.Count != groupThreshold)
+		{
+			throw new ArgumentException("shares from too many groups");
+		}
+
+		if (groups.Any(group => group.Value[0].Item1 != group.Value.Count))
+		{
+			throw new ArgumentException("for every group, number of member shares should match member threshold");
+		}
+
+		if (groups.Any(group => group.Value.Select(v => v.memberThreshold).ToHashSet().Count > 1))
+		{
+			throw new ArgumentException("member threshold must be the same within a group");
+		}
+
+		// Recover secrets for each group and then combine them to get the final secret
+		var groupSecrets = new List<ShareData>();
+		foreach (var group in groups)
+		{
+			var recoveredSecret = RecoverSecret(group.Value[0].memberThreshold,
+				group.Value.Select(v => (v.memberIndex, v.value)).ToArray());
+			groupSecrets.Add((group.Key, recoveredSecret));
+		}
+
+		var finalRecoveredSecret = RecoverSecret(groupThreshold, groupSecrets.ToArray());
+
+		// Decrypt the secret using the passphrase
+		var decryptedSeed = Decrypt(id, iterationExponent, finalRecoveredSecret, passphrase, shares[0].Extendable);
+		return decryptedSeed;
+	}
+
+	/// <summary>
+	/// Preprocesses the shares to group them by group index and validate constraints.
+	/// </summary>
+	/// <param name="shares">The array of shares to preprocess.</param>
+	/// <returns>A tuple containing identifiers and group information for the shares.</returns>
+	/// <exception cref="ArgumentException">Thrown when the shares do not meet the required constraints.</exception>
+	private static CommonParameters Preprocess(Share[] shares)
+	{
+		if (shares.Length < 1)
+		{
+			throw new ArgumentException("need at least one share to reconstruct secret");
+		}
+
+		// Ensure all shares belong to the same secret
+		var identifiers = shares.Select(s => s.Id).ToHashSet();
+		if (identifiers.Count > 1)
+		{
+			throw new ArgumentException("shares do not belong to the same secret");
+		}
+
+		// Ensure all shares have the same iteration exponent, group threshold, and group count
+		var iterationExponents = shares.Select(s => s.IterationExponent).ToHashSet();
+		if (iterationExponents.Count > 1)
+		{
+			throw new ArgumentException("shares do not have the same iteration exponent");
+		}
+
+		var groupThresholds = shares.Select(s => s.GroupThreshold).ToHashSet();
+		if (groupThresholds.Count > 1)
+		{
+			throw new ArgumentException("shares do not have the same group threshold");
+		}
+
+		var groupCounts = shares.Select(s => s.GroupCount).ToHashSet();
+		if (groupCounts.Count > 1)
+		{
+			throw new ArgumentException("shares do not have the same group count");
+		}
+
+		if (shares.Any(s => s.GroupThreshold > s.GroupCount))
+		{
+			throw new ArgumentException("greater group threshold than group counts");
+		}
+
+		// Group the shares by group index
+		var groups = new Dictionary<uint8, List<MemberData>>();
+		foreach (var share in shares)
+		{
+			if (!groups.TryGetValue(share.GroupIndex, out var value))
+			{
+				value = new List<MemberData>();
+				groups[share.GroupIndex] = value;
+			}
+
+			value.Add((share.MemberThreshold, share.MemberIndex, share.Value.ToArray()));
+		}
+
+		return (identifiers.First(),
+			iterationExponents.First(),
+			groupThresholds.First(),
+			groups);
+	}
+
+	/// <summary>
+	/// Recovers the secret from a set of shares.
+	/// </summary>
+	/// <param name="threshold">The number of shares required to reconstruct the secret.</param>
+	/// <param name="shares">The shares to be used for reconstruction.</param>
+	/// <returns>The recovered secret.</returns>
+	/// <exception cref="ArgumentException">Thrown when the share digests are incorrect.</exception>
+	public static uint8[] RecoverSecret(uint8 threshold, ShareData[] shares)
+	{
+		// If the threshold is 1, simply return the first share's value
+		if (threshold == 1)
+		{
+			return shares[0].value;
+		}
+
+		// Interpolate the shares to recover the shared secret and digest
+		var sharedSecret = Interpolate(shares, SECRET_INDEX);
+		var digestShare = Interpolate(shares, DIGEST_INDEX);
+
+		// Verify the share digest. (poor-man constant-time comparison)
+		if (BitConverter.ToUInt32(ShareDigest(digestShare[DIGEST_LENGTH_BYTES..], sharedSecret)) !=
+		    BitConverter.ToUInt32(digestShare[..DIGEST_LENGTH_BYTES]))
+		{
+			throw new ArgumentException("share digest incorrect");
+		}
+
+		return sharedSecret;
+	}
+
+	private static ShareData[] SplitSecret(uint8 threshold, uint8 shareCount, uint8[] sharedSecret)
+	{
+		if (threshold < 1)
+		{
+			throw new ArgumentException("sharing threshold must be > 1");
+		}
+
+		if (shareCount > MAX_SHARE_COUNT)
+		{
+			throw new ArgumentException("too many shares");
+		}
+
+		if (threshold > shareCount)
+		{
+			throw new ArgumentException("number of shares should be at least equal threshold");
+		}
+
+		var shares = new List<ShareData>();
+
+		if (threshold == 1)
+		{
+			for (uint8 i = 0; i < shareCount; i++)
+			{
+				shares.Add((i, sharedSecret.ToArray()));
+			}
+
+			return shares.ToArray();
+		}
+
+		int randomSharesCount = Math.Max(threshold - 2, 0);
+
+		using var rng = RandomNumberGenerator.Create();
+		for (uint8 i = 0; i < randomSharesCount; i++)
+		{
+			var share = new uint8[sharedSecret.Length];
+			rng.GetBytes(share);
+			shares.Add((i, share));
+		}
+
+		var baseShares = new List<ShareData>(shares);
+		var randomPart = new uint8[sharedSecret.Length - DIGEST_LENGTH_BYTES];
+		rng.GetBytes(randomPart);
+
+		var digest = ShareDigest(randomPart, sharedSecret);
+		baseShares.Add((DIGEST_INDEX, Utils.Concat(digest, randomPart)));
+		baseShares.Add((SECRET_INDEX, sharedSecret));
+
+		for (uint8 i = (uint8) randomSharesCount; i < shareCount; i++)
+		{
+			var interpolatedShare = Interpolate(baseShares.ToArray(), i);
+			shares.Add((i, interpolatedShare));
+		}
+
+		return shares.ToArray();
+	}
+
+	private static uint8[] ShareDigest(uint8[] random, uint8[] sharedSecret)
+	{
+		using var hmac = new HMACSHA256(random);
+		var hash = hmac.ComputeHash(sharedSecret);
+		return hash[..4];
+	}
+
+	/// <summary>
+	/// Interpolates the shares to recover the secret.
+	/// </summary>
+	/// <param name="shares">The shares used for interpolation.</param>
+	/// <param name="x">The index of the value to interpolate (secret or digest).</param>
+	/// <returns>The interpolated value.</returns>
+	private static uint8[] Interpolate(ShareData[] shares, uint8 x)
+	{
+		var xCoordinates = shares.Select(share => share.memberIndex).ToHashSet();
+		if (xCoordinates.Count != shares.Length)
+		{
+			throw new ArgumentException("need unique shares for interpolation");
+		}
+
+		if (shares.Length < 1)
+		{
+			throw new ArgumentException("need at least one share for interpolation");
+		}
+
+		var len = shares[0].value.Length;
+		if (shares.Any(share => share.value.Length != len))
+		{
+			throw new ArgumentException("shares should have equal length");
+		}
+
+		if (xCoordinates.Contains(x))
+		{
+			return shares.First(share => share.memberIndex == x).value;
+		}
+
+		static int Mod255(int n)
+		{
+			while (n < 0)
+			{
+				n += 255;
+			}
+
+			return n % 255;
+		}
+
+		int logProd = shares
+			.Select(share => Log[share.memberIndex ^ x])
+			.Aggregate(0, (a, v) => a + v);
+
+		var result = new uint8[len];
+		foreach (var (i, share) in shares)
+		{
+			var logBasis = Mod255(
+				logProd - Log[i ^ x]
+				        - shares.Select(j => Log[j.Item1 ^ i]).Aggregate(0, (a, v) => a + v)
+			);
+
+			for (var k = 0; k < share.Length; k++)
+			{
+				result[k] ^= share[k] != 0 ? Exp[Mod255(Log[share[k]] + logBasis)] : (uint8) 0;
+			}
+		}
+
+		return result;
+	}
+
+	private static uint8[] Encrypt(uint16 identifier, uint8 iterationExponent, uint8[] master, string passphrase,
+		bool extendable) =>
+		Crypt(identifier, iterationExponent, master, [0, 1, 2, 3], CheckPassphrase(passphrase), extendable);
+
+	private static uint8[] Decrypt(uint16 identifier, uint8 iterationExponent, uint8[] master, string passphrase,
+		bool extendable) =>
+		Crypt(identifier, iterationExponent, master, [3, 2, 1, 0], CheckPassphrase(passphrase), extendable);
+
+	private static string CheckPassphrase(string passphrase) =>
+		passphrase.Any(char.IsControl)
+			? throw new NotSupportedException("Passphrase should only contain printable ASCII.")
+			: passphrase;
+
+	private static uint8[] Crypt(
+		uint16 identifier,
+		uint8 iterationExponent,
+		uint8[] masterSecret,
+		uint8[] range,
+		string passphrase,
+		bool extendable)
+	{
+		var len = masterSecret.Length / 2;
+		var left = masterSecret[..len];
+		var right = masterSecret[len..];
+		foreach (var i in range)
+		{
+			var f = Feistel(identifier, iterationExponent, i, right, passphrase, extendable);
+			(left, right) = (right, Xor(left, f));
+		}
+
+		return Utils.Concat(right, left);
+	}
+
+	private static uint8[] Feistel(uint16 id, uint8 iterationExponent, uint8 step, uint8[] block, string passphrase,
+		bool extendable)
+	{
+		var key = Utils.Concat([step], Encoding.UTF8.GetBytes(passphrase));
+		var saltPrefix = extendable ? [] : Utils.Concat("shamir"u8.ToArray(), [(uint8) (id >> 8), (uint8) (id & 0xff)]);
+		var salt = Utils.Concat(saltPrefix, block);
+		var iters = (BASE_ITERATION_COUNT / ROUND_COUNT) << iterationExponent;
+		using var pbkdf2 = new Rfc2898DeriveBytes(key, salt, iters, HashAlgorithmName.SHA256);
+		return pbkdf2.GetBytes(block.Length);
+	}
+
+	private static byte[] Xor(byte[] a, byte[] b)
+	{
+		byte[] result = new byte[a.Length];
+		for (int i = 0; i < a.Length; i++)
+		{
+			result[i] = (byte) (a[i] ^ b[i]);
+		}
+
+		return result;
+	}
+
+	private static readonly uint8[] Exp =
+	[
+		1, 3, 5, 15, 17, 51, 85, 255, 26, 46, 114, 150, 161, 248, 19, 53, 95, 225, 56, 72, 216,
+		115, 149, 164, 247, 2, 6, 10, 30, 34, 102, 170, 229, 52, 92, 228, 55, 89, 235, 38, 106,
+		190, 217, 112, 144, 171, 230, 49, 83, 245, 4, 12, 20, 60, 68, 204, 79, 209, 104, 184, 211,
+		110, 178, 205, 76, 212, 103, 169, 224, 59, 77, 215, 98, 166, 241, 8, 24, 40, 120, 136, 131,
+		158, 185, 208, 107, 189, 220, 127, 129, 152, 179, 206, 73, 219, 118, 154, 181, 196, 87,
+		249, 16, 48, 80, 240, 11, 29, 39, 105, 187, 214, 97, 163, 254, 25, 43, 125, 135, 146, 173,
+		236, 47, 113, 147, 174, 233, 32, 96, 160, 251, 22, 58, 78, 210, 109, 183, 194, 93, 231, 50,
+		86, 250, 21, 63, 65, 195, 94, 226, 61, 71, 201, 64, 192, 91, 237, 44, 116, 156, 191, 218,
+		117, 159, 186, 213, 100, 172, 239, 42, 126, 130, 157, 188, 223, 122, 142, 137, 128, 155,
+		182, 193, 88, 232, 35, 101, 175, 234, 37, 111, 177, 200, 67, 197, 84, 252, 31, 33, 99, 165,
+		244, 7, 9, 27, 45, 119, 153, 176, 203, 70, 202, 69, 207, 74, 222, 121, 139, 134, 145, 168,
+		227, 62, 66, 198, 81, 243, 14, 18, 54, 90, 238, 41, 123, 141, 140, 143, 138, 133, 148, 167,
+		242, 13, 23, 57, 75, 221, 124, 132, 151, 162, 253, 28, 36, 108, 180, 199, 82, 246,
+	];
+
+	private static readonly uint8[] Log =
+	[
+		0, 0, 25, 1, 50, 2, 26, 198, 75, 199, 27, 104, 51, 238, 223, 3, 100, 4, 224, 14, 52, 141,
+		129, 239, 76, 113, 8, 200, 248, 105, 28, 193, 125, 194, 29, 181, 249, 185, 39, 106, 77,
+		228, 166, 114, 154, 201, 9, 120, 101, 47, 138, 5, 33, 15, 225, 36, 18, 240, 130, 69, 53,
+		147, 218, 142, 150, 143, 219, 189, 54, 208, 206, 148, 19, 92, 210, 241, 64, 70, 131, 56,
+		102, 221, 253, 48, 191, 6, 139, 98, 179, 37, 226, 152, 34, 136, 145, 16, 126, 110, 72, 195,
+		163, 182, 30, 66, 58, 107, 40, 84, 250, 133, 61, 186, 43, 121, 10, 21, 155, 159, 94, 202,
+		78, 212, 172, 229, 243, 115, 167, 87, 175, 88, 168, 80, 244, 234, 214, 116, 79, 174, 233,
+		213, 231, 230, 173, 232, 44, 215, 117, 122, 235, 22, 11, 245, 89, 203, 95, 176, 156, 169,
+		81, 160, 127, 12, 246, 111, 23, 196, 73, 236, 216, 67, 31, 45, 164, 118, 123, 183, 204,
+		187, 62, 90, 251, 96, 177, 134, 59, 82, 161, 108, 170, 85, 41, 157, 151, 178, 135, 144, 97,
+		190, 220, 252, 188, 149, 207, 205, 55, 63, 91, 209, 83, 57, 132, 60, 65, 162, 109, 71, 20,
+		42, 158, 93, 86, 242, 211, 171, 68, 17, 146, 217, 35, 32, 46, 137, 180, 124, 184, 38, 119,
+		153, 227, 165, 103, 74, 237, 222, 197, 49, 254, 24, 13, 99, 140, 128, 192, 247, 112, 7,
+	];
+}
+
+public record Share(
+	uint16 Id,
+	bool Extendable,
+	uint8 IterationExponent,
+	uint8 GroupIndex,
+	uint8 GroupThreshold,
+	uint8 GroupCount,
+	uint8 MemberIndex,
+	uint8 MemberThreshold,
+	uint8[] Value)
+{
+	private static int Bits2Words(int n) => (n + RADIX_BITS - 1) / RADIX_BITS;
+	internal const int ID_LENGTH_BITS = 15;
+	private const int RADIX_BITS = 10;
+
+	private static int ID_EXP_LENGTH_WORDS =
+		Bits2Words(ID_LENGTH_BITS + EXTENDABLE_FLAG_LENGTH_BITS + ITERATION_EXP_LENGTH_BITS);
+
+	private const int EXTENDABLE_FLAG_LENGTH_BITS = 1;
+	private const int ITERATION_EXP_LENGTH_BITS = 4;
+	private const int CHECKSUM_LENGTH_WORDS = 3;
+	private static int GROUP_PREFIX_LENGTH_WORDS = ID_EXP_LENGTH_WORDS + 1;
+	private static int METADATA_LENGTH_WORDS = ID_EXP_LENGTH_WORDS + 2 + CHECKSUM_LENGTH_WORDS;
+	private static int MIN_MNEMONIC_LENGTH_WORDS = METADATA_LENGTH_WORDS + Bits2Words(Shamir.MIN_STRENGTH_BITS);
+
+	public static Share FromMnemonic(string mnemonic)
+	{
+		var words = WordList.MnemonicToIndices(mnemonic);
+
+		if (words.Length < MIN_MNEMONIC_LENGTH_WORDS)
+		{
+			throw new ArgumentException(
+				$"Invalid mnemonic length. The length of each mnemonic must be at least {MIN_MNEMONIC_LENGTH_WORDS} words.");
+		}
+
+		var prefix = WordsToBytes(words[..(ID_EXP_LENGTH_WORDS + 2)]);
+		var prefixReader = new BitStreamReader(prefix);
+		var id = prefixReader.ReadUint16(ID_LENGTH_BITS);
+		var extendable = prefixReader.ReadUint8(EXTENDABLE_FLAG_LENGTH_BITS) == 1;
+
+		if (Checksum(words, extendable) != 1)
+		{
+			throw new ArgumentException(
+				$"Invalid mnemonic checksum for \"{string.Join(" ", mnemonic.Split().Take(ID_EXP_LENGTH_WORDS + 2))} ...\".");
+		}
+
+		var paddingLen = RADIX_BITS * (words.Length - METADATA_LENGTH_WORDS) % 16;
+		if (paddingLen > 8)
+		{
+			throw new ArgumentException("Invalid mnemonic length.");
+		}
+
+		var paddedValue = WordsToBytes(words[(ID_EXP_LENGTH_WORDS + 2)..^CHECKSUM_LENGTH_WORDS]);
+		var valueReader = new BitStreamReader(paddedValue);
+		if (valueReader.Read(paddingLen) != 0)
+		{
+			throw new ArgumentException("Invalid padding.");
+		}
+
+		var value = new List<uint8>();
+		while (valueReader.CanRead(8))
+		{
+			value.Add(valueReader.ReadUint8(8));
+		}
+
+		return new Share(
+			Id: id,
+			Extendable: extendable,
+			IterationExponent: prefixReader.ReadUint8(ITERATION_EXP_LENGTH_BITS),
+			GroupIndex: prefixReader.ReadUint8(4),
+			GroupThreshold: (uint8) (prefixReader.ReadUint8(4) + 1),
+			GroupCount: (uint8) (prefixReader.ReadUint8(4) + 1),
+			MemberIndex: prefixReader.ReadUint8(4),
+			MemberThreshold: (uint8) (prefixReader.ReadUint8(4) + 1),
+			Value: value.ToArray()
+		);
+	}
+
+	public string ToMnemonic(string[] wordlist)
+	{
+		var prefixWriter = new BitStreamWriter();
+		prefixWriter.Write(Id, ID_LENGTH_BITS);
+		prefixWriter.Write(Extendable ? 1ul : 0, EXTENDABLE_FLAG_LENGTH_BITS);
+		prefixWriter.Write(IterationExponent, ITERATION_EXP_LENGTH_BITS);
+		prefixWriter.Write(GroupIndex, 4);
+		prefixWriter.Write((uint8) (GroupThreshold - 1), 4);
+		prefixWriter.Write((uint8) (GroupCount - 1), 4);
+		prefixWriter.Write(MemberIndex, 4);
+		prefixWriter.Write((uint8) (MemberThreshold - 1), 4);
+		var valueWordCount = (8 * Value.Length + RADIX_BITS - 1) / RADIX_BITS;
+		var padding = valueWordCount * RADIX_BITS - Value.Length * 8;
+
+		var valueWriter = new BitStreamWriter();
+		valueWriter.Write(0, padding);
+		foreach (var b in Value)
+		{
+			valueWriter.Write(b, 8);
+		}
+
+		var bytes = Utils.Concat(prefixWriter.ToByteArray(), valueWriter.ToByteArray());
+		var words = Utils.Concat(BytesToWords(bytes), new uint16[] {0, 0, 0});
+		var chk = Checksum(words, Extendable) ^ 1;
+		var len = words.Length;
+		for (var i = 0; i < 3; i++)
+		{
+			words[len - 3 + i] = (uint16) ((chk >> (RADIX_BITS * (2 - i))) & 1023);
+		}
+
+		return string.Join(" ", words.Select(i => wordlist[i]));
+	}
+
+	private static uint16[] BytesToWords(uint8[] bytes)
+	{
+		var words = new List<uint16>();
+		var reader = new BitStreamReader(bytes);
+		while (!reader.EndOdStream)
+		{
+			words.Add(reader.ReadUint16(10));
+		}
+
+		return words.ToArray();
+	}
+
+	private static byte[] WordsToBytes(ushort[] words)
+	{
+		var writer = new BitStreamWriter();
+
+		foreach (var word in words)
+		{
+			writer.Write(word, 10);
+		}
+
+		return writer.ToByteArray();
+	}
+
+	private static readonly uint8[] CustomizationStringOrig = "shamir"u8.ToArray();
+	private static readonly uint8[] CustomizationStringExtendable = "shamir_extendable"u8.ToArray();
+
+	private static int Checksum(uint16[] values, bool extendable)
+	{
+		var gen = new[]
+		{
+			0x00E0E040, 0x01C1C080, 0x03838100, 0x07070200, 0x0E0E0009,
+			0x1C0C2412, 0x38086C24, 0x3090FC48, 0x21B1F890, 0x03F3F120,
+		};
+
+		var chk = 1;
+		var customizationString = extendable ? CustomizationStringExtendable : CustomizationStringOrig;
+		foreach (var v in customizationString.Select(x => (uint16) x).Concat(values))
+		{
+			var b = chk >> 20;
+			chk = ((chk & 0xFFFFF) << 10) ^ v;
+			for (var i = 0; i < 10; i++)
+			{
+				chk ^= ((b >> i) & 1) != 0 ? gen[i] : 0;
+			}
+		}
+
+		return chk;
+	}
+}
+
+public static class Utils
+{
+	public static T[] Concat<T>(params T[][] arrays) =>
+		arrays.SelectMany(x => x).ToArray();
+}

--- a/WalletWasabi/Wallets/ShamirSecretSharing/WordList.cs
+++ b/WalletWasabi/Wallets/ShamirSecretSharing/WordList.cs
@@ -1,0 +1,163 @@
+namespace WalletWasabi.Wallets.Slip39;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class WordList
+{
+	private static readonly string[] Wordlist;
+	private static readonly Dictionary<string, ushort> WordIndexMap;
+
+	static WordList()
+	{
+		Wordlist = LoadWordlist();
+		WordIndexMap = Wordlist
+			.Select((word, i) => new {word, i})
+			.ToDictionary(x => x.word, x => (ushort) x.i);
+	}
+
+	private static string[] LoadWordlist()
+	{
+		var wordlist = new[]
+			{
+			"academic", "acid", "acne", "acquire", "acrobat", "activity", "actress", "adapt", "adequate", "adjust",
+			"admit", "adorn", "adult", "advance", "advocate", "afraid", "again", "agency", "agree", "aide",
+			"aircraft", "airline", "airport", "ajar", "alarm", "album", "alcohol", "alien", "alive", "alpha",
+			"already", "alto", "aluminum", "always", "amazing", "ambition", "amount", "amuse", "analysis", "anatomy",
+			"ancestor", "ancient", "angel", "angry", "animal", "answer", "antenna", "anxiety", "apart", "aquatic",
+			"arcade", "arena", "argue", "armed", "artist", "artwork", "aspect", "auction", "august", "aunt",
+			"average", "aviation", "avoid", "award", "away", "axis", "axle", "beam", "beard", "beaver",
+			"become", "bedroom", "behavior", "being", "believe", "belong", "benefit", "best", "beyond", "bike",
+			"biology", "birthday", "bishop", "black", "blanket", "blessing", "blimp", "blind", "blue", "body",
+			"bolt", "boring", "born", "both", "boundary", "bracelet", "branch", "brave", "breathe", "briefing",
+			"broken", "brother", "browser", "bucket", "budget", "building", "bulb", "bulge", "bumpy", "bundle",
+			"burden", "burning", "busy", "buyer", "cage", "calcium", "camera", "campus", "canyon", "capacity",
+			"capital", "capture", "carbon", "cards", "careful", "cargo", "carpet", "carve", "category", "cause",
+			"ceiling", "center", "ceramic", "champion", "change", "charity", "check", "chemical", "chest", "chew",
+			"chubby", "cinema", "civil", "class", "clay", "cleanup", "client", "climate", "clinic", "clock",
+			"clogs", "closet", "clothes", "club", "cluster", "coal", "coastal", "coding", "column", "company",
+			"corner", "costume", "counter", "course", "cover", "cowboy", "cradle", "craft", "crazy", "credit",
+			"cricket", "criminal", "crisis", "critical", "crowd", "crucial", "crunch", "crush", "crystal", "cubic",
+			"cultural", "curious", "curly", "custody", "cylinder", "daisy", "damage", "dance", "darkness", "database",
+			"daughter", "deadline", "deal", "debris", "debut", "decent", "decision", "declare", "decorate", "decrease",
+			"deliver", "demand", "density", "deny", "depart", "depend", "depict", "deploy", "describe", "desert",
+			"desire", "desktop", "destroy", "detailed", "detect", "device", "devote", "diagnose", "dictate", "diet",
+			"dilemma", "diminish", "dining", "diploma", "disaster", "discuss", "disease", "dish", "dismiss", "display",
+			"distance", "dive", "divorce", "document", "domain", "domestic", "dominant", "dough", "downtown", "dragon",
+			"dramatic", "dream", "dress", "drift", "drink", "drove", "drug", "dryer", "duckling", "duke",
+			"duration", "dwarf", "dynamic", "early", "earth", "easel", "easy", "echo", "eclipse", "ecology",
+			"edge", "editor", "educate", "either", "elbow", "elder", "election", "elegant", "element", "elephant",
+			"elevator", "elite", "else", "email", "emerald", "emission", "emperor", "emphasis", "employer", "empty",
+			"ending", "endless", "endorse", "enemy", "energy", "enforce", "engage", "enjoy", "enlarge", "entrance",
+			"envelope", "envy", "epidemic", "episode", "equation", "equip", "eraser", "erode", "escape", "estate",
+			"estimate", "evaluate", "evening", "evidence", "evil", "evoke", "exact", "example", "exceed", "exchange",
+			"exclude", "excuse", "execute", "exercise", "exhaust", "exotic", "expand", "expect", "explain", "express",
+			"extend", "extra", "eyebrow", "facility", "fact", "failure", "faint", "fake", "false", "family",
+			"famous", "fancy", "fangs", "fantasy", "fatal", "fatigue", "favorite", "fawn", "fiber", "fiction",
+			"filter", "finance", "findings", "finger", "firefly", "firm", "fiscal", "fishing", "fitness", "flame",
+			"flash", "flavor", "flea", "flexible", "flip", "float", "floral", "fluff", "focus", "forbid",
+			"force", "forecast", "forget", "formal", "fortune", "forward", "founder", "fraction", "fragment",
+			"frequent",
+			"freshman", "friar", "fridge", "friendly", "frost", "froth", "frozen", "fumes", "funding", "furl",
+			"fused", "galaxy", "game", "garbage", "garden", "garlic", "gasoline", "gather", "general", "genius",
+			"genre", "genuine", "geology", "gesture", "glad", "glance", "glasses", "glen", "glimpse", "goat",
+			"golden", "graduate", "grant", "grasp", "gravity", "gray", "greatest", "grief", "grill", "grin",
+			"grocery", "gross", "group", "grownup", "grumpy", "guard", "guest", "guilt", "guitar", "gums",
+			"hairy", "hamster", "hand", "hanger", "harvest", "have", "havoc", "hawk", "hazard", "headset",
+			"health", "hearing", "heat", "helpful", "herald", "herd", "hesitate", "hobo", "holiday", "holy",
+			"home", "hormone", "hospital", "hour", "huge", "human", "humidity", "hunting", "husband", "hush",
+			"husky", "hybrid", "idea", "identify", "idle", "image", "impact", "imply", "improve", "impulse",
+			"include", "income", "increase", "index", "indicate", "industry", "infant", "inform", "inherit", "injury",
+			"inmate", "insect", "inside", "install", "intend", "intimate", "invasion", "involve", "iris", "island",
+			"isolate", "item", "ivory", "jacket", "jerky", "jewelry", "join", "judicial", "juice", "jump",
+			"junction", "junior", "junk", "jury", "justice", "kernel", "keyboard", "kidney", "kind", "kitchen",
+			"knife", "knit", "laden", "ladle", "ladybug", "lair", "lamp", "language", "large", "laser",
+			"laundry", "lawsuit", "leader", "leaf", "learn", "leaves", "lecture", "legal", "legend", "legs",
+			"lend", "length", "level", "liberty", "library", "license", "lift", "likely", "lilac", "lily",
+			"lips", "liquid", "listen", "literary", "living", "lizard", "loan", "lobe", "location", "losing",
+			"loud", "loyalty", "luck", "lunar", "lunch", "lungs", "luxury", "lying", "lyrics", "machine",
+			"magazine", "maiden", "mailman", "main", "makeup", "making", "mama", "manager", "mandate", "mansion",
+			"manual", "marathon", "march", "market", "marvel", "mason", "material", "math", "maximum", "mayor",
+			"meaning", "medal", "medical", "member", "memory", "mental", "merchant", "merit", "method", "metric",
+			"midst", "mild", "military", "mineral", "minister", "miracle", "mixed", "mixture", "mobile", "modern",
+			"modify", "moisture", "moment", "morning", "mortgage", "mother", "mountain", "mouse", "move", "much",
+			"mule", "multiple", "muscle", "museum", "music", "mustang", "nail", "national", "necklace", "negative",
+			"nervous", "network", "news", "nuclear", "numb", "numerous", "nylon", "oasis", "obesity", "object",
+			"observe", "obtain", "ocean", "often", "olympic", "omit", "oral", "orange", "orbit", "order",
+			"ordinary", "organize", "ounce", "oven", "overall", "owner", "paces", "pacific", "package", "paid",
+			"painting", "pajamas", "pancake", "pants", "papa", "paper", "parcel", "parking", "party", "patent",
+			"patrol", "payment", "payroll", "peaceful", "peanut", "peasant", "pecan", "penalty", "pencil", "percent",
+			"perfect", "permit", "petition", "phantom", "pharmacy", "photo", "phrase", "physics", "pickup", "picture",
+			"piece", "pile", "pink", "pipeline", "pistol", "pitch", "plains", "plan", "plastic", "platform",
+			"playoff", "pleasure", "plot", "plunge", "practice", "prayer", "preach", "predator", "pregnant", "premium",
+			"prepare", "presence", "prevent", "priest", "primary", "priority", "prisoner", "privacy", "prize",
+			"problem",
+			"process", "profile", "program", "promise", "prospect", "provide", "prune", "public", "pulse", "pumps",
+			"punish", "puny", "pupal", "purchase", "purple", "python", "quantity", "quarter", "quick", "quiet",
+			"race", "racism", "radar", "railroad", "rainbow", "raisin", "random", "ranked", "rapids", "raspy",
+			"reaction", "realize", "rebound", "rebuild", "recall", "receiver", "recover", "regret", "regular", "reject",
+			"relate", "remember", "remind", "remove", "render", "repair", "repeat", "replace", "require", "rescue",
+			"research", "resident", "response", "result", "retailer", "retreat", "reunion", "revenue", "review",
+			"reward",
+			"rhyme", "rhythm", "rich", "rival", "river", "robin", "rocky", "romantic", "romp", "roster",
+			"round", "royal", "ruin", "ruler", "rumor", "sack", "safari", "salary", "salon", "salt",
+			"satisfy", "satoshi", "saver", "says", "scandal", "scared", "scatter", "scene", "scholar", "science",
+			"scout", "scramble", "screw", "script", "scroll", "seafood", "season", "secret", "security", "segment",
+			"senior", "shadow", "shaft", "shame", "shaped", "sharp", "shelter", "sheriff", "short", "should",
+			"shrimp", "sidewalk", "silent", "silver", "similar", "simple", "single", "sister", "skin", "skunk",
+			"slap", "slavery", "sled", "slice", "slim", "slow", "slush", "smart", "smear", "smell",
+			"smirk", "smith", "smoking", "smug", "snake", "snapshot", "sniff", "society", "software", "soldier",
+			"solution", "soul", "source", "space", "spark", "speak", "species", "spelling", "spend", "spew",
+			"spider", "spill", "spine", "spirit", "spit", "spray", "sprinkle", "square", "squeeze", "stadium",
+			"staff", "standard", "starting", "station", "stay", "steady", "step", "stick", "stilt", "story",
+			"strategy", "strike", "style", "subject", "submit", "sugar", "suitable", "sunlight", "superior", "surface",
+			"surprise", "survive", "sweater", "swimming", "swing", "switch", "symbolic", "sympathy", "syndrome",
+			"system",
+			"tackle", "tactics", "tadpole", "talent", "task", "taste", "taught", "taxi", "teacher", "teammate",
+			"teaspoon", "temple", "tenant", "tendency", "tension", "terminal", "testify", "texture", "thank", "that",
+			"theater", "theory", "therapy", "thorn", "threaten", "thumb", "thunder", "ticket", "tidy", "timber",
+			"timely", "ting", "tofu", "together", "tolerate", "total", "toxic", "tracks", "traffic", "training",
+			"transfer", "trash", "traveler", "treat", "trend", "trial", "tricycle", "trip", "triumph", "trouble",
+			"true", "trust", "twice", "twin", "type", "typical", "ugly", "ultimate", "umbrella", "uncover",
+			"undergo", "unfair", "unfold", "unhappy", "union", "universe", "unkind", "unknown", "unusual", "unwrap",
+			"upgrade", "upstairs", "username", "usher", "usual", "valid", "valuable", "vampire", "vanish", "various",
+			"vegan", "velvet", "venture", "verdict", "verify", "very", "veteran", "vexed", "victim", "video",
+			"view", "vintage", "violence", "viral", "visitor", "visual", "vitamins", "vocal", "voice", "volume",
+			"voter", "voting", "walnut", "warmth", "warn", "watch", "wavy", "wealthy", "weapon", "webcam",
+			"welcome", "welfare", "western", "width", "wildlife", "window", "wine", "wireless", "wisdom", "withdraw",
+			"wits", "wolf", "woman", "work", "worthy", "wrap", "wrist", "writing", "wrote", "year",
+			"yelp", "yield", "yoga", "zero"
+		};
+		if (wordlist.Length != 1024)
+		{
+			throw new InvalidOperationException(
+				$"The wordlist should contain 1024 words, but it contains {wordlist.Length} words."
+			);
+		}
+
+		return wordlist;
+	}
+
+	public static ushort[] MnemonicToIndices(string mnemonic)
+	{
+		try
+		{
+			return mnemonic.Split()
+				.Select(word => WordIndexMap[word.ToLower()])
+				.ToArray();
+		}
+		catch (KeyNotFoundException keyError)
+		{
+			throw new MnemonicException($"Invalid mnemonic word {keyError.Message}.", keyError);
+		}
+	}
+}
+
+public class MnemonicException : Exception
+{
+	public MnemonicException(string message, Exception innerException)
+		: base(message, innerException)
+	{
+	}
+}


### PR DESCRIPTION
This PR adds the cryptography library to support the SLIP39 (Shamir Secret Sharing).

## How to use the code

There are tow main functions:

* `Generate` which takes the `seed`, and optional `passphrase` and the `n-of-m` group definition and creates `m` shares and,
* `Combine` which takes `n` shares and an option `passphrase` and "combine" them to recover the original seed.

## In code
 
```c#
var shares = Slip39.Generate(
    group:  (2, 3),     // 2 of 3 shares are required to reconstruct the secret
    seed: "ABCDEFGHIJKLMNOP"u8.ToArray(),
    passphrase: "TREZOR");

var recoveredSecret = Slip39.Combine(shares, passphrase);
Assert.Equal(masterSecret, recoveredSecret);
```