### PR TITLE
Dismiss BridgeDB message

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
@@ -101,7 +101,7 @@ public partial class HealthMonitor : ReactiveObject
 		// Tor Issues
 		var issues =
 			torStatusChecker.Issues
-			.Select(r => r.Where(issue => !issue.Resolved).ToList())
+			.Select(r => r.Where(issue => !issue.Resolved && !issue.Title.Contains("BridgeDB")).ToList())
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Publish();
 


### PR DESCRIPTION
## Issue
I saw Tor status checker shows warnings for BridgeDB graph issues on metrics.torproject.org, which don't affect core Tor functionality or WalletWasabi operations. This causes user confusion as indicated in issue #13932.

## Changes
- modified `HealthMonitor.cs` to filter out BridgeDB issues

## Testing
- [x] built and tested locally 
- [x] verified BridgeDB warnings no longer appear

Fixes #13932
