### PR TITLE
One config file per bitcoin network

### DIFF
--- a/WalletWasabi.Daemon/Config/Config.cs
+++ b/WalletWasabi.Daemon/Config/Config.cs
@@ -57,7 +57,7 @@ public class Config
 				GetLongValue("TorControlPort", TorSettings.DefaultControlPort, cliArgs)),
 			[nameof(TorBridges)] = (
 				"Tor is started with the set of specified bridges",
-				GetStringArrayValue("TorBridges", PersistentConfig.TorBridges, cliArgs)),
+				GetStringArrayValue("TorBridges", PersistentConfig.TorBridges.ToArray(), cliArgs)),
 			[nameof(TerminateTorOnExit)] = (
 				"Stop the Tor process when Wasabi is closed",
 				GetBoolValue("TerminateTorOnExit", PersistentConfig.TerminateTorOnExit, cliArgs)),
@@ -84,7 +84,7 @@ public class Config
 				GetStringValue("JsonRpcPassword", PersistentConfig.JsonRpcPassword, cliArgs)),
 			[ nameof(JsonRpcServerPrefixes)] = (
 				"The Json RPC server prefixes",
-				GetStringArrayValue("JsonRpcServerPrefixes", PersistentConfig.JsonRpcServerPrefixes, cliArgs)),
+				GetStringArrayValue("JsonRpcServerPrefixes", PersistentConfig.JsonRpcServerPrefixes.ToArray(), cliArgs)),
 			[ nameof(RpcOnionEnabled)] = (
 				"Publish the Json RPC Server as a Tor Onion service",
 				GetBoolValue("RpcOnionEnabled", value: false, cliArgs)),

--- a/WalletWasabi.Daemon/Config/Config.cs
+++ b/WalletWasabi.Daemon/Config/Config.cs
@@ -37,24 +37,12 @@ public class Config
 			[ nameof(Network)] = (
 				"The Bitcoin network to use: main, testnet, or regtest",
 				GetNetworkValue("Network", PersistentConfig.Network.ToString(), cliArgs)),
-			[ nameof(MainNetBackendUri)] = (
-				"The backend server's URL to connect to when the Bitcoin network is main",
-				GetStringValue("MainNetBackendUri", PersistentConfig.MainNetIndexerUri, cliArgs)),
-			[ nameof(TestNetBackendUri)] = (
-				"The backend server's URL to connect to when the Bitcoin network is testnet",
-				GetStringValue("TestNetBackendUri", PersistentConfig.TestNetIndexerUri, cliArgs)),
-			[ nameof(RegTestBackendUri)] = (
-				"The backend server's URL to connect to when the Bitcoin network is regtest",
-				GetStringValue("RegTestBackendUri", PersistentConfig.RegTestIndexerUri, cliArgs)),
-			[ nameof(MainNetCoordinatorUri)] = (
-				"The coordinator server's URL to connect to when the Bitcoin network is main",
-				GetStringValue("MainNetCoordinatorUri", PersistentConfig.MainNetCoordinatorUri, cliArgs)),
-			[ nameof(TestNetCoordinatorUri)] = (
-				"The coordinator server's URL to connect to when the Bitcoin network is testnet",
-				GetStringValue("TestNetCoordinatorUri", PersistentConfig.TestNetCoordinatorUri, cliArgs)),
-			[ nameof(RegTestCoordinatorUri)] = (
-				"The coordinator server's URL to connect to when the Bitcoin network is regtest",
-				GetStringValue("RegTestCoordinatorUri", PersistentConfig.RegTestCoordinatorUri, cliArgs)),
+			[ nameof(BackendUri)] = (
+				"The backend server's URL to connect to",
+				GetStringValue("BackendUri", PersistentConfig.IndexerUri, cliArgs)),
+			[ nameof(CoordinatorUri)] = (
+				"The coordinator server's URL to connect to",
+				GetStringValue("CoordinatorUri", PersistentConfig.CoordinatorUri, cliArgs)),
 			[ nameof(UseTor)] = (
 				"All the communications go through the Tor network",
 				GetTorModeValue("UseTor", PersistentConfig.UseTor, cliArgs)),
@@ -79,24 +67,12 @@ public class Config
 			[ nameof(UseBitcoinRpc)] = (
 				"Connect to bitcoin node rpc server",
 				GetBoolValue("UseBitcoinRpc", PersistentConfig.UseBitcoinRpc, cliArgs)),
-			[ nameof(MainNetBitcoinRpcCredentialString)] = (
+			[ nameof(BitcoinRpcCredentialString)] = (
 				"Credentials for authenticating against the bitcoin node rpc server",
-				GetStringValue("MainNetBitcoinRpcCredentialString", PersistentConfig.MainNetBitcoinRpcCredentialString, cliArgs)),
-			[ nameof(TestNetBitcoinRpcCredentialString)] = (
-				"Credentials for authenticating against the bitcoin node rpc server",
-				GetStringValue("TestNetBitcoinRpcCredentialString", PersistentConfig.TestNetBitcoinRpcCredentialString, cliArgs)),
-			[ nameof(RegTestBitcoinRpcCredentialString)] = (
-				"Credentials for authenticating against the bitcoin node rpc server",
-				GetStringValue("RegTestBitcoinRpcCredentialString", PersistentConfig.RegTestBitcoinRpcCredentialString, cliArgs)),
-			[ nameof(MainNetBitcoinRpcEndPoint)] = (
+				GetStringValue("BitcoinRpcCredentialString", PersistentConfig.BitcoinRpcCredentialString, cliArgs)),
+			[ nameof(BitcoinRpcEndPoint)] = (
 				"-",
-				GetEndPointValue("MainNetBitcoinRpcEndPoint", PersistentConfig.MainNetBitcoinRpcEndPoint, cliArgs)),
-			[ nameof(TestNetBitcoinRpcEndPoint)] = (
-				"-",
-				GetEndPointValue("TestNetBitcoinRpcEndPoint", PersistentConfig.TestNetBitcoinRpcEndPoint, cliArgs)),
-			[ nameof(RegTestBitcoinRpcEndPoint)] = (
-				"-",
-				GetEndPointValue("RegTestBitcoinRpcEndPoint", PersistentConfig.RegTestBitcoinRpcEndPoint, cliArgs)),
+				GetEndPointValue("BitcoinRpcEndPoint", PersistentConfig.BitcoinRpcEndPoint, cliArgs)),
 			[ nameof(JsonRpcServerEnabled)] = (
 				"Start the Json RPC Server and accept requests",
 				GetBoolValue("JsonRpcServerEnabled", PersistentConfig.JsonRpcServerEnabled, cliArgs)),
@@ -166,7 +142,7 @@ public class Config
 			}
 		}
 
-		ServiceConfiguration = new ServiceConfiguration(GetBitcoinRpcEndPoint(), DustThreshold, DropUnconfirmedTransactionsAfterDays);
+		ServiceConfiguration = new ServiceConfiguration(BitcoinRpcEndPoint, DustThreshold, DropUnconfirmedTransactionsAfterDays);
 	}
 
 	private Dictionary<string, (string Hint, IValue Value)> Data { get; }
@@ -174,12 +150,8 @@ public class Config
 	public string[] CliArgs { get; }
 	public Network Network => GetEffectiveValue<NetworkValue, Network>(nameof(Network));
 
-	public string MainNetBackendUri => GetEffectiveValue<StringValue, string>(nameof(MainNetBackendUri));
-	public string TestNetBackendUri => GetEffectiveValue<StringValue, string>(nameof(TestNetBackendUri));
-	public string RegTestBackendUri => GetEffectiveValue<StringValue, string>(nameof(RegTestBackendUri));
-	public string MainNetCoordinatorUri => GetEffectiveValue<StringValue, string>(nameof(MainNetCoordinatorUri));
-	public string TestNetCoordinatorUri => GetEffectiveValue<StringValue, string>(nameof(TestNetCoordinatorUri));
-	public string RegTestCoordinatorUri => GetEffectiveValue<StringValue, string>(nameof(RegTestCoordinatorUri));
+	public string BackendUri => GetEffectiveValue<StringValue, string>(nameof(BackendUri));
+	public string CoordinatorUri => GetEffectiveValue<StringValue, string>(nameof(CoordinatorUri));
 	public TorMode UseTor => Network == Network.RegTest ? TorMode.Disabled : GetEffectiveValue<TorModeValue, TorMode>(nameof(UseTor));
 	public string? TorFolder => GetEffectiveValue<NullableStringValue, string?>(nameof(TorFolder));
 	public int TorSocksPort => GetEffectiveValue<IntValue, int>(nameof(TorSocksPort));
@@ -188,12 +160,8 @@ public class Config
 	public bool TerminateTorOnExit => GetEffectiveValue<BoolValue, bool>(nameof(TerminateTorOnExit));
 	public bool DownloadNewVersion => GetEffectiveValue<BoolValue, bool>(nameof(DownloadNewVersion));
 	public bool UseBitcoinRpc => GetEffectiveValue<BoolValue, bool>(nameof(UseBitcoinRpc));
-	public string MainNetBitcoinRpcCredentialString => GetEffectiveValue<StringValue, string>(nameof(MainNetBitcoinRpcCredentialString));
-	public string TestNetBitcoinRpcCredentialString => GetEffectiveValue<StringValue, string>(nameof(TestNetBitcoinRpcCredentialString));
-	public string RegTestBitcoinRpcCredentialString => GetEffectiveValue<StringValue, string>(nameof(RegTestBitcoinRpcCredentialString));
-	public EndPoint MainNetBitcoinRpcEndPoint => GetEffectiveValue<EndPointValue, EndPoint>(nameof(MainNetBitcoinRpcEndPoint));
-	public EndPoint TestNetBitcoinRpcEndPoint => GetEffectiveValue<EndPointValue, EndPoint>(nameof(TestNetBitcoinRpcEndPoint));
-	public EndPoint RegTestBitcoinRpcEndPoint => GetEffectiveValue<EndPointValue, EndPoint>(nameof(RegTestBitcoinRpcEndPoint));
+	public string BitcoinRpcCredentialString => GetEffectiveValue<StringValue, string>(nameof(BitcoinRpcCredentialString));
+	public EndPoint BitcoinRpcEndPoint => GetEffectiveValue<EndPointValue, EndPoint>(nameof(BitcoinRpcEndPoint));
 	public bool JsonRpcServerEnabled => GetEffectiveValue<BoolValue, bool>(nameof(JsonRpcServerEnabled));
 	public string JsonRpcUser => GetEffectiveValue<StringValue, string>(nameof(JsonRpcUser));
 	public string JsonRpcPassword => GetEffectiveValue<StringValue, string>(nameof(JsonRpcPassword));
@@ -230,81 +198,13 @@ public class Config
 	/// </remarks>
 	public bool IsOverridden { get; }
 
-	public EndPoint GetBitcoinRpcEndPoint()
-	{
-		if (Network == Network.Main)
-		{
-			return MainNetBitcoinRpcEndPoint;
-		}
-		if (Network == Network.TestNet)
-		{
-			return TestNetBitcoinRpcEndPoint;
-		}
-		if (Network == Network.RegTest)
-		{
-			return RegTestBitcoinRpcEndPoint;
-		}
-		throw new NotSupportedNetworkException(Network);
-	}
-
-	public string GetBitcoinRpcCredentialString()
-	{
-		if (Network == Network.Main)
-		{
-			return MainNetBitcoinRpcCredentialString;
-		}
-
-		if (Network == Network.TestNet)
-		{
-			return TestNetBitcoinRpcCredentialString;
-		}
-
-		if (Network == Network.RegTest)
-		{
-			return RegTestBitcoinRpcCredentialString;
-		}
-
-		throw new NotSupportedNetworkException(Network);
-	}
-
-	public Uri GetBackendUri()
-	{
-		if (Network == Network.Main)
-		{
-			return new Uri(MainNetBackendUri);
-		}
-
-		if (Network == Network.TestNet)
-		{
-			return new Uri(TestNetBackendUri);
-		}
-
-		if (Network == Network.RegTest)
-		{
-			return new Uri(RegTestBackendUri);
-		}
-
-		throw new NotSupportedNetworkException(Network);
-	}
-
-	private Uri GetCoordinatorUri()
-	{
-		var result = Network switch
-		{
-			{ } n when n == Network.Main => MainNetCoordinatorUri,
-			{ } n when n == Network.TestNet => TestNetCoordinatorUri,
-			{ } n when n == Network.RegTest => RegTestCoordinatorUri,
-			_ => throw new NotSupportedNetworkException(Network)
-		};
-
-		return new Uri(result);
-	}
+	public EndPoint GetBitcoinRpcEndPoint() => BitcoinRpcEndPoint;
 
 	public bool TryGetCoordinatorUri([NotNullWhen(true)] out Uri? coordinatorUri)
 	{
 		try
 		{
-			coordinatorUri = GetCoordinatorUri();
+			coordinatorUri = new Uri(CoordinatorUri);
 			return coordinatorUri.Host != "api.wasabiwallet.io";
 		}
 		catch (Exception e) when (e is UriFormatException or ArgumentException or NotSupportedNetworkException)
@@ -523,7 +423,7 @@ public class Config
 		return false;
 	}
 
-	private static bool GetCliArgsValue(string key, string[] cliArgs, [NotNullWhen(true)] out string? cliArgsValue)
+	public static bool GetCliArgsValue(string key, string[] cliArgs, [NotNullWhen(true)] out string? cliArgsValue)
 	{
 		if (ArgumentHelpers.TryGetValue(key, cliArgs, out cliArgsValue))
 		{

--- a/WalletWasabi.Daemon/Config/Config.cs
+++ b/WalletWasabi.Daemon/Config/Config.cs
@@ -36,7 +36,7 @@ public class Config
 		{
 			[ nameof(Network)] = (
 				"The Bitcoin network to use: main, testnet, or regtest",
-				GetNetworkValue("Network", PersistentConfig.Network.ToString(), cliArgs)),
+				GetNetworkValue("Network", PersistentConfig.Network.ToString(), [])),
 			[ nameof(BackendUri)] = (
 				"The backend server's URL to connect to",
 				GetStringValue("BackendUri", PersistentConfig.IndexerUri, cliArgs)),
@@ -130,7 +130,7 @@ public class Config
 		foreach (string optionName in Data.Keys)
 		{
 			// It is allowed to override the log level.
-			if (!string.Equals(optionName, nameof(LogLevel)))
+			if (!string.Equals(optionName, nameof(LogLevel)) && !string.Equals(optionName, nameof(Network)) )
 			{
 				(_, IValue optionValue) = Data[optionName];
 

--- a/WalletWasabi.Daemon/Config/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfig.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using NBitcoin;
-using System.Linq;
 using System.Net;
 using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Helpers;
@@ -24,7 +23,7 @@ public record PersistentConfig : IPersistentConfig
 
 	public bool TerminateTorOnExit { get; init; }
 
-	public string[] TorBridges { get; init; } = [];
+	public ValueList<string> TorBridges { get; init; } = ValueList<string>.Empty;
 
 	public bool DownloadNewVersion { get; init; } = true;
 
@@ -40,11 +39,11 @@ public record PersistentConfig : IPersistentConfig
 
 	public string JsonRpcPassword { get; init; } = "";
 
-	public string[] JsonRpcServerPrefixes { get; init; } =
+	public ValueList<string> JsonRpcServerPrefixes { get; init; } = new(
 	[
 		"http://127.0.0.1:37128/",
 		"http://localhost:37128/"
-	];
+	]);
 
 	public Money DustThreshold { get; init; } = Money.Coins(Constants.DefaultDustThreshold);
 

--- a/WalletWasabi.Daemon/Config/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfig.cs
@@ -11,57 +11,33 @@ namespace WalletWasabi.Daemon;
 
 public interface IPersistentConfig;
 
-public record PersistentConfig : IPersistentConfig
+public record PersistentConfig(
+	Network Network,
+	string IndexerUri,
+	string CoordinatorUri,
+	string UseTor,
+	bool TerminateTorOnExit,
+	ValueList<string> TorBridges,
+	bool DownloadNewVersion,
+	bool UseBitcoinRpc,
+	string BitcoinRpcCredentialString,
+	EndPoint BitcoinRpcEndPoint,
+	bool JsonRpcServerEnabled,
+	string JsonRpcUser,
+	string JsonRpcPassword,
+	ValueList<string> JsonRpcServerPrefixes,
+	Money DustThreshold,
+	bool EnableGpu,
+	string CoordinatorIdentifier,
+	string ExchangeRateProvider,
+	string FeeRateEstimationProvider,
+	string ExternalTransactionBroadcaster,
+	decimal MaxCoinJoinMiningFeeRate,
+	int AbsoluteMinInputCount,
+	int MaxDaysInMempool,
+	int ConfigVersion
+	) : IPersistentConfig
 {
-	public Network Network { get; init; } = Network.Main;
-
-	public string IndexerUri { get; init; } = Constants.IndexerUri;
-
-	public string CoordinatorUri { get; init; } = "";
-
-	public string UseTor { get; init; } = "Enabled";
-
-	public bool TerminateTorOnExit { get; init; }
-
-	public ValueList<string> TorBridges { get; init; } = ValueList<string>.Empty;
-
-	public bool DownloadNewVersion { get; init; } = true;
-
-	public bool UseBitcoinRpc { get; init; }
-
-	public string BitcoinRpcCredentialString { get; init; } = "";
-
-	public EndPoint BitcoinRpcEndPoint { get; init; } = Constants.DefaultMainNetBitcoinCoreRpcEndPoint;
-
-	public bool JsonRpcServerEnabled { get; init; }
-
-	public string JsonRpcUser { get; init; } = "";
-
-	public string JsonRpcPassword { get; init; } = "";
-
-	public ValueList<string> JsonRpcServerPrefixes { get; init; } = new(
-	[
-		"http://127.0.0.1:37128/",
-		"http://localhost:37128/"
-	]);
-
-	public Money DustThreshold { get; init; } = Money.Coins(Constants.DefaultDustThreshold);
-
-	public bool EnableGpu { get; init; } = true;
-
-	public string CoordinatorIdentifier { get; init; } = "CoinJoinCoordinatorIdentifier";
-
-	public string ExchangeRateProvider { get; init; } = Constants.DefaultExchangeRateProvider;
-	public string  FeeRateEstimationProvider { get; init; } = Constants.DefaultFeeRateEstimationProvider;
-	public string ExternalTransactionBroadcaster { get; init; } = "MempoolSpace";
-
-	public decimal MaxCoinJoinMiningFeeRate { get; init; } = Constants.DefaultMaxCoinJoinMiningFeeRate;
-
-	public int AbsoluteMinInputCount { get; init; } = Constants.DefaultAbsoluteMinInputCount;
-
-	public int MaxDaysInMempool { get; init; } = Constants.DefaultMaxDaysInMempool;
-	public int ConfigVersion { get; init; }
-
 	public string GetConfigFileName() =>
 		Network switch
 		{

--- a/WalletWasabi.Daemon/Config/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfig.cs
@@ -48,7 +48,7 @@ public record PersistentConfig(
 		};
 }
 
-public record PersistentConfigPrev2_5_1(
+public record PersistentConfigPrev2_6_0(
 	string MainNetIndexerUri,
 	string TestNetIndexerUri,
 	string RegTestIndexerUri,
@@ -81,7 +81,7 @@ public record PersistentConfigPrev2_5_1(
 	int MaxDaysInMempool,
 	int ConfigVersion) : IPersistentConfig
 {
-	public PersistentConfigPrev2_5_1 Migrate() =>
+	public PersistentConfigPrev2_6_0 Migrate() =>
 		MigrateMaxCoordinationFeeRate()
 		.MigrateOldDefaultBackendUris()
 		.MigrateP2pToRpcConnection() with
@@ -89,9 +89,9 @@ public record PersistentConfigPrev2_5_1(
 			ConfigVersion = 2
 		};
 
-	private PersistentConfigPrev2_5_1 MigrateMaxCoordinationFeeRate() => this;
+	private PersistentConfigPrev2_6_0 MigrateMaxCoordinationFeeRate() => this;
 
-	private PersistentConfigPrev2_5_1 MigrateOldDefaultBackendUris()
+	private PersistentConfigPrev2_6_0 MigrateOldDefaultBackendUris()
 	{
 		if (MainNetIndexerUri == "https://wasabiwallet.io/" || TestNetIndexerUri == "https://wasabiwallet.co/")
 		{
@@ -105,7 +105,7 @@ public record PersistentConfigPrev2_5_1(
 		return this;
 	}
 
-	private PersistentConfigPrev2_5_1 MigrateP2pToRpcConnection()
+	private PersistentConfigPrev2_6_0 MigrateP2pToRpcConnection()
 	{
 		if (ConfigVersion >= 2)
 		{

--- a/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
@@ -60,6 +60,8 @@ public static class PersistentConfigManager
 	{
 		string jsonString = JsonEncoder.ToReadableString(obj, PersistentConfigEncode.PersistentConfig);
 		File.WriteAllText(filePath, jsonString, Encoding.UTF8);
+		var networkFilePath = Path.Combine(Path.GetDirectoryName(filePath) ?? string.Empty, ".network");
+		File.WriteAllText(networkFilePath, obj.Network.ToString());
 		return jsonString;
 	}
 

--- a/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
@@ -60,7 +60,7 @@ public static class PersistentConfigManager
 	{
 		string jsonString = JsonEncoder.ToReadableString(obj, PersistentConfigEncode.PersistentConfig);
 		File.WriteAllText(filePath, jsonString, Encoding.UTF8);
-		var networkFilePath = Path.Combine(Path.GetDirectoryName(filePath) ?? string.Empty, ".network");
+		var networkFilePath = Path.Combine(Path.GetDirectoryName(filePath) ?? string.Empty, "network");
 		File.WriteAllText(networkFilePath, obj.Network.ToString());
 		return jsonString;
 	}

--- a/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
@@ -16,7 +16,7 @@ public static class PersistentConfigManager
 		return jsonString;
 	}
 
-	public static PersistentConfig LoadFile(string filePath)
+	public static IPersistentConfig LoadFile(string filePath)
 	{
 		try
 		{

--- a/WalletWasabi.Daemon/Config/Serialization.cs
+++ b/WalletWasabi.Daemon/Config/Serialization.cs
@@ -6,6 +6,7 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Serialization;
 using static WalletWasabi.Serialization.Encode;
 using static WalletWasabi.Serialization.Decode;
+using Network = NBitcoin.Network;
 
 namespace WalletWasabi.Daemon;
 
@@ -59,32 +60,32 @@ public static class PersistentConfigDecode
 	private static IPEndPoint DefaultEndPoint = new (IPAddress.None, 0);
 
 	public static readonly Decoder<PersistentConfig> PersistentConfigPost2_5_1 =
-		Object(get => new PersistentConfig
-		{
-			IndexerUri = get.Required("BackendUri", Decode.String),
-			CoordinatorUri = get.Required("CoordinatorUri", Decode.String),
-			UseTor = get.Required("UseTor", UseTor),
-			TerminateTorOnExit = get.Required("TerminateTorOnExit", Decode.Bool),
-			TorBridges = get.Required("TorBridges", ValueList(Decode.String)),
-			DownloadNewVersion = get.Required("DownloadNewVersion", Decode.Bool),
-			UseBitcoinRpc = get.Optional("UseBitcoinRpc", Decode.Bool, false),
-			BitcoinRpcCredentialString = get.Optional("BitcoinRpcCredentialString", Decode.String) ?? "",
-			BitcoinRpcEndPoint = get.Optional("BitcoinRpcEndPoint", Decode.EndPoint) ?? DefaultEndPoint,
-			JsonRpcServerEnabled = get.Required("JsonRpcServerEnabled", Decode.Bool),
-			JsonRpcUser = get.Required("JsonRpcUser", Decode.String),
-			JsonRpcPassword = get.Required("JsonRpcPassword", Decode.String),
-			JsonRpcServerPrefixes = get.Required("JsonRpcServerPrefixes", ValueList(Decode.String)),
-			DustThreshold = get.Required("DustThreshold", Decode.MoneyBitcoins),
-			EnableGpu = get.Required("EnableGpu", Decode.Bool),
-			ExchangeRateProvider = get.Optional("ExchangeRateProvider", Decode.String) ?? "Mempoolspace",
-			FeeRateEstimationProvider = get.Optional("FeeRateEstimationProvider", Decode.String) ?? "BlockstreamInfo",
-			ExternalTransactionBroadcaster = get.Optional("ExternalTransactionBroadcaster", Decode.String) ?? "MempoolSpace",
-			CoordinatorIdentifier = get.Required("CoordinatorIdentifier", Decode.String),
-			MaxCoinJoinMiningFeeRate = get.Required("MaxCoinJoinMiningFeeRate", Decode.Decimal),
-			AbsoluteMinInputCount = get.Required("AbsoluteMinInputCount", Decode.Int),
-			MaxDaysInMempool = get.Optional("MaxDaysInMempool", Decode.Int, Constants.DefaultMaxDaysInMempool),
-			ConfigVersion = get.Required("ConfigVersion", Decode.Int)
-		});
+		Object(get => new PersistentConfig(
+			Network: Network.Main, // Network is not part of the config
+			IndexerUri : get.Required("BackendUri", Decode.String),
+			CoordinatorUri : get.Required("CoordinatorUri", Decode.String),
+			UseTor : get.Required("UseTor", UseTor),
+			TerminateTorOnExit : get.Required("TerminateTorOnExit", Decode.Bool),
+			TorBridges : get.Required("TorBridges", ValueList(Decode.String)),
+			DownloadNewVersion : get.Required("DownloadNewVersion", Decode.Bool),
+			UseBitcoinRpc : get.Optional("UseBitcoinRpc", Decode.Bool, false),
+			BitcoinRpcCredentialString : get.Optional("BitcoinRpcCredentialString", Decode.String) ?? "",
+			BitcoinRpcEndPoint : get.Optional("BitcoinRpcEndPoint", Decode.EndPoint) ?? DefaultEndPoint,
+			JsonRpcServerEnabled : get.Required("JsonRpcServerEnabled", Decode.Bool),
+			JsonRpcUser : get.Required("JsonRpcUser", Decode.String),
+			JsonRpcPassword : get.Required("JsonRpcPassword", Decode.String),
+			JsonRpcServerPrefixes : get.Required("JsonRpcServerPrefixes", ValueList(Decode.String)),
+			DustThreshold : get.Required("DustThreshold", Decode.MoneyBitcoins),
+			EnableGpu : get.Required("EnableGpu", Decode.Bool),
+			ExchangeRateProvider : get.Optional("ExchangeRateProvider", Decode.String) ?? "Mempoolspace",
+			FeeRateEstimationProvider : get.Optional("FeeRateEstimationProvider", Decode.String) ?? "BlockstreamInfo",
+			ExternalTransactionBroadcaster : get.Optional("ExternalTransactionBroadcaster", Decode.String) ?? "MempoolSpace",
+			CoordinatorIdentifier : get.Required("CoordinatorIdentifier", Decode.String),
+			MaxCoinJoinMiningFeeRate : get.Required("MaxCoinJoinMiningFeeRate", Decode.Decimal),
+			AbsoluteMinInputCount : get.Required("AbsoluteMinInputCount", Decode.Int),
+			MaxDaysInMempool : get.Optional("MaxDaysInMempool", Decode.Int, Constants.DefaultMaxDaysInMempool),
+			ConfigVersion : get.Required("ConfigVersion", Decode.Int)
+		));
 
 	public static readonly Decoder<PersistentConfigPrev2_5_1> PersistentConfigPrev2_5_1 =
 		Object(get => new PersistentConfigPrev2_5_1(

--- a/WalletWasabi.Daemon/Config/Serialization.cs
+++ b/WalletWasabi.Daemon/Config/Serialization.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Net;
 using System.Text.Json.Nodes;
@@ -52,6 +53,9 @@ public static class PersistentConfigDecode
 			Decode.String
 		]);
 
+	public static Decoder<ValueList<T>> ValueList<T>(Decoder<T> decoder) where T : IEquatable<T> =>
+		Array(decoder).Map(x => new ValueList<T>(x));
+
 	private static IPEndPoint DefaultEndPoint = new (IPAddress.None, 0);
 
 	public static readonly Decoder<PersistentConfig> PersistentConfigPost2_5_1 =
@@ -61,7 +65,7 @@ public static class PersistentConfigDecode
 			CoordinatorUri = get.Required("CoordinatorUri", Decode.String),
 			UseTor = get.Required("UseTor", UseTor),
 			TerminateTorOnExit = get.Required("TerminateTorOnExit", Decode.Bool),
-			TorBridges = get.Required("TorBridges", Decode.Array(Decode.String)),
+			TorBridges = get.Required("TorBridges", ValueList(Decode.String)),
 			DownloadNewVersion = get.Required("DownloadNewVersion", Decode.Bool),
 			UseBitcoinRpc = get.Optional("UseBitcoinRpc", Decode.Bool, false),
 			BitcoinRpcCredentialString = get.Optional("BitcoinRpcCredentialString", Decode.String) ?? "",
@@ -69,7 +73,7 @@ public static class PersistentConfigDecode
 			JsonRpcServerEnabled = get.Required("JsonRpcServerEnabled", Decode.Bool),
 			JsonRpcUser = get.Required("JsonRpcUser", Decode.String),
 			JsonRpcPassword = get.Required("JsonRpcPassword", Decode.String),
-			JsonRpcServerPrefixes = get.Required("JsonRpcServerPrefixes", Decode.Array(Decode.String)),
+			JsonRpcServerPrefixes = get.Required("JsonRpcServerPrefixes", ValueList(Decode.String)),
 			DustThreshold = get.Required("DustThreshold", Decode.MoneyBitcoins),
 			EnableGpu = get.Required("EnableGpu", Decode.Bool),
 			ExchangeRateProvider = get.Optional("ExchangeRateProvider", Decode.String) ?? "Mempoolspace",

--- a/WalletWasabi.Daemon/Config/Serialization.cs
+++ b/WalletWasabi.Daemon/Config/Serialization.cs
@@ -59,7 +59,7 @@ public static class PersistentConfigDecode
 
 	private static IPEndPoint DefaultEndPoint = new (IPAddress.None, 0);
 
-	public static readonly Decoder<PersistentConfig> PersistentConfigPost2_5_1 =
+	public static readonly Decoder<PersistentConfig> PersistentConfigPost2_6_0 =
 		Object(get => new PersistentConfig(
 			Network: Network.Main, // Network is not part of the config
 			IndexerUri : get.Required("BackendUri", Decode.String),
@@ -87,8 +87,8 @@ public static class PersistentConfigDecode
 			ConfigVersion : get.Required("ConfigVersion", Decode.Int)
 		));
 
-	public static readonly Decoder<PersistentConfigPrev2_5_1> PersistentConfigPrev2_5_1 =
-		Object(get => new PersistentConfigPrev2_5_1(
+	public static readonly Decoder<PersistentConfigPrev2_6_0> PersistentConfigPrev2_6_0 =
+		Object(get => new PersistentConfigPrev2_6_0(
 			get.Required("MainNetBackendUri", Decode.String),
 			get.Required("TestNetBackendUri", Decode.String),
 			get.Required("RegTestBackendUri", Decode.String),
@@ -124,7 +124,7 @@ public static class PersistentConfigDecode
 
 	public static readonly Decoder<IPersistentConfig> PersistentConfig =
 		OneOf([
-			PersistentConfigPrev2_5_1.Map(IPersistentConfig (x) => x),
-			PersistentConfigPost2_5_1.Map(IPersistentConfig (x) => x)
+			PersistentConfigPrev2_6_0.Map(IPersistentConfig (x) => x),
+			PersistentConfigPost2_6_0.Map(IPersistentConfig (x) => x)
 		]);
 }

--- a/WalletWasabi.Daemon/Config/Serialization.cs
+++ b/WalletWasabi.Daemon/Config/Serialization.cs
@@ -17,24 +17,15 @@ public static class PersistentConfigEncode
 
 	public static JsonNode PersistentConfig(PersistentConfig cfg) =>
 		Object([
-			("Network", Network(cfg.Network)),
-			("MainNetBackendUri", String(cfg.MainNetIndexerUri)),
-			("TestNetBackendUri", String(cfg.TestNetIndexerUri)),
-			("RegTestBackendUri", String(cfg.RegTestIndexerUri)),
-			("MainNetCoordinatorUri", String(cfg.MainNetCoordinatorUri)),
-			("TestNetCoordinatorUri", String(cfg.TestNetCoordinatorUri)),
-			("RegTestCoordinatorUri", String(cfg.RegTestCoordinatorUri)),
+			("BackendUri", String(cfg.IndexerUri)),
+			("CoordinatorUri", String(cfg.CoordinatorUri)),
 			("UseTor", UseTor(cfg.UseTor)),
 			("TerminateTorOnExit", Bool(cfg.TerminateTorOnExit)),
 			("TorBridges", Array(cfg.TorBridges.Select(String))),
 			("DownloadNewVersion", Bool(cfg.DownloadNewVersion)),
 			("UseBitcoinRpc", Bool(cfg.UseBitcoinRpc)),
-			("MainNetBitcoinRpcCredentialString", String(cfg.MainNetBitcoinRpcCredentialString)),
-			("TestNetBitcoinRpcCredentialString", String(cfg.TestNetBitcoinRpcCredentialString)),
-			("RegTestBitcoinRpcCredentialString", String(cfg.RegTestBitcoinRpcCredentialString)),
-			("MainNetBitcoinRpcEndPoint", EndPoint(cfg.MainNetBitcoinRpcEndPoint, Constants.DefaultMainNetBitcoinCoreRpcPort)),
-			("TestNetBitcoinRpcEndPoint", EndPoint(cfg.TestNetBitcoinRpcEndPoint, Constants.DefaultTestNetBitcoinCoreRpcPort)),
-			("RegTestBitcoinRpcEndPoint", EndPoint(cfg.RegTestBitcoinRpcEndPoint, Constants.DefaultRegTestBitcoinCoreRpcPort)),
+			("BitcoinRpcCredentialString", String(cfg.BitcoinRpcCredentialString)),
+			("BitcoinRpcEndPoint", EndPoint(cfg.BitcoinRpcEndPoint, Constants.DefaultMainNetBitcoinCoreRpcPort)),
 			("JsonRpcServerEnabled", Bool(cfg.JsonRpcServerEnabled)),
 			("JsonRpcUser", String(cfg.JsonRpcUser)),
 			("JsonRpcPassword", String(cfg.JsonRpcPassword)),
@@ -47,6 +38,7 @@ public static class PersistentConfigEncode
 			("ExternalTransactionBroadcaster", String(cfg.ExternalTransactionBroadcaster)),
 			("MaxCoinJoinMiningFeeRate", Decimal(cfg.MaxCoinJoinMiningFeeRate)),
 			("AbsoluteMinInputCount", Int(cfg.AbsoluteMinInputCount)),
+			("MaxDaysInMempool", Int(cfg.MaxDaysInMempool)),
 			("ConfigVersion", Int(cfg.ConfigVersion))
 		]);
 }
@@ -62,27 +54,18 @@ public static class PersistentConfigDecode
 
 	private static IPEndPoint DefaultEndPoint = new (IPAddress.None, 0);
 
-	public static readonly Decoder<PersistentConfig> PersistentConfig =
+	public static readonly Decoder<PersistentConfig> PersistentConfigPost2_5_1 =
 		Object(get => new PersistentConfig
 		{
-			Network = get.Required("Network", Decode.Network),
-			MainNetIndexerUri = get.Required("MainNetBackendUri", Decode.String),
-			TestNetIndexerUri = get.Required("TestNetBackendUri", Decode.String),
-			RegTestIndexerUri = get.Required("RegTestBackendUri", Decode.String),
-			MainNetCoordinatorUri = get.Required("MainNetCoordinatorUri", Decode.String),
-			TestNetCoordinatorUri = get.Required("TestNetCoordinatorUri", Decode.String),
-			RegTestCoordinatorUri = get.Required("RegTestCoordinatorUri", Decode.String),
+			IndexerUri = get.Required("BackendUri", Decode.String),
+			CoordinatorUri = get.Required("CoordinatorUri", Decode.String),
 			UseTor = get.Required("UseTor", UseTor),
 			TerminateTorOnExit = get.Required("TerminateTorOnExit", Decode.Bool),
 			TorBridges = get.Required("TorBridges", Decode.Array(Decode.String)),
 			DownloadNewVersion = get.Required("DownloadNewVersion", Decode.Bool),
 			UseBitcoinRpc = get.Optional("UseBitcoinRpc", Decode.Bool, false),
-			MainNetBitcoinRpcCredentialString = get.Optional("MainNetBitcoinRpcCredentialString", Decode.String) ?? "",
-			TestNetBitcoinRpcCredentialString = get.Optional("TestNetBitcoinRpcCredentialString", Decode.String) ?? "",
-			RegTestBitcoinRpcCredentialString = get.Optional("RegTestBitcoinRpcCredentialString", Decode.String) ?? "",
-			MainNetBitcoinRpcEndPoint = get.Optional("MainNetBitcoinRpcEndPoint", Decode.EndPoint) ?? DefaultEndPoint,
-			TestNetBitcoinRpcEndPoint = get.Optional("TestNetBitcoinRpcEndPoint", Decode.EndPoint) ?? DefaultEndPoint,
-			RegTestBitcoinRpcEndPoint = get.Optional("RegTestBitcoinRpcEndPoint", Decode.EndPoint) ?? DefaultEndPoint,
+			BitcoinRpcCredentialString = get.Optional("BitcoinRpcCredentialString", Decode.String) ?? "",
+			BitcoinRpcEndPoint = get.Optional("BitcoinRpcEndPoint", Decode.EndPoint) ?? DefaultEndPoint,
 			JsonRpcServerEnabled = get.Required("JsonRpcServerEnabled", Decode.Bool),
 			JsonRpcUser = get.Required("JsonRpcUser", Decode.String),
 			JsonRpcPassword = get.Required("JsonRpcPassword", Decode.String),
@@ -95,6 +78,48 @@ public static class PersistentConfigDecode
 			CoordinatorIdentifier = get.Required("CoordinatorIdentifier", Decode.String),
 			MaxCoinJoinMiningFeeRate = get.Required("MaxCoinJoinMiningFeeRate", Decode.Decimal),
 			AbsoluteMinInputCount = get.Required("AbsoluteMinInputCount", Decode.Int),
+			MaxDaysInMempool = get.Optional("MaxDaysInMempool", Decode.Int, Constants.DefaultMaxDaysInMempool),
 			ConfigVersion = get.Required("ConfigVersion", Decode.Int)
 		});
+
+	public static readonly Decoder<PersistentConfigPrev2_5_1> PersistentConfigPrev2_5_1 =
+		Object(get => new PersistentConfigPrev2_5_1(
+			get.Required("MainNetBackendUri", Decode.String),
+			get.Required("TestNetBackendUri", Decode.String),
+			get.Required("RegTestBackendUri", Decode.String),
+			get.Required("MainNetCoordinatorUri", Decode.String),
+			get.Required("TestNetCoordinatorUri", Decode.String),
+			get.Required("RegTestCoordinatorUri", Decode.String),
+			get.Required("UseTor", UseTor),
+			get.Required("TerminateTorOnExit", Decode.Bool),
+			get.Required("TorBridges", Decode.Array(Decode.String)),
+			get.Required("DownloadNewVersion", Decode.Bool),
+			get.Optional("UseBitcoinRpc", Decode.Bool, false),
+			get.Optional("MainNetBitcoinRpcCredentialString", Decode.String) ?? "",
+			get.Optional("TestNetBitcoinRpcCredentialString", Decode.String) ?? "",
+			get.Optional("RegTestBitcoinRpcCredentialString", Decode.String) ?? "",
+			get.Optional("MainNetBitcoinRpcEndPoint", Decode.EndPoint) ?? DefaultEndPoint,
+			get.Optional("TestNetBitcoinRpcEndPoint", Decode.EndPoint) ?? DefaultEndPoint,
+			get.Optional("RegTestBitcoinRpcEndPoint", Decode.EndPoint) ?? DefaultEndPoint,
+			get.Required("JsonRpcServerEnabled", Decode.Bool),
+			get.Required("JsonRpcUser", Decode.String),
+			get.Required("JsonRpcPassword", Decode.String),
+			get.Required("JsonRpcServerPrefixes", Decode.Array(Decode.String)),
+			get.Required("DustThreshold", Decode.MoneyBitcoins),
+			get.Required("EnableGpu", Decode.Bool),
+			get.Required("CoordinatorIdentifier", Decode.String),
+			get.Optional("ExchangeRateProvider", Decode.String) ?? "Mempoolspace",
+			get.Optional("FeeRateEstimationProvider", Decode.String) ?? "BlockstreamInfo",
+			get.Optional("ExternalTransactionBroadcaster", Decode.String) ?? "MempoolSpace",
+			get.Required("MaxCoinJoinMiningFeeRate", Decode.Decimal),
+			get.Required("AbsoluteMinInputCount", Decode.Int),
+			get.Optional("MaxDaysInMempool", Decode.Int, Constants.DefaultMaxDaysInMempool),
+			get.Required("ConfigVersion", Decode.Int)
+		));
+
+	public static readonly Decoder<IPersistentConfig> PersistentConfig =
+		OneOf([
+			PersistentConfigPrev2_5_1.Map(IPersistentConfig (x) => x),
+			PersistentConfigPost2_5_1.Map(IPersistentConfig (x) => x)
+		]);
 }

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -45,10 +45,9 @@ public class Global
 	/// <remarks>Use this variable as a guard to prevent touching <see cref="_stoppingCts"/> that might have already been disposed.</remarks>
 	private volatile bool _disposeRequested;
 
-	public Global(string dataDir, string configFilePath, Config config)
+	public Global(string dataDir, Config config)
 	{
 		DataDir = dataDir;
-		ConfigFilePath = configFilePath;
 		Config = config;
 		TorSettings = new TorSettings(
 			DataDir,
@@ -76,7 +75,7 @@ public class Global
 		BitcoinStore = new BitcoinStore(_indexStore, _allTransactionStore, mempoolService, smartHeaderChain, blocks);
 
 		ExternalSourcesHttpClientFactory = BuildHttpClientFactory();
-		BackendHttpClientFactory = new IndexerHttpClientFactory(Config.GetBackendUri(), BuildHttpClientFactory());
+		BackendHttpClientFactory = new IndexerHttpClientFactory(new Uri(config.BackendUri), BuildHttpClientFactory());
 
 		Uri[] relayUrls = [new ("wss://relay.primal.net"), new("wss://nos.lol"), new("wss://relay.damus.io")];
 		var nostrClientFactory = () => NostrClientFactory.Create(relayUrls, TorSettings.SocksEndpoint);
@@ -135,10 +134,10 @@ public class Global
 		ICompactFilterProvider filtersProvider =
 			new WebApiFilterProvider(maxFiltersToSync, BackendHttpClientFactory, EventBus);
 
-		var credentialString = config.GetBitcoinRpcCredentialString();
+		var credentialString = config.BitcoinRpcCredentialString;
 		if (config.UseBitcoinRpc && !string.IsNullOrWhiteSpace(credentialString))
 		{
-			var bitcoinRpcEndPoint = config.GetBitcoinRpcEndPoint();
+			var bitcoinRpcEndPoint = config.BitcoinRpcEndPoint;
 			BitcoinRpcClient = new RpcClientBase(new RPCClient(credentialString, bitcoinRpcEndPoint.ToString(), Network));
 			HostedServices.Register<RpcMonitor>(() => new RpcMonitor(TimeSpan.FromSeconds(7), BitcoinRpcClient, EventBus), "RPC Monitor");
 
@@ -197,8 +196,6 @@ public class Global
 	public IHttpClientFactory ExternalSourcesHttpClientFactory { get; }
 	public IHttpClientFactory BackendHttpClientFactory { get; }
 	public IHttpClientFactory? CoordinatorHttpClientFactory { get; set; }
-
-	public string ConfigFilePath { get; }
 	public Config Config { get; }
 	public WalletManager WalletManager { get; }
 	public TransactionBroadcaster TransactionBroadcaster { get; set; }

--- a/WalletWasabi.Daemon/WasabiApplication.cs
+++ b/WalletWasabi.Daemon/WasabiApplication.cs
@@ -105,7 +105,10 @@ public class WasabiApplication
 	{
 		CreateConfigFiles();
 		MigrateConfigFiles();
+
+		var networkFilePath = Path.Combine(Config.DataDir, ".network");
 		Config.GetCliArgsValue("network", AppConfig.Arguments, out var networkName);
+		networkName ??= File.ReadAllText(networkFilePath);
 		var network = Network.GetNetwork(networkName ?? "mainnet");
 		var configFileName = networkName switch
 		{

--- a/WalletWasabi.Daemon/WasabiApplication.cs
+++ b/WalletWasabi.Daemon/WasabiApplication.cs
@@ -150,7 +150,7 @@ public class WasabiApplication
 		var configFilePath = Path.Combine(Config.DataDir, "Config.json");
 		var persistentConfig = PersistentConfigManager.LoadFile(configFilePath);
 
-		if (persistentConfig is PersistentConfigPrev2_5_1 oldConfig)
+		if (persistentConfig is PersistentConfigPrev2_6_0 oldConfig)
 		{
 			oldConfig = oldConfig.Migrate();
 			var mainConfig = new PersistentConfig(

--- a/WalletWasabi.Daemon/WasabiApplication.cs
+++ b/WalletWasabi.Daemon/WasabiApplication.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using WalletWasabi.Bases;
 using WalletWasabi.Extensions;
+using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Services;
 using WalletWasabi.Services.Terminate;
@@ -151,10 +152,10 @@ public class WasabiApplication
 				JsonRpcUser = oldConfig.JsonRpcUser,
 				JsonRpcPassword = oldConfig.JsonRpcPassword,
 				JsonRpcServerEnabled = oldConfig.JsonRpcServerEnabled,
-				JsonRpcServerPrefixes = oldConfig.JsonRpcServerPrefixes,
+				JsonRpcServerPrefixes = new ValueList<string>(oldConfig.JsonRpcServerPrefixes),
 				TerminateTorOnExit = oldConfig.TerminateTorOnExit,
 				IndexerUri = oldConfig.MainNetIndexerUri,
-				TorBridges = oldConfig.TorBridges,
+				TorBridges = new ValueList<string>(oldConfig.TorBridges),
 				MaxCoinJoinMiningFeeRate = oldConfig.MaxCoinJoinMiningFeeRate
 			};
 			var mainnetConfigFilePath = Path.Combine(Config.DataDir, "Config.json");

--- a/WalletWasabi.Daemon/WasabiApplication.cs
+++ b/WalletWasabi.Daemon/WasabiApplication.cs
@@ -106,7 +106,7 @@ public class WasabiApplication
 		CreateConfigFiles();
 		MigrateConfigFiles();
 
-		var networkFilePath = Path.Combine(Config.DataDir, ".network");
+		var networkFilePath = Path.Combine(Config.DataDir, "network");
 		Config.GetCliArgsValue("network", AppConfig.Arguments, out var networkName);
 		networkName ??= File.ReadAllText(networkFilePath);
 		var network = Network.GetNetwork(networkName ?? "mainnet");

--- a/WalletWasabi.Fluent/App.axaml.cs
+++ b/WalletWasabi.Fluent/App.axaml.cs
@@ -115,7 +115,7 @@ public class App : Application
 
 	private static IApplicationSettings CreateApplicationSettings()
 	{
-		return new ApplicationSettings(Services.PersistentConfigFilePath, Services.PersistentConfig, Services.Config, Services.UiConfig);
+		return new ApplicationSettings(Services.PersistentConfig, Services.Config, Services.UiConfig);
 	}
 
 	private static ITransactionBroadcasterModel CreateBroadcaster(Network network)

--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -78,6 +78,7 @@ public partial class ApplicationSettings : ReactiveObject
 
 	public ApplicationSettings(PersistentConfig persistentConfig, Config config, UiConfig uiConfig)
 	{
+		_persistentConfigFilePath = Services.PersistentConfigFilePath;
 		_startupConfig = persistentConfig;
 
 		_config = config;
@@ -255,44 +256,31 @@ public partial class ApplicationSettings : ReactiveObject
 		result = result with { EnableGpu = EnableGpu };
 
 		// Bitcoin
-		if (Network == config.Network)
+		if (EndPointParser.TryParse(BitcoinRpcEndPoint, Network.DefaultPort, out EndPoint? endPoint))
 		{
-			if (EndPointParser.TryParse(BitcoinRpcEndPoint, Network.DefaultPort, out EndPoint? endPoint))
-			{
-				result = result with { BitcoinRpcEndPoint = endPoint, BitcoinRpcCredentialString = BitcoinRpcCredentialString};
-			}
-
-			result = result with { CoordinatorUri = CoordinatorUri };
-			result = result with { IndexerUri = IndexerUri };
-
-			result = result with
-			{
-				UseBitcoinRpc = UseBitcoinRpc,
-				DustThreshold = decimal.TryParse(DustThreshold, out var threshold) ?
-					Money.Coins(threshold) :
-					Money.Coins(Constants.DefaultDustThreshold),
-				MaxCoinJoinMiningFeeRate = decimal.TryParse(MaxCoinJoinMiningFeeRate, out var maxCoinjoinMiningFeeRate) ?
-					maxCoinjoinMiningFeeRate :
-					Constants.DefaultMaxCoinJoinMiningFeeRate,
-				AbsoluteMinInputCount = int.TryParse(AbsoluteMinInputCount, out var absoluteMinInputCount) ?
-					absoluteMinInputCount :
-					Constants.DefaultAbsoluteMinInputCount,
-				ExchangeRateProvider = ExchangeRateProvider,
-				FeeRateEstimationProvider = FeeRateEstimationProvider,
-				ExternalTransactionBroadcaster = ExternalTransactionBroadcaster
-			};
+			result = result with { BitcoinRpcEndPoint = endPoint, BitcoinRpcCredentialString = BitcoinRpcCredentialString};
 		}
-		else
+
+		result = result with { CoordinatorUri = CoordinatorUri };
+		result = result with { IndexerUri = IndexerUri };
+
+		result = result with
 		{
-			result = result with
-			{
-				Network = Network
-			};
-
-			BitcoinRpcEndPoint = result.BitcoinRpcEndPoint.ToString(defaultPort: -1);
-			BitcoinRpcCredentialString = result.BitcoinRpcCredentialString;
-			IndexerUri = result.IndexerUri;
-		}
+			Network = Network,
+			UseBitcoinRpc = UseBitcoinRpc,
+			DustThreshold = decimal.TryParse(DustThreshold, out var threshold) ?
+				Money.Coins(threshold) :
+				Money.Coins(Constants.DefaultDustThreshold),
+			MaxCoinJoinMiningFeeRate = decimal.TryParse(MaxCoinJoinMiningFeeRate, out var maxCoinjoinMiningFeeRate) ?
+				maxCoinjoinMiningFeeRate :
+				Constants.DefaultMaxCoinJoinMiningFeeRate,
+			AbsoluteMinInputCount = int.TryParse(AbsoluteMinInputCount, out var absoluteMinInputCount) ?
+				absoluteMinInputCount :
+				Constants.DefaultAbsoluteMinInputCount,
+			ExchangeRateProvider = ExchangeRateProvider,
+			FeeRateEstimationProvider = FeeRateEstimationProvider,
+			ExternalTransactionBroadcaster = ExternalTransactionBroadcaster
+		};
 
 		// General
 		result = result with

--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -201,10 +201,14 @@ public partial class ApplicationSettings : ReactiveObject
 
 	public void ResetToDefault()
 	{
-		var newPersistentConfig = new PersistentConfig
+		var defaultConfig = _startupConfig.Network switch
 		{
-			CoordinatorUri = CoordinatorUri,
+			var network when network == Network.Main => PersistentConfigManager.DefaultMainNetConfig,
+			var network when network == Network.TestNet => PersistentConfigManager.DefaultTestNetConfig,
+			var network when network == Network.RegTest => PersistentConfigManager.DefaultRegTestConfig,
 		};
+
+		var newPersistentConfig = defaultConfig with {CoordinatorUri = CoordinatorUri};
 
 		var newUiConfig = new UiConfig
 		{

--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -50,9 +50,7 @@ public partial class ApplicationSettings : ReactiveObject
 	[AutoNotify] private string _externalTransactionBroadcaster;
 
 	// Coordinator
-	[AutoNotify] private string _mainNetCoordinatorUri;
-	[AutoNotify] private string _testNetCoordinatorUri;
-	[AutoNotify] private string _regTestCoordinatorUri;
+	[AutoNotify] private string _coordinatorUri;
 	[AutoNotify] private string _maxCoinJoinMiningFeeRate;
 	[AutoNotify] private string _absoluteMinInputCount;
 
@@ -78,9 +76,8 @@ public partial class ApplicationSettings : ReactiveObject
 	// Non-persistent
 	[AutoNotify] private bool _doUpdateOnClose;
 
-	public ApplicationSettings(string persistentConfigFilePath, PersistentConfig persistentConfig, Config config, UiConfig uiConfig)
+	public ApplicationSettings(PersistentConfig persistentConfig, Config config, UiConfig uiConfig)
 	{
-		_persistentConfigFilePath = persistentConfigFilePath;
 		_startupConfig = persistentConfig;
 
 		_config = config;
@@ -93,7 +90,7 @@ public partial class ApplicationSettings : ReactiveObject
 	private void ApplyConfigs(PersistentConfig persistentConfig, UiConfig uiConfig)
 	{
 		// Connections
-		IndexerUri = persistentConfig.GetIndexerUri();
+		IndexerUri = persistentConfig.IndexerUri;
 		UseTor = Config.ObjectToTorMode(persistentConfig.UseTor);
 		ExchangeRateProvider = persistentConfig.ExchangeRateProvider;
 		FeeRateEstimationProvider = persistentConfig.FeeRateEstimationProvider;
@@ -102,14 +99,12 @@ public partial class ApplicationSettings : ReactiveObject
 		// Bitcoin
 		Network = persistentConfig.Network;
 		UseBitcoinRpc = persistentConfig.UseBitcoinRpc;
-		BitcoinRpcEndPoint = persistentConfig.GetBitcoinRpcEndPoint().ToString(defaultPort: -1);
-		BitcoinRpcCredentialString = persistentConfig.GetBitcoinRpcCredentialString();
+		BitcoinRpcEndPoint = persistentConfig.BitcoinRpcEndPoint.ToString(defaultPort: -1);
+		BitcoinRpcCredentialString = persistentConfig.BitcoinRpcCredentialString;
 		DustThreshold = persistentConfig.DustThreshold.ToString();
 
 		// Coordinator
-		MainNetCoordinatorUri = persistentConfig.MainNetCoordinatorUri;
-		TestNetCoordinatorUri = persistentConfig.TestNetCoordinatorUri;
-		RegTestCoordinatorUri = persistentConfig.RegTestCoordinatorUri;
+		CoordinatorUri = persistentConfig.CoordinatorUri;
 
 		MaxCoinJoinMiningFeeRate = persistentConfig.MaxCoinJoinMiningFeeRate.ToString(CultureInfo.InvariantCulture);
 		AbsoluteMinInputCount = persistentConfig.AbsoluteMinInputCount.ToString(CultureInfo.InvariantCulture);
@@ -154,14 +149,12 @@ public partial class ApplicationSettings : ReactiveObject
 			this.WhenAnyValue(
 					x => x.MaxCoinJoinMiningFeeRate,
 					x => x.AbsoluteMinInputCount,
-					x => x.MainNetCoordinatorUri,
-					x => x.TestNetCoordinatorUri,
-					x => x.RegTestCoordinatorUri,
+					x => x.CoordinatorUri,
 					x => x.IndexerUri,
 					x => x.ExchangeRateProvider,
 					x => x.FeeRateEstimationProvider,
 					x => x.ExternalTransactionBroadcaster,
-					(_, _, _, _, _, _, _, _, _) => Unit.Default)
+					(_, _, _, _, _, _, _) => Unit.Default)
 				.Skip(1);
 
 		Observable
@@ -209,9 +202,7 @@ public partial class ApplicationSettings : ReactiveObject
 	{
 		var newPersistentConfig = new PersistentConfig
 		{
-			MainNetCoordinatorUri = MainNetCoordinatorUri,
-			TestNetCoordinatorUri = TestNetCoordinatorUri,
-			RegTestCoordinatorUri = RegTestCoordinatorUri
+			CoordinatorUri = CoordinatorUri,
 		};
 
 		var newUiConfig = new UiConfig
@@ -229,7 +220,7 @@ public partial class ApplicationSettings : ReactiveObject
 
 	public bool CheckIfRestartIsNeeded(PersistentConfig config)
 	{
-		return !_startupConfig.DeepEquals(config);
+		return _startupConfig != config;
 	}
 
 	private void Save()
@@ -239,8 +230,12 @@ public partial class ApplicationSettings : ReactiveObject
 			{
 				try
 				{
-					PersistentConfig currentConfig = PersistentConfigManager.LoadFile(_persistentConfigFilePath);
-					PersistentConfig newConfig = ApplyChanges(currentConfig);
+					var loadedConfig = PersistentConfigManager.LoadFile(_persistentConfigFilePath);
+					if (loadedConfig is not PersistentConfig currentConfig)
+					{
+						throw new NotSupportedException("Only configuration files after v2.5.1 are supported.");
+					}
+					var newConfig = ApplyChanges(currentConfig);
 					PersistentConfigManager.ToFile(_persistentConfigFilePath, newConfig);
 
 					_isRestartNeeded.OnNext(CheckIfRestartIsNeeded(newConfig));
@@ -264,44 +259,11 @@ public partial class ApplicationSettings : ReactiveObject
 		{
 			if (EndPointParser.TryParse(BitcoinRpcEndPoint, Network.DefaultPort, out EndPoint? endPoint))
 			{
-				if (Network == Network.Main)
-				{
-					result = result with { MainNetBitcoinRpcEndPoint = endPoint, MainNetBitcoinRpcCredentialString = BitcoinRpcCredentialString};
-				}
-				else if (Network == Network.TestNet)
-				{
-					result = result with { TestNetBitcoinRpcEndPoint = endPoint, TestNetBitcoinRpcCredentialString = BitcoinRpcCredentialString};
-				}
-				else if (Network == Network.RegTest)
-				{
-					result = result with { RegTestBitcoinRpcEndPoint = endPoint, RegTestBitcoinRpcCredentialString = BitcoinRpcCredentialString};
-				}
-				else
-				{
-					throw new NotSupportedNetworkException(Network);
-				}
+				result = result with { BitcoinRpcEndPoint = endPoint, BitcoinRpcCredentialString = BitcoinRpcCredentialString};
 			}
 
-			result = result with { MainNetCoordinatorUri = MainNetCoordinatorUri };
-			result = result with { TestNetCoordinatorUri = TestNetCoordinatorUri };
-			result = result with { RegTestCoordinatorUri = RegTestCoordinatorUri };
-
-			if (Network == Network.Main)
-			{
-				result = result with { MainNetIndexerUri = IndexerUri };
-			}
-			else if (Network == Network.TestNet)
-			{
-				result = result with { TestNetIndexerUri = IndexerUri };
-			}
-			else if (Network == Network.RegTest)
-			{
-				result = result with { RegTestIndexerUri = IndexerUri };
-			}
-			else
-			{
-				throw new NotSupportedNetworkException(Network);
-			}
+			result = result with { CoordinatorUri = CoordinatorUri };
+			result = result with { IndexerUri = IndexerUri };
 
 			result = result with
 			{
@@ -327,9 +289,9 @@ public partial class ApplicationSettings : ReactiveObject
 				Network = Network
 			};
 
-			BitcoinRpcEndPoint = result.GetBitcoinRpcEndPoint().ToString(defaultPort: -1);
-			BitcoinRpcCredentialString = result.GetBitcoinRpcCredentialString();
-			IndexerUri = result.GetIndexerUri();
+			BitcoinRpcEndPoint = result.BitcoinRpcEndPoint.ToString(defaultPort: -1);
+			BitcoinRpcCredentialString = result.BitcoinRpcCredentialString;
+			IndexerUri = result.IndexerUri;
 		}
 
 		// General
@@ -352,62 +314,13 @@ public partial class ApplicationSettings : ReactiveObject
 			return false;
 		}
 
-		if (!TrySetCoordinatorUri(coordinatorConnectionString.CoordinatorUri.ToString(), coordinatorConnectionString.Network))
-		{
-			return false;
-		}
+		CoordinatorUri = coordinatorConnectionString.CoordinatorUri.ToString();
 
 		AbsoluteMinInputCount = coordinatorConnectionString.AbsoluteMinInputCount.ToString();
 
 		// TODO: Save Name and ReadMoreUri to display it after.
 
 		return true;
-	}
-
-	public bool TrySetCoordinatorUri(string uri, Network? network = null)
-	{
-		network ??= Network;
-
-		if (network == Network.Main)
-		{
-			MainNetCoordinatorUri = uri;
-			return true;
-		}
-
-		if (network == Network.TestNet)
-		{
-			TestNetCoordinatorUri = uri;
-			return true;
-		}
-
-		if (network == Network.RegTest)
-		{
-			RegTestCoordinatorUri = uri;
-			return true;
-		}
-
-		Logger.LogWarning($"Coordinator URI didn't change due to unknown network: {network}");
-		return false;
-	}
-
-	public string GetCoordinatorUri()
-	{
-		if (Network == Network.Main)
-		{
-			return MainNetCoordinatorUri;
-		}
-
-		if (Network == Network.TestNet)
-		{
-			return TestNetCoordinatorUri;
-		}
-
-		if (Network == Network.RegTest)
-		{
-			return RegTestCoordinatorUri;
-		}
-
-		throw new NotSupportedNetworkException(Network);
 	}
 
 	private void ApplyUiConfigChanges()

--- a/WalletWasabi.Fluent/Services.cs
+++ b/WalletWasabi.Fluent/Services.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Net.Http;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.TransactionBroadcasting;
@@ -25,7 +26,7 @@ public static class Services
 
 	public static IHttpClientFactory HttpClientFactory { get; private set; } = null!;
 
-	public static string PersistentConfigFilePath { get; private set; } = null!;
+	public static string PersistentConfigFilePath => Path.Combine(DataDir, PersistentConfig.GetConfigFileName());
 
 	public static PersistentConfig PersistentConfig { get; private set; } = null!;
 
@@ -69,7 +70,6 @@ public static class Services
 		TorSettings = global.TorSettings;
 		BitcoinStore = global.BitcoinStore;
 		HttpClientFactory = global.ExternalSourcesHttpClientFactory;
-		PersistentConfigFilePath = global.ConfigFilePath;
 		PersistentConfig = global.Config.PersistentConfig;
 		WalletManager = global.WalletManager;
 		TransactionBroadcaster = global.TransactionBroadcaster;

--- a/WalletWasabi.Fluent/UiConfig/UiConfig.cs
+++ b/WalletWasabi.Fluent/UiConfig/UiConfig.cs
@@ -168,6 +168,13 @@ public class UiConfig : ConfigBase
 			var decodingResult = decoder(cfgFile);
 			return decodingResult.Match(cfg => cfg, error => throw new InvalidOperationException(error));
 		}
+		catch (FileNotFoundException)
+		{
+			var config = new UiConfig(filePath);
+			File.WriteAllTextAsync(filePath, config.EncodeAsJson());
+			Logging.Logger.LogInfo($"File did not exist. Created at path: '{filePath}'.");
+			return config;
+		}
 		catch (Exception ex)
 		{
 			var config = new UiConfig(filePath);

--- a/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
@@ -35,17 +35,15 @@ public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 		this.ValidateProperty(x => x.MaxCoinJoinMiningFeeRate, ValidateMaxCoinJoinMiningFeeRate);
 		this.ValidateProperty(x => x.AbsoluteMinInputCount, ValidateAbsoluteMinInputCount);
 
-		_coordinatorUri = settings.GetCoordinatorUri();
+		_coordinatorUri = settings.CoordinatorUri;
 		_maxCoinJoinMiningFeeRate = settings.MaxCoinJoinMiningFeeRate;
 		_absoluteMinInputCount = settings.AbsoluteMinInputCount;
 
 		this.WhenAnyValue(
-				x => x.Settings.MainNetCoordinatorUri,
-				x => x.Settings.TestNetCoordinatorUri,
-				x => x.Settings.RegTestCoordinatorUri,
+				x => x.Settings.CoordinatorUri,
 				x => x.Settings.Network)
 			.ToSignal()
-			.Subscribe(x => CoordinatorUri = Settings.GetCoordinatorUri());
+			.Subscribe(x => CoordinatorUri = Settings.CoordinatorUri);
 
 		this.WhenAnyValue(x => x.Settings.MaxCoinJoinMiningFeeRate)
 			.ToSignal()
@@ -75,7 +73,7 @@ public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 			return;
 		}
 
-		Settings.TrySetCoordinatorUri(coordinatorUri);
+		Settings.CoordinatorUri = coordinatorUri;
 	}
 
 	private void ValidateMaxCoinJoinMiningFeeRate(IValidationErrors errors)

--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -10,12 +10,6 @@
   <StackPanel Classes="settingsLayout">
 
     <DockPanel>
-      <TextBlock Text="Network" />
-      <ComboBox ItemsSource="{Binding Networks}"
-                SelectedItem="{Binding Settings.Network}" />
-    </DockPanel>
-
-    <DockPanel>
       <TextBlock Text="Connect to Bitcoin Node RPC" />
       <ToggleSwitch IsChecked="{Binding Settings.UseBitcoinRpc}" />
     </DockPanel>

--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -10,6 +10,12 @@
   <StackPanel Classes="settingsLayout">
 
     <DockPanel>
+      <TextBlock Text="Network" />
+      <ComboBox ItemsSource="{Binding Networks}"
+                SelectedItem="{Binding Settings.Network}" />
+    </DockPanel>
+
+    <DockPanel>
       <TextBlock Text="Connect to Bitcoin Node RPC" />
       <ToggleSwitch IsChecked="{Binding Settings.UseBitcoinRpc}" />
     </DockPanel>

--- a/WalletWasabi.Tests/UnitTests/Bases/PersistentConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/PersistentConfigManagerTests.cs
@@ -14,9 +14,6 @@ namespace WalletWasabi.Tests.UnitTests.Bases;
 /// </summary>
 public class PersistentConfigManagerTests
 {
-	/// <summary>
-	/// Tests <see cref="PersistentConfigManager.ToFile{T}(string, T)"/> and <see cref="PersistentConfigManager.LoadFile{TResponse}(string, bool)"/>.
-	/// </summary>
 	[Fact]
 	public async Task ToFileAndLoadFileTestAsync()
 	{
@@ -29,10 +26,10 @@ public class PersistentConfigManagerTests
 		PersistentConfig actualConfig = new();
 
 		string storedJson = PersistentConfigManager.ToFile(configPath, actualConfig);
-		PersistentConfig readConfig = PersistentConfigManager.LoadFile(configPath);
+		var readConfig = PersistentConfigManager.LoadFile(configPath) as PersistentConfig;
 
 		// Objects are supposed to be equal by value-equality rules.
-		Assert.True(actualConfig.DeepEquals(readConfig));
+		Assert.Equal(actualConfig, readConfig);
 
 		// Check that JSON strings are equal as well.
 		{
@@ -47,23 +44,15 @@ public class PersistentConfigManagerTests
 			=> $$"""
 			{
 			  "Network": "Main",
-			  "MainNetBackendUri": "https://api.wasabiwallet.io/",
-			  "TestNetBackendUri": "https://api.wasabiwallet.co/",
-			  "RegTestBackendUri": "http://localhost:37127/",
-			  "MainNetCoordinatorUri": "",
-			  "TestNetCoordinatorUri": "",
-			  "RegTestCoordinatorUri": "http://localhost:37128/",
+			  "BackendUri": "https://api.wasabiwallet.io/",
+			  "CoordinatorUri": "",
 			  "UseTor": "Enabled",
 			  "TerminateTorOnExit": false,
 			  "TorBridges": [],
 			  "DownloadNewVersion": true,
 			  "UseBitcoinRpc": false,
-			  "MainNetBitcoinRpcCredentialString": "",
-			  "TestNetBitcoinRpcCredentialString": "",
-			  "RegTestBitcoinRpcCredentialString": "",
-			  "MainNetBitcoinRpcEndPoint": "127.0.0.1:8332",
-			  "TestNetBitcoinRpcEndPoint": "127.0.0.1:48332",
-			  "RegTestBitcoinRpcEndPoint": "127.0.0.1:18443",
+			  "BitcoinRpcCredentialString": "",
+			  "BitcoinRpcEndPoint": "127.0.0.1:8332",
 			  "JsonRpcServerEnabled": false,
 			  "JsonRpcUser": "",
 			  "JsonRpcPassword": "",

--- a/WalletWasabi.Tests/UnitTests/Bases/PersistentConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/PersistentConfigManagerTests.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Text.Json;
 using System.Threading.Tasks;
 using WalletWasabi.Bases;
 using WalletWasabi.Daemon;
@@ -43,7 +42,6 @@ public class PersistentConfigManagerTests
 		static string GetConfigString(string localBitcoinCoreDataDir)
 			=> $$"""
 			{
-			  "Network": "Main",
 			  "BackendUri": "https://api.wasabiwallet.io/",
 			  "CoordinatorUri": "",
 			  "UseTor": "Enabled",
@@ -68,6 +66,7 @@ public class PersistentConfigManagerTests
 			  "ExternalTransactionBroadcaster": "MempoolSpace",
 			  "MaxCoinJoinMiningFeeRate": 150.0,
 			  "AbsoluteMinInputCount": 21,
+			  "MaxDaysInMempool": 30,
 			  "ConfigVersion": 0
 			}
 			""";

--- a/WalletWasabi.Tests/UnitTests/Bases/PersistentConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/PersistentConfigManagerTests.cs
@@ -22,7 +22,7 @@ public class PersistentConfigManagerTests
 		string expectedLocalBitcoinCoreDataDir = nameof(PersistentConfigManagerTests);
 
 		// Create config and store it.
-		PersistentConfig actualConfig = new();
+		PersistentConfig actualConfig = PersistentConfigManager.DefaultMainNetConfig;
 
 		string storedJson = PersistentConfigManager.ToFile(configPath, actualConfig);
 		var readConfig = PersistentConfigManager.LoadFile(configPath) as PersistentConfig;
@@ -67,7 +67,7 @@ public class PersistentConfigManagerTests
 			  "MaxCoinJoinMiningFeeRate": 150.0,
 			  "AbsoluteMinInputCount": 21,
 			  "MaxDaysInMempool": 30,
-			  "ConfigVersion": 0
+			  "ConfigVersion": 2
 			}
 			""";
 

--- a/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullApplicationSettings.cs
+++ b/WalletWasabi.Tests/UnitTests/ViewModels/UiContext/NullApplicationSettings.cs
@@ -29,8 +29,7 @@ public class NullApplicationSettings : IApplicationSettings
 	public string ExchangeRateProvider { get; set; } = "";
 	public string FeeRateEstimationProvider { get; set; } = "";
 	public string ExternalTransactionBroadcaster { get; set; } = "";
-	public string MainNetCoordinatorUri { get; set; } = "";
-	public string TestNetCoordinatorUri { get; set; } = "";
+	public string CoordinatorUri { get; set; } = "";
 	public bool DarkModeEnabled { get; set; }
 	public bool AutoCopy { get; set; }
 	public bool AutoPaste { get; set; }
@@ -60,11 +59,6 @@ public class NullApplicationSettings : IApplicationSettings
 	public bool TrySetCoordinatorUri(string uri, Network? network = null)
 	{
 		return false;
-	}
-
-	public string GetCoordinatorUri()
-	{
-		return "";
 	}
 
 	public void ResetToDefault()

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -89,6 +89,7 @@ public static class Constants
 
 	public static readonly string DefaultExchangeRateProvider = "MempoolSpace";
 	public static readonly string DefaultFeeRateEstimationProvider = "MempoolSpace";
+	public static readonly string DefaultExternalTransactionBroadcaster= "MempoolSpace";
 
 	public static readonly Money MaximumNumberOfBitcoinsMoney = Money.Coins(MaximumNumberOfBitcoins);
 

--- a/WalletWasabi/Helpers/ValueList.cs
+++ b/WalletWasabi/Helpers/ValueList.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WalletWasabi.Helpers;
+
+public class ValueList<T>(T[] items) : IEnumerable<T>, IEquatable<ValueList<T>>
+	where T : IEquatable<T>
+{
+	public static ValueList<T> Empty { get; } = new([]);
+
+	public bool Equals(ValueList<T>? other) =>
+		this.SequenceEqual(other as IEnumerable<T> ?? []);
+
+	public override int GetHashCode() =>
+		items.Aggregate(typeof(T).GetHashCode(), HashCode.Combine);
+
+	public override bool Equals(object? obj) =>
+		Equals(obj as ValueList<T>);
+
+	public IEnumerator<T> GetEnumerator() =>
+		((IEnumerable<T>) items).GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() =>
+		((IEnumerable) items).GetEnumerator();
+}

--- a/WalletWasabi/Helpers/ValueList.cs
+++ b/WalletWasabi/Helpers/ValueList.cs
@@ -7,6 +7,10 @@ namespace WalletWasabi.Helpers;
 public class ValueList<T>(T[] items) : IEnumerable<T>, IEquatable<ValueList<T>>
 	where T : IEquatable<T>
 {
+	public ValueList() : this(Array.Empty<T>())
+	{
+	}
+
 	public static ValueList<T> Empty { get; } = new([]);
 
 	public bool Equals(ValueList<T>? other) =>


### PR DESCRIPTION
The current config file has some properties that are network dependent and others that are not. Why? Because otherwise all the properties should triplicado `MainNetSomething`, `TestNetSomething` and `RegTestSomething`.

In other to make it easier to configure Wasabi with different settings for different networks, each network has its own configuration file.