### PR TITLE
FeeRate provider fallback

### DIFF
--- a/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
+++ b/WalletWasabi.Tests/Helpers/ArenaBuilder.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinRpc;
+using WalletWasabi.FeeRateEstimation;
 using WalletWasabi.Helpers;
 using WalletWasabi.WabiSabi.Coordinator;
 using WalletWasabi.WabiSabi.Coordinator.DoSPrevention;
@@ -33,8 +34,9 @@ public class ArenaBuilder
 		IRPCClient rpc = Rpc ?? WabiSabiFactory.CreatePreconfiguredRpcClient();
 		Network network = Network ?? Network.Main;
 		RoundParameterFactory roundParameterFactory = RoundParameterFactory ?? CreateRoundParameterFactory(config, network);
+		FeeRateProvider feeProvider = FeeRateProviders.RpcAsync(rpc);
 
-		Arena arena = new(config, rpc, prison, roundParameterFactory, period:period);
+		Arena arena = new(config, rpc, prison, roundParameterFactory, feeProvider, period:period);
 
 		foreach (var round in rounds)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using NBitcoin;
 using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.FeeRateEstimation;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Models;
@@ -61,6 +62,7 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 			services.AddSingleton<RoundParameterFactory>();
 			services.AddSingleton(typeof(TimeSpan), _ => TimeSpan.FromSeconds(2));
 			services.AddSingleton(s => new CoinJoinScriptStore());
+			services.AddSingleton(s => FeeRateProviders.RpcAsync(s.GetRequiredService<IRPCClient>()));
 			services.AddSingleton<CoinJoinFeeRateStatStore>(s =>
 				CoinJoinFeeRateStatStore.LoadFromFile(
 					"./CoinJoinFeeRateStatStore.txt",


### PR DESCRIPTION
This PR is an step toward to make easier and cheaper to run a coordinator because it allows them to run a heavily pruned node which is also in `BlockOnly` mode, what requires much less cpu, memory and bandwidth but it cannot provide fee estimations.

What we do here is to add two fallback mining fee rate estimation providers  (`mempool.space` and `blockstream.info`). In case the coordinator is publish as an onion service, the fallback providers are queried using the onion routing; otherwise it queried on the clearnet.