### PR TITLE
Show warning to restart Coinjoin after ExcludedCoins change

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListItem.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Coins/CoinListItem.cs
@@ -110,15 +110,7 @@ public abstract partial class CoinListItem : ViewModelBase, ITreeDataGridExpande
 	public bool? IsSelected
 	{
 		get => _isSelected;
-		set
-		{
-			if (!CanBeSelected && value == true)
-			{
-				return;
-			}
-
-			this.RaiseAndSetIfChanged(ref _isSelected, value);
-		}
+		set => this.RaiseAndSetIfChanged(ref _isSelected, value);
 	}
 
 	public ScriptType? ScriptType { get; protected set; }

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/ExcludedCoinsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/ExcludedCoinsView.axaml
@@ -35,10 +35,10 @@
     <DockPanel>
       <InfoMessage Foreground="{DynamicResource WarningMessageForeground}"
                    HorizontalAlignment="Center"
-                   Opacity="{Binding ShowRestartCoinjoinWarning, Converter={x:Static conv:BoolOpacityConverters.BoolToOpacity}}"
+                   Opacity="{Binding IsCoinjoining, Converter={x:Static conv:BoolOpacityConverters.BoolToOpacity}}"
                    DockPanel.Dock="Bottom"
                    Margin="0,16,0,0">
-          <TextBlock Text="Restart Coinjoin to apply changes." />
+          <TextBlock Text="Stop the Coinjoin process to change excluded coins." />
       </InfoMessage>
       <coins:CoinListView DataContext="{Binding CoinList}" />
     </DockPanel>

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/ExcludedCoinsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/ExcludedCoinsView.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Settings"
              xmlns:coins="clr-namespace:WalletWasabi.Fluent.Views.Wallets.Coins"
              xmlns:sorting="clr-namespace:WalletWasabi.Fluent.Controls.Sorting"
+             xmlns:conv="clr-namespace:WalletWasabi.Fluent.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Settings.ExcludedCoinsView"
              x:DataType="vm:ExcludedCoinsViewModel"
@@ -31,6 +32,15 @@
                       IsChecked="{Binding HasSelection}"/>
       </StackPanel>
     </ContentArea.TopContent>
-    <coins:CoinListView DataContext="{Binding CoinList}" />
+    <DockPanel>
+      <InfoMessage Foreground="{DynamicResource WarningMessageForeground}"
+                   HorizontalAlignment="Center"
+                   Opacity="{Binding ShowRestartCoinjoinWarning, Converter={x:Static conv:BoolOpacityConverters.BoolToOpacity}}"
+                   DockPanel.Dock="Bottom"
+                   Margin="0,16,0,0">
+          <TextBlock Text="Restart Coinjoin to apply changes." />
+      </InfoMessage>
+      <coins:CoinListView DataContext="{Binding CoinList}" />
+    </DockPanel>
   </ContentArea>
 </UserControl>


### PR DESCRIPTION
This shows the warning:
- When a coinjoin round is found
- When selection has changed

I didn't add a feature to catch if the selection was reverted to initial state