### PR TITLE
Parse endpoints correctly

### DIFF
--- a/WalletWasabi.Daemon/Config/Config.cs
+++ b/WalletWasabi.Daemon/Config/Config.cs
@@ -221,7 +221,7 @@ public class Config
 	{
 		if (GetOverrideValue(key, cliArgs, out string? overrideValue, out ValueSource? valueSource))
 		{
-			if (!EndPointParser.TryParse(overrideValue, 0, out var endpoint))
+			if (!EndPointParser.TryParse(overrideValue, out var endpoint))
 			{
 				throw new ArgumentNullException(key, "Not a valid endpoint");
 			}

--- a/WalletWasabi.Daemon/Config/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfig.cs
@@ -126,8 +126,8 @@ public record PersistentConfigPrev2_6_0(
 		static EndPoint GetRpcEndpoint(BitcoinConfig config, string network, int defaultPort) =>
 			(config.GetSettingOrNull("rpcbind", network), config.GetSettingOrNull("rpcport", network)) switch
 			{
-				({} host, {} port) when EndPointParser.TryParse($"{host}:{port}", defaultPort, out var endPoint) => endPoint,
-				({} host, null) when EndPointParser.TryParse(host, defaultPort, out var endPoint) => endPoint,
+				({} host, {} port) when EndPointParser.TryParse($"{host}:{port}", out var endPoint) => endPoint,
+				({} host, null) when EndPointParser.TryParse($"{host}:{defaultPort}", out var endPoint) => endPoint,
 				(null, {} port) when int.TryParse(port, out var intPort) => new IPEndPoint(IPAddress.Loopback, intPort),
 				_ => new IPEndPoint(IPAddress.Loopback, defaultPort)
 			};

--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -260,7 +260,7 @@ public partial class ApplicationSettings : ReactiveObject
 		result = result with { EnableGpu = EnableGpu };
 
 		// Bitcoin
-		if (EndPointParser.TryParse(BitcoinRpcEndPoint, Network.DefaultPort, out EndPoint? endPoint))
+		if (EndPointParser.TryParse(BitcoinRpcEndPoint, out EndPoint? endPoint))
 		{
 			result = result with { BitcoinRpcEndPoint = endPoint, BitcoinRpcCredentialString = BitcoinRpcCredentialString};
 		}

--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -57,7 +57,7 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 	{
 		if (!string.IsNullOrWhiteSpace(BitcoinRpcEndPoint))
 		{
-			if (!EndPointParser.TryParse(BitcoinRpcEndPoint, Settings.Network.DefaultPort, out _))
+			if (!EndPointParser.TryParse(BitcoinRpcEndPoint, out _))
 			{
 				errors.Add(ErrorSeverity.Error, "Invalid endpoint.");
 			}

--- a/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/BitcoinTabSettingsView.axaml
@@ -22,7 +22,8 @@
     <DockPanel IsVisible="{Binding Settings.UseBitcoinRpc}"
       ToolTip.Tip="Wasabi will download blocks from a full node you control.">
       <TextBlock Text="Bitcoin RPC Endpoint" />
-        <TextBox Text="{Binding BitcoinRpcEndPoint}">
+        <TextBox Text="{Binding BitcoinRpcEndPoint}"
+          Watermark="&lt;domain or ip&gt;:&lt;port&gt;">
           <Interaction.Behaviors>
             <TextBoxAutoSelectTextBehavior />
             <WhitespacePasteRemovalBehavior />

--- a/WalletWasabi.Tests/BitcoinCore/Configuration/CoreConfigTranslator.cs
+++ b/WalletWasabi.Tests/BitcoinCore/Configuration/CoreConfigTranslator.cs
@@ -46,7 +46,7 @@ public class CoreConfigTranslator
 	public WhiteBind? TryGetWhiteBind()
 	{
 		var stringValue = TryGetValue("whitebind");
-		if (stringValue is { } && WhiteBind.TryParse(stringValue, Network, out WhiteBind? value))
+		if (stringValue is { } && WhiteBind.TryParse(stringValue, out WhiteBind? value))
 		{
 			return value;
 		}

--- a/WalletWasabi.Tests/BitcoinCore/Configuration/Whitening/WhiteBind.cs
+++ b/WalletWasabi.Tests/BitcoinCore/Configuration/Whitening/WhiteBind.cs
@@ -5,6 +5,6 @@ namespace WalletWasabi.Tests.BitcoinCore.Configuration.Whitening;
 
 public class WhiteBind : WhiteEntry
 {
-	public static bool TryParse(string value, Network network, [NotNullWhen(true)] out WhiteBind? white)
-		=> TryParse<WhiteBind>(value, network, out white);
+	public static bool TryParse(string value, [NotNullWhen(true)] out WhiteBind? white)
+		=> TryParse<WhiteBind>(value, out white);
 }

--- a/WalletWasabi.Tests/BitcoinCore/Configuration/Whitening/WhiteEntry.cs
+++ b/WalletWasabi.Tests/BitcoinCore/Configuration/Whitening/WhiteEntry.cs
@@ -11,7 +11,7 @@ public abstract class WhiteEntry
 	public string Permissions { get; private set; } = "";
 	public EndPoint? EndPoint { get; private set; } = null;
 
-	public static bool TryParse<T>(string value, Network network, [NotNullWhen(true)] out T? whiteEntry) where T : WhiteEntry, new()
+	public static bool TryParse<T>(string value, [NotNullWhen(true)] out T? whiteEntry) where T : WhiteEntry, new()
 	{
 		whiteEntry = null;
 
@@ -19,7 +19,7 @@ public abstract class WhiteEntry
 		var parts = value?.Split('@');
 		if (parts is { })
 		{
-			if (EndPointParser.TryParse(parts.LastOrDefault(), network.DefaultPort, out EndPoint? endPoint))
+			if (EndPointParser.TryParse(parts.LastOrDefault(), out EndPoint? endPoint))
 			{
 				whiteEntry = new T
 				{

--- a/WalletWasabi.Tests/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi.Tests/BitcoinCore/CoreNode.cs
@@ -88,7 +88,7 @@ public class CoreNode
 			coreNodeParams.RpcEndPointStrategy.EndPoint.TryGetPort(out rpcPort);
 		}
 
-		if (!EndPointParser.TryParse($"{rpcHost}:{rpcPort}", coreNodeParams.Network.RPCPort, out EndPoint? rpcEndPoint))
+		if (!EndPointParser.TryParse($"{rpcHost}:{rpcPort}", out EndPoint? rpcEndPoint))
 		{
 			throw new InvalidOperationException($"Failed to get RPC endpoint on {rpcHost}:{rpcPort}.");
 		}

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTranslatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/ConfigTranslatorTests.cs
@@ -109,9 +109,6 @@ public class ConfigTranslatorTests
 		ipEndPoint = whiteBind!.EndPoint as IPEndPoint;
 		Assert.NotNull(ipEndPoint);
 		Assert.Equal(IPAddress.Loopback, ipEndPoint!.Address);
-
-		// Default port.
-		Assert.Equal(8333, ipEndPoint.Port);
 		Assert.Equal("", whiteBind.Permissions);
 
 		config.AddOrUpdate("whitebind=foo@127.0.0.1");
@@ -120,7 +117,6 @@ public class ConfigTranslatorTests
 		ipEndPoint = whiteBind!.EndPoint as IPEndPoint;
 		Assert.NotNull(ipEndPoint);
 		Assert.Equal(IPAddress.Loopback, ipEndPoint!.Address);
-		Assert.Equal(8333, ipEndPoint.Port);
 		Assert.Equal("foo", whiteBind.Permissions);
 
 		config.AddOrUpdate("whitebind=foo,boo@127.0.0.1");
@@ -129,7 +125,6 @@ public class ConfigTranslatorTests
 		ipEndPoint = whiteBind!.EndPoint as IPEndPoint;
 		Assert.NotNull(ipEndPoint);
 		Assert.Equal(IPAddress.Loopback, ipEndPoint!.Address);
-		Assert.Equal(8333, ipEndPoint.Port);
 		Assert.Equal("foo,boo", whiteBind.Permissions);
 
 		config.AddOrUpdate("main.whitebind=@@@");

--- a/WalletWasabi/Serialization/Config.cs
+++ b/WalletWasabi/Serialization/Config.cs
@@ -80,7 +80,7 @@ public static partial class Decode
 	public static readonly Decoder<EndPoint> EndPoint =
 		String.AndThen(s =>
 		{
-			if (EndPointParser.TryParse(s, 80, out EndPoint? endPoint))
+			if (EndPointParser.TryParse(s, out EndPoint? endPoint))
 			{
 				return Succeed(endPoint);
 			}


### PR DESCRIPTION
Parse `EndPoint` regardless of whether it is an `ip:host` or a `host:port`.  Also, it removes the default port concept given that an endpoint must have a port.