### PR TITLE
SLIP-39 Seed entropy reduced to 128 bits (20 words)

### DIFF
--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -97,6 +97,6 @@ public class WalletGenerator
 
 	public static byte[] GenerateShamirEntropy()
 	{
-		return RandomUtils.GetBytes(256 / 8);
+		return RandomUtils.GetBytes(128 / 8);
 	}
 }


### PR DESCRIPTION
BIP39 Wasabi wallets are created with 128bits entropy. SLIP39 Wasabi wallet must be 128 too. 