### PR TITLE
[trivial] improve Tor warning text

### DIFF
--- a/WalletWasabi.Fluent/Views/StatusIcon/TorIssues.axaml
+++ b/WalletWasabi.Fluent/Views/StatusIcon/TorIssues.axaml
@@ -16,7 +16,7 @@
     <ToolTip.Tip>
       <DockPanel>
         <TextBlock DockPanel.Dock="Top" Text="Tor network is having issues:" />
-        <TextBlock DockPanel.Dock="Bottom" Text="Click this icon for details" />
+        <TextBlock DockPanel.Dock="Bottom" Text="Click this icon for details on the Tor website" />
         <ItemsControl Margin="8" ItemsSource="{Binding HealthMonitor.TorIssues}">
           <ItemsControl.ItemTemplate>
             <DataTemplate x:DataType="tor:Issue">


### PR DESCRIPTION
When the user reads `Click on this icon for details` it does not expect it to open the browser.
So mention it in the text.

until https://github.com/WalletWasabi/WalletWasabi/issues/12022 is implemented, we should make it clear for the user that a link will lead to/opens the browser (unexpectedly).

![Screenshot from 2025-04-30 11-24-57](https://github.com/user-attachments/assets/615a3b80-94b5-47fc-b897-dbec633ca3ff)
