### PR TITLE
fix: replace EndPoint.ToString() with 'ToEndpointString()'.

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -143,7 +143,7 @@ public class Global
 		if (config.UseBitcoinRpc && !string.IsNullOrWhiteSpace(credentialString))
 		{
 			var bitcoinRpcEndPoint = config.BitcoinRpcEndPoint;
-			BitcoinRpcClient = new RpcClientBase(new RPCClient(credentialString, bitcoinRpcEndPoint.ToString(), Network));
+			BitcoinRpcClient = new RpcClientBase(new RPCClient(credentialString, bitcoinRpcEndPoint.ToEndpointString(), Network));
 			HostedServices.Register<RpcMonitor>(() => new RpcMonitor(TimeSpan.FromSeconds(7), BitcoinRpcClient, EventBus), "RPC Monitor");
 
 			var supportsBlockFilters = BitcoinRpcClient.SupportsBlockFiltersAsync(CancellationToken.None).GetAwaiter().GetResult();


### PR DESCRIPTION
using a hostname for the Bitcoin RPC connection currently does not work because 'DnsEndpoint.ToString()' returns a string in this format: 'AddressFamily/hostname:port' (result is: `Unspecified/bitcoind.startos:8332`), which is not a valid hostname+port.

NBitcoin has an extension method to get the correct string: ToEndpointString()