### PR TITLE
Increase Primary Guards used + Conflux throughput

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -33,6 +33,10 @@ public class TorSettingsTests
 			$"--DataDirectory \"{Path.Combine("temp", "tempDataDir", "tordata2")}\"",
 			$"--GeoIPFile \"{Path.Combine("tempDistributionDir", "Tor", "Geoip", "geoip")}\"",
 			$"--GeoIPv6File \"{Path.Combine("tempDistributionDir", "Tor", "Geoip", "geoip6")}\"",
+			$"--NumEntryGuards 3",
+			$"--NumPrimaryGuards 3",
+			$"--ConfluxEnabled 1",
+			$"--ConfluxClientUX throughput",
 			$"--Log \"notice file {Path.Combine("temp", "tempDataDir", "TorLogs.txt")}\"",
 			$"__OwningControllerProcess 7");
 

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -172,7 +172,9 @@ public class TorSettings
 			$"--CookieAuthFile \"{CookieAuthFilePath}\"",
 			$"--DataDirectory \"{TorDataDir}\"",
 			$"--GeoIPFile \"{_geoIpPath}\"",
-			$"--GeoIPv6File \"{_geoIp6Path}\""
+			$"--GeoIPv6File \"{_geoIp6Path}\"",
+			$"--NumEntryGuards 3",
+			$"--NumPrimaryGuards 3"
 		];
 
 		if (useBridges)

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -174,7 +174,9 @@ public class TorSettings
 			$"--GeoIPFile \"{_geoIpPath}\"",
 			$"--GeoIPv6File \"{_geoIp6Path}\"",
 			$"--NumEntryGuards 3",
-			$"--NumPrimaryGuards 3"
+			$"--NumPrimaryGuards 3",
+			$"--ConfluxEnabled 1",
+			$"--ConfluxClientUX throughput"
 		];
 
 		if (useBridges)


### PR DESCRIPTION
I have found that a huge problem of Wasabi with Tor is that at some point in time Wasabi makes too many circuit creation requests to the same entry guard which leads to be timed out for DoS protection by the entry guard.

This PR increases the pool of Entry Guards being Primarily used, from 1 to 3.
This leads to a huge stability increase of Wasabi, especially at start up.

Note that the max for this settings is 10 but it is advised not to use a huge pool of entry guards because it increases attack surface. However in our case this conservative is worth it.