### PR TITLE
Support fee rates with decimal values

### DIFF
--- a/WalletWasabi.Fluent/Converters/StatusConverters.cs
+++ b/WalletWasabi.Fluent/Converters/StatusConverters.cs
@@ -25,7 +25,7 @@ public static class StatusConverters
 		});
 
 	public static readonly IValueConverter FeeRateToString =
-		new FuncValueConverter<int, string>(x => x == 0 ? "No data" : $"{x} s/vB");
+		new FuncValueConverter<decimal, string>(x => x == 0 ? "No data" : $"{x} s/vB");
 
 	public static readonly IValueConverter BlockchainTipToString =
 		new FuncValueConverter<uint, string>(x => x == 0 ? "No data" : $"{x:N0}");

--- a/WalletWasabi.Fluent/Converters/StatusConverters.cs
+++ b/WalletWasabi.Fluent/Converters/StatusConverters.cs
@@ -25,7 +25,7 @@ public static class StatusConverters
 		});
 
 	public static readonly IValueConverter FeeRateToString =
-		new FuncValueConverter<decimal, string>(x => x == 0 ? "No data" : $"{x} s/vB");
+		new FuncValueConverter<decimal, string>(x => x == 0 ? "No data" : $"{x:0.##} s/vB");
 
 	public static readonly IValueConverter BlockchainTipToString =
 		new FuncValueConverter<uint, string>(x => x == 0 ? "No data" : $"{x:N0}");

--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -14,18 +14,18 @@ namespace WalletWasabi.Fluent.Helpers;
 public static class TransactionFeeHelper
 {
 	private static readonly FeeRateEstimations TestNetFeeRateEstimations = new(
-		new Dictionary<int, int>
+		new Dictionary<int, FeeRate>
 		{
-			[1] = 17,
-			[2] = 12,
-			[3] = 9,
-			[6] = 9,
-			[18] = 2,
-			[36] = 2,
-			[72] = 2,
-			[144] = 2,
-			[432] = 1,
-			[1008] = 1
+			[1] = new( 17m),
+			[2] = new( 12m),
+			[3] = new( 9m),
+			[6] = new( 9m),
+			[18] = new( 2m),
+			[36] = new( 2m),
+			[72] = new( 2m),
+			[144] = new( 2m),
+			[432] = new( 1m),
+			[1008] = new( 1m)
 		});
 
 	public static async Task<FeeRateEstimations> GetFeeEstimatesWhenReadyAsync(Wallet wallet, CancellationToken cancellationToken)

--- a/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
@@ -24,7 +24,7 @@ public partial class HealthMonitor : ReactiveObject
 {
 	private readonly ObservableAsPropertyHelper<ICollection<Issue>> _torIssues;
 
-	[AutoNotify] private int _priorityFee;
+	[AutoNotify] private decimal _priorityFee;
 	[AutoNotify] private uint _blockchainTip;
 	[AutoNotify] private TorStatus _torStatus;
 	[AutoNotify] private IndexerStatus _indexerStatus;
@@ -57,7 +57,7 @@ public partial class HealthMonitor : ReactiveObject
 			.Select(e => e.AllFeeEstimate.Estimations.FirstOrDefault(x => x.Key == 2).Value)
 			.WhereNotNull()
 			.ObserveOn(RxApp.MainThreadScheduler)
-			.Subscribe(priorityFee => PriorityFee = priorityFee);
+			.Subscribe(priorityFee => PriorityFee = priorityFee.SatoshiPerByte);
 
 		// Blockchain Tip
 		var smartHeaderChain = Services.BitcoinStore.SmartHeaderChain;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/CustomFeeRateDialogViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/CustomFeeRateDialogViewModel.cs
@@ -4,6 +4,7 @@ using NBitcoin;
 using ReactiveUI;
 using WalletWasabi.Fluent.Validation;
 using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
+using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;
@@ -72,9 +73,9 @@ public partial class CustomFeeRateDialogViewModel : DialogViewModelBase<FeeRate>
 			return;
 		}
 
-		if (value < decimal.One)
+		if (value < Constants.MinRelayFeeRate.SatoshiPerByte)
 		{
-			errors.Add(ErrorSeverity.Error, "Cannot be less than 1 sat/vByte.");
+			errors.Add(ErrorSeverity.Error, $"Cannot be less than {Constants.MinRelayFeeRate.SatoshiPerByte} sat/vByte.");
 			return;
 		}
 

--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -21,11 +21,11 @@ public class AllFeeEstimateTests
 	[Fact]
 	public void Serialization()
 	{
-		var estimations = new Dictionary<int, int>
+		var estimations = new Dictionary<int, FeeRate>
 		{
-			{ 2, 102 },
-			{ 3, 20 },
-			{ 19, 1 }
+			{ 2, new FeeRate(102M) },
+			{ 3, new FeeRate(20M) },
+			{ 19,new FeeRate( 1M) }
 		};
 		var allFee = new AllFeeEstimate(estimations);
 		var serialized = JsonEncoder.ToString(allFee, Encode.AllFeeEstimate);
@@ -40,12 +40,12 @@ public class AllFeeEstimateTests
 	[Fact]
 	public void OrdersByTarget()
 	{
-		var estimations = new Dictionary<int, int>
+		var estimations = new Dictionary<int, FeeRate>
 		{
-			{ 3, 20 },
-			{ 2, 102 },
-			{ 19, 1 },
-			{ 20, 1 }
+			{ 3, new FeeRate( 20M) },
+			{ 2, new FeeRate( 102M) },
+			{ 19,new FeeRate(  1M) },
+			{ 20,new FeeRate(  1M) }
 		};
 
 		var allFee = new AllFeeEstimate(estimations);
@@ -57,10 +57,10 @@ public class AllFeeEstimateTests
 	[Fact]
 	public void HandlesDuplicate()
 	{
-		var estimations = new Dictionary<int, int>
+		var estimations = new Dictionary<int, FeeRate>
 		{
-			{ 2, 20 },
-			{ 3, 20 }
+			{ 2, new FeeRate(20M) },
+			{ 3, new FeeRate(20M) }
 		};
 
 		var allFee = new AllFeeEstimate(estimations);
@@ -72,9 +72,9 @@ public class AllFeeEstimateTests
 	public void HandlesOne()
 	{
 		// If there's no 2, this'll be 2.
-		var estimations = new Dictionary<int, int>
+		var estimations = new Dictionary<int, FeeRate>
 		{
-			{ 1, 20 }
+			{ 1, new FeeRate(20M) }
 		};
 
 		var allFees = new AllFeeEstimate(estimations);
@@ -82,10 +82,10 @@ public class AllFeeEstimateTests
 		Assert.Equal(estimations[1], allFees.Estimations[2]);
 
 		// If there's 2, 1 is dismissed.
-		estimations = new Dictionary<int, int>
+		estimations = new Dictionary<int, FeeRate>
 		{
-			{ 1, 20 },
-			{ 2, 21 }
+			{ 1, new FeeRate(20M) },
+			{ 2, new FeeRate(21M) }
 		};
 
 		allFees = new AllFeeEstimate(estimations);
@@ -96,9 +96,9 @@ public class AllFeeEstimateTests
 	[Fact]
 	public void EndOfTheRange()
 	{
-		var estimations = new Dictionary<int, int>
+		var estimations = new Dictionary<int, FeeRate>
 		{
-			{ 1007, 20 }
+			{ 1007, new FeeRate(20M) }
 		};
 
 		var allFees = new AllFeeEstimate(estimations);
@@ -109,23 +109,23 @@ public class AllFeeEstimateTests
 	[Fact]
 	public void HandlesInconsistentData()
 	{
-		var estimations = new Dictionary<int, int>
+		var estimations = new Dictionary<int, FeeRate>
 		{
-			{ 2, 20 },
-			{ 3, 21 }
+			{ 2, new FeeRate(20M) },
+			{ 3, new FeeRate(21M) }
 		};
 
 		var allFee = new AllFeeEstimate(estimations);
 		Assert.Single(allFee.Estimations);
 		Assert.Equal(estimations[2], allFee.Estimations[2]);
 
-		estimations = new Dictionary<int, int>
+		estimations = new Dictionary<int, FeeRate>
 		{
-			{ 18, 1000 },
-			{ 3, 21 },
-			{ 2, 20 },
-			{ 100, 100 },
-			{ 6, 4 },
+			{ 18, new FeeRate(1000M) },
+			{ 3, new FeeRate(21M) },
+			{ 2, new FeeRate(20M) },
+			{ 100, new FeeRate(100M) },
+			{ 6, new FeeRate(4M) },
 		};
 
 		allFee = new AllFeeEstimate(estimations);
@@ -226,9 +226,9 @@ public class AllFeeEstimateTests
 
 		var allFee = await mockRpc.EstimateAllFeeAsync();
 		Assert.Equal(3, allFee.Estimations.Count);
-		Assert.Equal(99, allFee.Estimations[2]);
-		Assert.Equal(75, allFee.Estimations[6]);
-		Assert.Equal(31, allFee.Estimations[1008]);
+		Assert.Equal(99, allFee.Estimations[2].SatoshiPerByte);
+		Assert.Equal(75, allFee.Estimations[6].SatoshiPerByte);
+		Assert.Equal(31, allFee.Estimations[1008].SatoshiPerByte);
 	}
 
 	[Fact]
@@ -267,9 +267,9 @@ public class AllFeeEstimateTests
 			};
 
 		var allFee = await mockRpc.EstimateAllFeeAsync();
-		Assert.Equal(140, allFee.Estimations[2]);
-		Assert.Equal(124, allFee.Estimations[144]);
-		Assert.True(allFee.Estimations[1008] > 1);
+		Assert.Equal(140, allFee.Estimations[2].SatoshiPerByte);
+		Assert.Equal(124, allFee.Estimations[144].SatoshiPerByte);
+		Assert.True(allFee.Estimations[1008].SatoshiPerByte > 1);
 	}
 
 
@@ -304,7 +304,7 @@ public class AllFeeEstimateTests
 			Assert.Subset(Constants.ConfirmationTargets.ToHashSet(), estimations.Keys.ToHashSet());
 			Assert.Equal(estimations.Keys, estimations.Keys.OrderBy(x => x));
 			Assert.Equal(estimations.Values, estimations.Values.OrderByDescending(x => x));
-			Assert.All(estimations, (e) => Assert.True(e.Value >= mempoolInfo.MemPoolMinFee * 100_000));
+			Assert.All(estimations, (e) => Assert.True(e.Value.SatoshiPerByte >= (decimal)mempoolInfo.MemPoolMinFee * 100_000));
 		}
 	}
 
@@ -319,7 +319,7 @@ public class AllFeeEstimateTests
 		var estimations = feeRates.Estimations;
 		var minFee = estimations.Min(x => x.Value);
 
-		Assert.Equal(15, minFee); // this is the calculated MempoolMinFee needed to be in the top 200MB
+		Assert.Equal(15, minFee.SatoshiPerByte); // this is the calculated MempoolMinFee needed to be in the top 200MB
 	}
 
 	[Theory]
@@ -336,7 +336,7 @@ public class AllFeeEstimateTests
 		var estimations = feeRates.Estimations;
 		var minFee = estimations.Min(x => x.Value);
 
-		Assert.Equal(expectedMinFee, minFee);
+		Assert.Equal(expectedMinFee, minFee.SatoshiPerByte);
 	}
 
 	[Theory]
@@ -363,18 +363,18 @@ public class AllFeeEstimateTests
 		var estimations = feeRates.Estimations;
 		var maxFee = estimations.Max(x => x.Value);
 
-		Assert.Equal(expectedMaxFee, maxFee);
+		Assert.Equal(expectedMaxFee, maxFee.SatoshiPerByte);
 	}
 
 	[Fact]
 	public void WildEstimations()
 	{
-		var estimations = new Dictionary<int, int>
+		var estimations = new Dictionary<int, FeeRate>
 		{
-			{ 2, 102 }, // 20m
-			{ 3, 20 }, // 30m
-			{ 6, 10 }, // 1h
-			{ 18, 1 } // 3h
+			{ 2,new FeeRate(102m) }, // 20m
+			{ 3,new FeeRate(20m) }, // 30m
+			{ 6,new FeeRate(10m) }, // 1h
+			{ 18,new FeeRate(1m) } // 3h
 		};
 
 		var allFee = new AllFeeEstimate(estimations);

--- a/WalletWasabi/Blockchain/TransactionBuilding/FeeStrategy.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/FeeStrategy.cs
@@ -6,7 +6,7 @@ namespace WalletWasabi.Blockchain.TransactionBuilding;
 
 public class FeeStrategy
 {
-	public static readonly FeeRate MinimumFeeRate = new(1m);
+	public static readonly FeeRate MinimumFeeRate = Constants.MinRelayFeeRate;
 
 	private int? _target;
 	private FeeRate? _feeRate;
@@ -22,7 +22,7 @@ public class FeeStrategy
 	{
 		if (feeRate < MinimumFeeRate)
 		{
-			throw new ArgumentOutOfRangeException(nameof(feeRate), feeRate, "Cannot be less than 1 sat/vByte.");
+			throw new ArgumentOutOfRangeException(nameof(feeRate), feeRate, $"Cannot be less than {MinimumFeeRate.SatoshiPerByte} sat/vByte.");
 		}
 
 		Type = FeeStrategyType.Rate;

--- a/WalletWasabi/Serialization/Backend.cs
+++ b/WalletWasabi/Serialization/Backend.cs
@@ -28,8 +28,8 @@ public static partial class Encode
 	public static JsonNode Filter(FilterModel filter) =>
 		String(filter.ToLine());
 
-	public static JsonNode FeeEstimations(Dictionary<int, int> estimations) =>
-		Dictionary(estimations.ToDictionary(x => x.Key.ToString(), x => Int(x.Value)));
+	public static JsonNode FeeEstimations(Dictionary<int, FeeRate> estimations) =>
+		Dictionary(estimations.ToDictionary(x => x.Key.ToString(), x => FeeRate(x.Value)));
 
 	public static JsonNode AllFeeEstimate(AllFeeEstimate estimate) =>
 		Object([
@@ -61,7 +61,7 @@ public static partial class Encode
 			ExchangeRate exchangeRate => ExchangeRate(exchangeRate),
 			SynchronizeResponse syncResp => SynchronizeResponse(syncResp),
 			FiltersResponse filtersResp => FiltersResponse(filtersResp),
-			Dictionary<int, int> feeEstimations => FeeEstimations(feeEstimations),
+			Dictionary<int, FeeRate> feeEstimations => FeeEstimations(feeEstimations),
 			IEnumerable<string> s => Array(s.Select(String)),
 			IEnumerable<uint256> u => Array(u.Select(UInt256)),
 			IEnumerable<ExchangeRate> e => Array(e.Select(ExchangeRate)),
@@ -74,7 +74,7 @@ public static partial class Decode
 {
 	public static readonly Decoder<AllFeeEstimate> AllFeeEstimate =
 		Object(get => new AllFeeEstimate(
-			get.Required("estimations", Dictionary(Int)).ToDictionary(x => int.Parse(x.Key), x => x.Value)
+			get.Required("estimations", Dictionary(FeeRate)).ToDictionary(x => int.Parse(x.Key), x => x.Value)
 		));
 
 	public static readonly Decoder<FilterModel> Filter =

--- a/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
+++ b/WalletWasabi/WebClients/BlockstreamInfo/BlockstreamInfoClient.cs
@@ -45,10 +45,10 @@ public class BlockstreamInfoClient
 
 		var responseString = await response.Content.ReadAsStringAsync(cancel).ConfigureAwait(false);
 		var parsed = JsonDocument.Parse(responseString).RootElement;
-		var myDic = new Dictionary<int, int>();
+		var myDic = new Dictionary<int, FeeRate>();
 		foreach (var elem in parsed.EnumerateObject())
 		{
-			myDic.Add(int.Parse(elem.Name), (int)Math.Ceiling(elem.Value.GetDouble()));
+			myDic.Add(int.Parse(elem.Name), new FeeRate(elem.Value.GetDecimal()));
 		}
 
 		return new AllFeeEstimate(myDic);


### PR DESCRIPTION
<img width="154" height="110" alt="image" src="https://github.com/user-attachments/assets/97d3dbda-50a2-4ba3-9451-b9980372e73a" />

Before this PR Wasabi only supported integer values for fee rate estimations, this means that fee rates received from fee rate providers were rounded **up** to be converted from decimal to integer. For example, if Wasabi received 1.3s/vb it transformed to 2s/vb.

After this PR Wasabi supports more accurate estimations and do not rounds them.  