### PR TITLE
Move Max CJ FeeRate to Coinjoin settings

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
@@ -24,7 +24,6 @@ namespace WalletWasabi.Fluent.ViewModels.Settings;
 public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 {
 	[AutoNotify] private string _coordinatorUri;
-	[AutoNotify] private string _maxCoinJoinMiningFeeRate;
 	[AutoNotify] private string _absoluteMinInputCount;
 
 	public CoordinatorTabSettingsViewModel(IApplicationSettings settings)
@@ -32,11 +31,9 @@ public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 		Settings = settings;
 
 		this.ValidateProperty(x => x.CoordinatorUri, ValidateCoordinatorUri);
-		this.ValidateProperty(x => x.MaxCoinJoinMiningFeeRate, ValidateMaxCoinJoinMiningFeeRate);
 		this.ValidateProperty(x => x.AbsoluteMinInputCount, ValidateAbsoluteMinInputCount);
 
 		_coordinatorUri = settings.GetCoordinatorUri();
-		_maxCoinJoinMiningFeeRate = settings.MaxCoinJoinMiningFeeRate;
 		_absoluteMinInputCount = settings.AbsoluteMinInputCount;
 
 		this.WhenAnyValue(
@@ -46,10 +43,6 @@ public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 				x => x.Settings.Network)
 			.ToSignal()
 			.Subscribe(x => CoordinatorUri = Settings.GetCoordinatorUri());
-
-		this.WhenAnyValue(x => x.Settings.MaxCoinJoinMiningFeeRate)
-			.ToSignal()
-			.Subscribe(x => MaxCoinJoinMiningFeeRate = Settings.MaxCoinJoinMiningFeeRate);
 
 		this.WhenAnyValue(x => x.Settings.AbsoluteMinInputCount)
 			.ToSignal()
@@ -76,30 +69,6 @@ public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 		}
 
 		Settings.TrySetCoordinatorUri(coordinatorUri);
-	}
-
-	private void ValidateMaxCoinJoinMiningFeeRate(IValidationErrors errors)
-	{
-		var maxCoinJoinMiningFeeRate = MaxCoinJoinMiningFeeRate;
-
-		if (string.IsNullOrEmpty(maxCoinJoinMiningFeeRate))
-		{
-			return;
-		}
-
-		if (!decimal.TryParse(maxCoinJoinMiningFeeRate, out var maxCoinJoinMiningFeeRateDecimal))
-		{
-			errors.Add(ErrorSeverity.Error, "Invalid number.");
-			return;
-		}
-
-		if (maxCoinJoinMiningFeeRateDecimal < 1)
-		{
-			errors.Add(ErrorSeverity.Error, "Mining fee rate must be at least 1 sat/vb");
-			return;
-		}
-
-		Settings.MaxCoinJoinMiningFeeRate = maxCoinJoinMiningFeeRateDecimal.ToString(CultureInfo.InvariantCulture);
 	}
 
 	private void ValidateAbsoluteMinInputCount(IValidationErrors errors)

--- a/WalletWasabi.Fluent/Views/Settings/CoordinatorTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/CoordinatorTabSettingsView.axaml
@@ -20,11 +20,6 @@
       </TextBox>
     </DockPanel>
 
-    <DockPanel ToolTip.Tip="The client will refuse to participate in rounds with a mining fee rate (sat/vb) higher than the value indicated here.">
-      <TextBlock Text="Max Coinjoin Mining Fee Rate" />
-      <CurrencyEntryBox Classes="standalone" Name="CoinJoinMiningFeeRateTextBox" Text="{Binding MaxCoinJoinMiningFeeRate}" CurrencyCode="sat/vb"/>
-    </DockPanel>
-
     <DockPanel ToolTip.Tip="The client will refuse to participate in rounds with a minimum input count lower than the value indicated here.">
       <TextBlock Text="Min Input Count" />
       <TextBox Classes="standalone" Name="AbsoluteMinInputCountTextBox" Text="{Binding AbsoluteMinInputCount}">

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
@@ -58,6 +58,11 @@
       <TextBox Classes="standalone" Name="AnonScoreTargetTextBox" Text="{Binding AnonScoreTarget}" DockPanel.Dock="Right" Watermark="Choose between 2 and 300." MaxLength="3" />
     </DockPanel>
 
+    <DockPanel ToolTip.Tip="The client will refuse to participate in rounds with a mining fee rate (sat/vb) higher than the value indicated here.">
+      <TextBlock Text="Max Coinjoin Mining Fee Rate" />
+      <CurrencyEntryBox Classes="standalone" Name="CoinJoinMiningFeeRateTextBox" Text="{Binding MaxCoinJoinMiningFeeRate}" CurrencyCode="sat/vb"/>
+    </DockPanel>
+
     <Separator />
 
     <DockPanel>


### PR DESCRIPTION
Closes: https://github.com/WalletWasabi/WalletWasabi/issues/13852

Even with this change, `MaxCJFeeRate` is still a global setting and not per wallet setting.
Which can be a little bit confusing, because now the `MaxCJFeeRate` is under "Wallet Settings".

Should we make it a setting for each wallet?

_If we should not move this settings, please close the PR._