### PR TITLE
Update Checker warning if Tor is disabled

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/StatusIcon/StatusIconViewModel.cs
@@ -53,6 +53,8 @@ public partial class StatusIconViewModel : ViewModelBase
 
 	public string BitcoinCoreName => "Bitcoin Node";
 
+	public bool IsTorDisabled => HealthMonitor.TorStatus == WalletWasabi.Models.TorStatus.TurnedOff;
+
 	private string GetVersionText()
 	{
 		if (HealthMonitor.IsReadyToInstall)

--- a/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
+++ b/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
@@ -109,6 +109,12 @@
                 </Panel>
               </StatusItem.Icon>
             </StatusItem>
+            
+            <StatusItem Title="Update Checker" StatusText="Wasabi won't look for updates while Tor is disabled." IsVisible="{Binding IsTorDisabled}">
+              <StatusItem.Icon>
+                <PathIcon Data="{StaticResource warning_filled}" />
+              </StatusItem.Icon>
+            </StatusItem>
 
             <StatusItem Title="Backend"
                           StatusText="{Binding HealthMonitor.IndexerStatus, Converter={x:Static converters:StatusConverters.IndexerStatusToString}}">


### PR DESCRIPTION
As discussed with @turbolay, we should mention the fact that Wasabi won't receive new release notifications while Tor is disabled.

![Screenshot 2025-05-09 140555](https://github.com/user-attachments/assets/dee09a92-a54b-487b-a675-df1bc81573b5)
