### PR TITLE
Publish Coordinator as Onion Service

### DIFF
--- a/WalletWasabi.Coordinator/Program.cs
+++ b/WalletWasabi.Coordinator/Program.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
-using WalletWasabi.Backend;
 using WalletWasabi.Logging;
 
 namespace WalletWasabi.Coordinator;
@@ -23,6 +22,5 @@ public static class Program
 
 	public static IHostBuilder CreateHostBuilder(string[] args) =>
 		Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder => webBuilder
-			.UseStartup<Startup>()
-			.UseUrls(Environment.GetEnvironmentVariable("WASABI_BIND") ?? "http://localhost:37126/"));
+			.UseStartup<Startup>());
 }

--- a/WalletWasabi.Coordinator/Startup.cs
+++ b/WalletWasabi.Coordinator/Startup.cs
@@ -121,7 +121,7 @@ public class Startup(IConfiguration configuration)
 					Timeout = TimeSpan.FromSeconds(5)
 				});
 
-		if (true /*config.PublishAsOnionService*/)
+		if (config.PublishAsOnionService)
 		{
 			services.AddBackgroundService<TorProcessManagerService>();
 		}

--- a/WalletWasabi.Coordinator/Startup.cs
+++ b/WalletWasabi.Coordinator/Startup.cs
@@ -57,7 +57,10 @@ public class Startup(IConfiguration configuration)
 		WabiSabiConfig config = WabiSabiConfig.LoadFile(Path.Combine(dataDir, "Config.json"));
 		services.AddSingleton(config);
 
-		var torSetting = new TorSettings(dataDir, "/nix/store/7fmf99a7rkb8i5kij390jnywxyk45yiw-tor-0.4.8.16/bin/tor", true, TorMode.Enabled, 37155, 37156);
+		var torSetting = new TorSettings(dataDir,
+			distributionFolderPath: EnvironmentHelpers.GetFullBaseDirectory(),
+			true, TorMode.Enabled, 37155, 37156);
+
 		services.AddSingleton(torSetting);
 
 		services.AddSingleton<IdempotencyRequestCache>();

--- a/WalletWasabi.Coordinator/Startup.cs
+++ b/WalletWasabi.Coordinator/Startup.cs
@@ -17,8 +17,9 @@ using WalletWasabi.Discoverability;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
+using WalletWasabi.Models;
 using WalletWasabi.Serialization;
-using WalletWasabi.Userfacing;
+using WalletWasabi.Tor;
 using WalletWasabi.WabiSabi.Coordinator;
 using WalletWasabi.WabiSabi.Coordinator.DoSPrevention;
 using WalletWasabi.WabiSabi.Coordinator.Rounds;
@@ -55,6 +56,9 @@ public class Startup(IConfiguration configuration)
 
 		WabiSabiConfig config = WabiSabiConfig.LoadFile(Path.Combine(dataDir, "Config.json"));
 		services.AddSingleton(config);
+
+		var torSetting = new TorSettings(dataDir, "/nix/store/7fmf99a7rkb8i5kij390jnywxyk45yiw-tor-0.4.8.16/bin/tor", true, TorMode.Enabled, 37155, 37156);
+		services.AddSingleton(torSetting);
 
 		services.AddSingleton<IdempotencyRequestCache>();
 		services.AddSingleton<IRPCClient>(provider =>
@@ -116,6 +120,11 @@ public class Startup(IConfiguration configuration)
 				{
 					Timeout = TimeSpan.FromSeconds(5)
 				});
+
+		if (true /*config.PublishAsOnionService*/)
+		{
+			services.AddBackgroundService<TorProcessManagerService>();
+		}
 	}
 
 	[SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "This method gets called by the runtime. Use this method to configure the HTTP request pipeline")]

--- a/WalletWasabi.Coordinator/TorProcessManagerService.cs
+++ b/WalletWasabi.Coordinator/TorProcessManagerService.cs
@@ -1,6 +1,7 @@
-using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using WalletWasabi.Logging;
 using WalletWasabi.Services;
@@ -9,27 +10,37 @@ using WalletWasabi.WabiSabi.Coordinator;
 
 namespace WalletWasabi.Coordinator;
 
-public class TorProcessManagerService(TorSettings torSettings, WabiSabiConfig config) : IHostedService
+public class TorProcessManagerService(TorSettings torSettings, WabiSabiConfig config, IConfiguration configuration) : IHostedService
 {
 	private readonly TorProcessManager _torManager = new(torSettings, new EventBus());
 
 	public async Task StartAsync(CancellationToken cancellationToken)
 	{
+		var urls = configuration["urls"];
+		if (urls is null)
+		{
+			Logger.LogWarning("The coordinator doesn't have urls configured!");
+			return;
+		}
+
 		var (_, torControlClient) = await _torManager.StartAsync(attempts: 3, cancellationToken).ConfigureAwait(false);
 		Logger.LogInfo($"{nameof(TorProcessManager)} is initialized.");
 
 		if (torControlClient is { } nonNullTorControlClient)
 		{
+			// multiple urls can be configured but that would need to create multiple onion services and we don't want to do that.
+			var address = urls.Split(";").First();
+			var uri = new Uri(address);
 			string onionServiceId;
 			if (!string.IsNullOrWhiteSpace(config.OnionServicePrivateKey))
 			{
 				onionServiceId = await nonNullTorControlClient
-					.CreateOnionServiceAsync(config.OnionServicePrivateKey, 80, 37126, cancellationToken).ConfigureAwait(false);
+					.CreateOnionServiceAsync(config.OnionServicePrivateKey, 80, uri.Port, cancellationToken).ConfigureAwait(false);
 			}
 			else
 			{
 				(onionServiceId, var privateKey) = await nonNullTorControlClient
-					.CreateKeylessOnionServiceAsync(80, 37126, cancellationToken).ConfigureAwait(false);
+					.CreateKeylessOnionServiceAsync(80, uri.Port, cancellationToken).ConfigureAwait(false);
 				config.OnionServicePrivateKey = privateKey;
 				config.AnnouncerConfig.CoordinatorUri = $"http://{onionServiceId}.onion";
 				config.AnnouncerConfig.ReadMoreUri = $"http://{onionServiceId}.onion";

--- a/WalletWasabi.Coordinator/TorProcessManagerService.cs
+++ b/WalletWasabi.Coordinator/TorProcessManagerService.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using WalletWasabi.Logging;
+using WalletWasabi.Services;
+using WalletWasabi.Tor;
+
+namespace WalletWasabi.Coordinator;
+
+public class TorProcessManagerService(TorSettings torSettings) : IHostedService
+{
+	private readonly TorProcessManager _torManager = new(torSettings, new EventBus());
+
+	public async Task StartAsync(CancellationToken cancellationToken)
+	{
+		var (_, torControlClient) = await _torManager.StartAsync(attempts: 3, cancellationToken).ConfigureAwait(false);
+		Logger.LogInfo($"{nameof(TorProcessManager)} is initialized.");
+
+		if (torControlClient is { } nonNullTorControlClient)
+		{
+			var keyFilePath = Path.Combine(torSettings.TorDataDir, "onion-service-private-key");
+			var onionServiceId = "";
+			if (File.Exists(keyFilePath))
+			{
+				var onionServicePrivateKey = await File.ReadAllTextAsync(keyFilePath, cancellationToken);
+				onionServiceId = await nonNullTorControlClient
+					.CreateOnionServiceAsync(onionServicePrivateKey, 80, 37126, cancellationToken).ConfigureAwait(false);
+			}
+			else
+			{
+				(onionServiceId, var privateKey) = await nonNullTorControlClient
+					.CreateKeylessOnionServiceAsync(80, 37126, cancellationToken).ConfigureAwait(false);
+				await File.WriteAllTextAsync(keyFilePath, privateKey, cancellationToken).ConfigureAwait(false);
+			}
+
+			var OnionServiceUri = new Uri($"http://{onionServiceId}.onion");
+			Logger.LogInfo($"Coordinator server listening on {OnionServiceUri}");
+		}
+	}
+
+	public async Task StopAsync(CancellationToken cancellationToken)
+	{
+		await _torManager.DisposeAsync().ConfigureAwait(false);
+	}
+}

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -351,7 +351,7 @@ public class Global
 				var anonymousAccessAllowed = string.IsNullOrEmpty(Config.JsonRpcUser) || string.IsNullOrEmpty(Config.JsonRpcPassword);
 				if (!anonymousAccessAllowed)
 				{
-					var onionServiceId = await nonNullTorControlClient.CreateOnionServiceAsync(80, 37129, cancellationToken).ConfigureAwait(false);
+					var onionServiceId = await nonNullTorControlClient.CreateEphemeralOnionServiceAsync(80, 37129, cancellationToken).ConfigureAwait(false);
 					OnionServiceUri = new Uri($"http://{onionServiceId}.onion");
 					Logger.LogInfo($"RPC server listening on {OnionServiceUri}");
 				}

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -351,7 +351,7 @@ public class Global
 				var anonymousAccessAllowed = string.IsNullOrEmpty(Config.JsonRpcUser) || string.IsNullOrEmpty(Config.JsonRpcPassword);
 				if (!anonymousAccessAllowed)
 				{
-					var onionServiceId = await nonNullTorControlClient.CreateOnionServiceAsync(TorSettings.RpcVirtualPort, TorSettings.RpcOnionPort, cancellationToken).ConfigureAwait(false);
+					var onionServiceId = await nonNullTorControlClient.CreateOnionServiceAsync(80, 37129, cancellationToken).ConfigureAwait(false);
 					OnionServiceUri = new Uri($"http://{onionServiceId}.onion");
 					Logger.LogInfo($"RPC server listening on {OnionServiceUri}");
 				}

--- a/WalletWasabi/Discoverability/AnnouncerConfig.cs
+++ b/WalletWasabi/Discoverability/AnnouncerConfig.cs
@@ -10,9 +10,9 @@ public record AnnouncerConfig
 	public string CoordinatorName { get; init; } = "Coordinator";
 	public bool IsEnabled { get; init; } = false;
 	public string CoordinatorDescription { get; init; } = "WabiSabi Coinjoin Coordinator";
-	public string CoordinatorUri { get; init; } = "https://api.example.com/";
+	public string CoordinatorUri { get; set; } = "https://api.example.com/";
 	public uint AbsoluteMinInputCount { get; init; } = 21;
-	public string ReadMoreUri { get; init; } = "https://api.example.com/";
+	public string ReadMoreUri { get; set; } = "https://api.example.com/";
 	public string[] RelayUris { get; init;  } = ["wss://relay.primal.net"];
 	public string Key { get; init; } = InitKey();
 

--- a/WalletWasabi/Serialization/Config.cs
+++ b/WalletWasabi/Serialization/Config.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Text.Json.Nodes;
 using NBitcoin;
 using WalletWasabi.Discoverability;
-using WalletWasabi.Helpers;
 using WalletWasabi.Userfacing;
 using WalletWasabi.WabiSabi.Coordinator;
 
@@ -72,6 +71,8 @@ public static partial class Encode
 			("AllowP2wshOutputs", Bool(cfg.AllowP2wshOutputs)),
 			("DelayTransactionSigning", Bool(cfg.DelayTransactionSigning)),
 			("AnnouncerConfig", AnnouncerConfig(cfg.AnnouncerConfig)),
+			("PublishAsOnionService", Bool(cfg.PublishAsOnionService)),
+			("OnionServicePrivateKey", Optional(cfg.OnionServicePrivateKey, String))
 		]);
 }
 
@@ -148,6 +149,8 @@ public static partial class Decode
 			AllowP2shOutputs = get.Required("AllowP2shOutputs", Bool),
 			AllowP2wshOutputs = get.Required("AllowP2wshOutputs", Bool),
 			DelayTransactionSigning = get.Required("DelayTransactionSigning", Bool),
-			AnnouncerConfig = get.Required("AnnouncerConfig", AnnouncerConfig)
+			AnnouncerConfig = get.Required("AnnouncerConfig", AnnouncerConfig),
+			PublishAsOnionService = get.Optional("PublishAsOnionService", Bool, true),
+			OnionServicePrivateKey = get.Optional("OnionServicePrivateKey", String)
 		});
 }

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -134,9 +134,6 @@ public class TorSettings
 
 	/// <summary>Tor control endpoint.</summary>
 	public EndPoint ControlEndpoint { get; }
-	public int RpcVirtualPort => 80;
-	public int RpcOnionPort => 37129;
-
 	private readonly string _geoIpPath;
 	private readonly string _geoIp6Path;
 

--- a/WalletWasabi/WabiSabi/Coordinator/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Coordinator/WabiSabiConfig.cs
@@ -116,6 +116,9 @@ public class WabiSabiConfig : ConfigBase
 
 	public ImmutableSortedSet<ScriptType> AllowedOutputTypes => GetScriptTypes(AllowP2wpkhOutputs, AllowP2trOutputs, AllowP2pkhOutputs, AllowP2shOutputs, AllowP2wshOutputs);
 
+	public bool PublishAsOnionService { get; init; }
+	public string? OnionServicePrivateKey { get; set; }
+
 	public Script GetNextCleanCoordinatorScript() => DeriveCoordinatorScript(CoordinatorExtPubKeyCurrentDepth);
 
 	public Script DeriveCoordinatorScript(int index) => CoordinatorExtPubKey.Derive(0, false).Derive(index, false).PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit);


### PR DESCRIPTION
After this PR coordinators will be exposed as onion services by default. 

New coordinators' operators need to do nothing at all, the coordinator will generate a new private key and store it in the `Config.json`  file:

```json
  "PublishAsOnionService": true,
  "OnionServicePrivateKey": "ED25519-V3:U8bTYDyXRqL6kwFG7ErGnKQ8vrpyPMrRnGmW49oRdyC033rBqmX8DIm8JRP7q468SLFrbUExi5XhFuquEsspcg=="
```

Next it will display the onion service url in the log file, something like this:

```
TorProcessManagerService.StartAsync (39)        Coordinator server listening on http://i44n7q2hhps7lowgd3jcw2eagirbu4hivbm7472alhuxsogd7x3rp7vd.onion
```

The coordinator will also automatically change the nostr announcement data in the `Config.json` file to reflect the change in the coordinator's uri.

It is also important to note that the coordinators' operators do not need to install tor because the one distributed with Wasabi will be used.

---------------

To prevent the coordinator to make all this changes, coordinators' operators can set the new config settings as follow:

```json
  "PublishAsOnionService": false,
```
