### PR TITLE
Auto-exclude from CJ UTXOs above conf. value

### DIFF
--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -443,7 +443,15 @@ public class WasabiJsonRpcService : IJsonRpcService
 
 		AssertWalletIsLoaded();
 
-		activeWallet.ExcludeCoinFromCoinJoin(new OutPoint(transactionId, n), exclude);
+		if (exclude)
+		{
+			activeWallet.UpdateExcludedCoinsFromCoinJoin([new OutPoint(transactionId, n)], []);
+		}
+		else
+		{
+			activeWallet.UpdateExcludedCoinsFromCoinJoin([], [new OutPoint(transactionId, n)]);
+
+		}
 	}
 
 	[JsonRpcMethod("listkeys")]

--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
@@ -16,12 +16,13 @@ namespace WalletWasabi.Fluent.Models.Wallets;
 [AutoInterface]
 public partial class WalletCoinsModel(Wallet wallet, IWalletModel walletModel) : CoinListModel(wallet, walletModel)
 {
-	public async Task UpdateExcludedCoinsFromCoinjoinAsync(ICoinModel[] coinsToExclude)
+	public async Task UpdateExcludedCoinsFromCoinjoinAsync(ICoinModel[] coinsAdded, ICoinModel[] coinsRemoved)
 	{
 		await Task.Run(() =>
 		{
-			var outPoints = coinsToExclude.Select(x => x.GetSmartCoin().Outpoint).ToArray();
-			Wallet.UpdateExcludedCoinsFromCoinJoin(outPoints);
+			var smartCoinsAdded = coinsAdded.Select(x => x.GetSmartCoin().Outpoint).ToArray();
+			var smartCoinsRemoved = coinsRemoved.Select(x => x.GetSmartCoin().Outpoint).ToArray();
+			Wallet.UpdateExcludedCoinsFromCoinJoin(smartCoinsAdded, smartCoinsRemoved);
 		});
 	}
 

--- a/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
@@ -19,6 +19,7 @@ public partial class WalletSettingsModel : ReactiveObject
 	[AutoNotify] private bool _autoCoinjoin;
 	[AutoNotify] private bool _preferPsbtWorkflow;
 	[AutoNotify] private Money _plebStopThreshold;
+	[AutoNotify] private Money _excludeCoinFromCoinjoinThreshold;
 	[AutoNotify] private int _anonScoreTarget;
 	[AutoNotify] private bool _nonPrivateCoinIsolation;
 	[AutoNotify] private WalletId? _outputWalletId;
@@ -37,6 +38,7 @@ public partial class WalletSettingsModel : ReactiveObject
 		_autoCoinjoin = _keyManager.AutoCoinJoin;
 		_preferPsbtWorkflow = _keyManager.PreferPsbtWorkflow;
 		_plebStopThreshold = _keyManager.PlebStopThreshold ?? KeyManager.DefaultPlebStopThreshold;
+		_excludeCoinFromCoinjoinThreshold = _keyManager.ExcludeCoinFromCoinjoinThreshold;
 		_anonScoreTarget = _keyManager.AnonScoreTarget;
 		_nonPrivateCoinIsolation = _keyManager.NonPrivateCoinIsolation;
 
@@ -55,6 +57,7 @@ public partial class WalletSettingsModel : ReactiveObject
 				x => x.AutoCoinjoin,
 				x => x.PreferPsbtWorkflow,
 				x => x.PlebStopThreshold,
+				x => x.ExcludeCoinFromCoinjoinThreshold,
 				x => x.AnonScoreTarget,
 				x => x.NonPrivateCoinIsolation)
 			.Skip(1)
@@ -101,6 +104,12 @@ public partial class WalletSettingsModel : ReactiveObject
 		_keyManager.AutoCoinJoin = AutoCoinjoin;
 		_keyManager.PreferPsbtWorkflow = PreferPsbtWorkflow;
 		_keyManager.PlebStopThreshold = PlebStopThreshold;
+		if (ExcludeCoinFromCoinjoinThreshold != _keyManager.ExcludeCoinFromCoinjoinThreshold)
+		{
+			_keyManager.ResetBypassAutomaticExclusionFromCoinjoin();
+			_keyManager.ExcludeCoinFromCoinjoinThreshold = ExcludeCoinFromCoinjoinThreshold;
+			Services.WalletManager.GetWalletByName(_keyManager.WalletName).LoadExcludedCoins();
+		}
 		_keyManager.AnonScoreTarget = AnonScoreTarget;
 		_keyManager.NonPrivateCoinIsolation = NonPrivateCoinIsolation;
 		_keyManager.DefaultSendWorkflow = DefaultSendWorkflow;

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
@@ -92,7 +92,7 @@
       <CurrencyEntryBox Classes="standalone" Text="{Binding PlebStopThreshold}" CurrencyCode="BTC" />
     </DockPanel>
 
-    <DockPanel ToolTip.Tip="Coins above this value will automatically be excluded from coinjoin.">
+    <DockPanel ToolTip.Tip="Coins of this value and above will automatically be excluded from coinjoin.">
       <TextBlock Text="Exclude Coin From Coinjoin Threshold" />
       <CurrencyEntryBox Classes="standalone" Text="{Binding ExcludeCoinFromCoinjoinThreshold}" CurrencyCode="BTC" />
     </DockPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
@@ -91,5 +91,10 @@
       <TextBlock Text="Stop coinjoin threshold" />
       <CurrencyEntryBox Classes="standalone" Text="{Binding PlebStopThreshold}" CurrencyCode="BTC" />
     </DockPanel>
+
+    <DockPanel ToolTip.Tip="Coins above this value will automatically be excluded from coinjoin.">
+      <TextBlock Text="Exclude Coin From Coinjoin Threshold" />
+      <CurrencyEntryBox Classes="standalone" Text="{Binding ExcludeCoinFromCoinjoinThreshold}" CurrencyCode="BTC" />
+    </DockPanel>
   </StackPanel>
 </UserControl>

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -68,6 +68,7 @@ public static class Constants
 	public const int DefaultRegTestBitcoinCorePort = 18443;
 
 	public const decimal DefaultDustThreshold = 0.00005m;
+	public const decimal DefaultExcludeCoinFromCoinjoinThreshold = MaximumNumberOfBitcoins;
 	public const decimal DefaultMaxCoinJoinMiningFeeRate = 150.0m;
 	public const int DefaultAbsoluteMinInputCount = 21;
 	public const int AbsoluteMinInputCount = 2;


### PR DESCRIPTION
This feature is the easiest way to do something that users have been requesting since forever.
It allows to force some consolidation while coinjoining by automatically freezing UTXOs above a certain (configurable) threshold).

It bundles some logic basically because you need to be able to bypass this automatic inclusion for individual coins.
Changing the value for the threshold invalidates the bypassed list.

In its current form it is really handy to use

As usual for features like that, it can be used for small fingerprinting, however I think this specific one is ok.

This PR also improves the exclude from coinjoin code which was really bad

@lontivero Feel free to refactor some stuff if you want