### PR TITLE
Hide backend status when connected to Node

### DIFF
--- a/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
+++ b/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
@@ -117,6 +117,7 @@
             </StatusItem>
 
             <StatusItem Title="Backend"
+                          IsVisible="{Binding !HealthMonitor.CanUseBitcoinRpc, FallbackValue=True}"
                           StatusText="{Binding HealthMonitor.IndexerStatus, Converter={x:Static converters:StatusConverters.IndexerStatusToString}}">
               <StatusItem.Icon>
                 <PathIcon Data="{StaticResource connector_regular}" />


### PR DESCRIPTION
Fixes: https://github.com/WalletWasabi/WalletWasabi/issues/13929

This PR hides the backend status in the StatusIcon if we are connected to a full node. (backend is not used in this case)