### PR TITLE
Redundant exchange rate providers fallback mechanism

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Settings/ConnectionsSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/ConnectionsSettingsTabViewModel.cs
@@ -53,7 +53,7 @@ public partial class ConnectionsSettingsTabViewModel : RoutableViewModel
 
 	public IApplicationSettings Settings { get; }
 
-	public IEnumerable<string> ExchangeRateProviders => ExchangeRateProvider.Providers.Select(x => x.Name);
+	public IEnumerable<string> ExchangeRateProviders => WalletWasabi.Wallets.Exchange.ExchangeRateProviders.Providers;
 	public IEnumerable<string> FeeRateEstimationProviders => FeeRateProviders.Providers;
 	public IEnumerable<string> ExternalBroadcastProviders { get; }
 

--- a/WalletWasabi.Fluent/Views/Settings/ConnectionsSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Views/Settings/ConnectionsSettingsTabView.axaml
@@ -22,14 +22,14 @@
       </TextBox>
     </DockPanel>
 
-    <DockPanel>
+    <DockPanel ToolTip.Tip="The client will try to fetch exchange rate from this provider. If unavailable, it will fallback to any other.">
       <TextBlock Text="Exchange Rate Provider" />
       <ComboBox ItemsSource="{Binding ExchangeRateProviders}"
                 SelectedItem="{Binding Settings.ExchangeRateProvider}" />
     </DockPanel>
 
     <DockPanel ToolTip.Tip="The client will try to fetch fee rate estimations from this provider. If unavailable, it will fallback to any other.">
-      <TextBlock Text="Preferred Fee Rate Provider" />
+      <TextBlock Text="Fee Rate Provider" />
       <ComboBox ItemsSource="{Binding FeeRateEstimationProviders}"
                 SelectedItem="{Binding Settings.FeeRateEstimationProvider}" />
     </DockPanel>

--- a/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/ExternalApiTests.cs
@@ -11,27 +11,26 @@ public class ExternalApiTests
 {
 	[Fact]
 	public async Task MempoolSpaceExchangeRateProviderTestsAsync() =>
-		await AssertProviderAsync("MempoolSpace");
+		await AssertExchangeRateProviderAsync(ExchangeRateProviders.MempoolSpaceAsync);
 
 	[Fact]
 	public async Task BlockchainInfoExchangeRateProviderTestsAsync() =>
-		await AssertProviderAsync("BlockchainInfo");
+		await AssertExchangeRateProviderAsync(ExchangeRateProviders.BlockstreamAsync);
 
 	[Fact]
 	public async Task CoinGeckoExchangeRateProviderTestsAsync() =>
-		await AssertProviderAsync("CoinGecko");
+		await AssertExchangeRateProviderAsync(ExchangeRateProviders.CoinGeckoAsync);
 
 	[Fact]
 	public async Task GeminiExchangeRateProviderTestsAsync() =>
-		await AssertProviderAsync("Gemini");
+		await AssertExchangeRateProviderAsync(ExchangeRateProviders.GeminiAsync);
 
-	private async Task AssertProviderAsync(string providerName)
+	private async Task AssertExchangeRateProviderAsync(Func<HttpClientFactory, ExchangeRateProvider> providerFactory)
 	{
 		using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(3));
-		var provider = new ExchangeRateProvider(new HttpClientFactory());
-		var userAgent = WebClients.UserAgent.GetNew(Random.Shared.Next());
-		var rate = await provider.GetExchangeRateAsync(providerName, userAgent, timeoutCts.Token).ConfigureAwait(false);
-		Assert.NotEqual(0m, rate.Rate);
+		var provider = providerFactory(new HttpClientFactory());
+		var exchangeRate = await provider(CancellationToken.None).ConfigureAwait(false);
+		Assert.True(exchangeRate.Rate > 0);
 	}
 
 	[Fact]

--- a/WalletWasabi/Wallets/Exchange/ExchangeRateUpdater.cs
+++ b/WalletWasabi/Wallets/Exchange/ExchangeRateUpdater.cs
@@ -2,38 +2,30 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Bases;
-using WalletWasabi.Logging;
 using WalletWasabi.Services;
-using WalletWasabi.WebClients;
 
 namespace WalletWasabi.Wallets.Exchange;
 
 public class ExchangeRateUpdater : PeriodicRunner
 {
-	private readonly Func<string> _exchangeRateProviderGetter;
 	private readonly EventBus _eventBus;
 	private readonly ExchangeRateProvider _provider;
-	private readonly UserAgentPicker _userAgentPicker;
 	public decimal UsdExchangeRate { get; private set; }
 
-	public ExchangeRateUpdater(TimeSpan period, Func<string> exchangeRateProviderGetter,
-		IHttpClientFactory httpClientFactory, EventBus eventBus)
+	public ExchangeRateUpdater(TimeSpan period, ExchangeRateProvider exchangeRateProvider, EventBus eventBus)
 		: base(period)
 	{
-		_provider = new ExchangeRateProvider(httpClientFactory);
-		_exchangeRateProviderGetter = exchangeRateProviderGetter;
-		_userAgentPicker = UserAgent.GenerateUserAgentPicker(false);
+		_provider = exchangeRateProvider;
 		_eventBus = eventBus;
 	}
 
 	protected override async Task ActionAsync(CancellationToken cancellationToken)
 	{
-		var newExchangeRate = await _provider.GetExchangeRateAsync(_exchangeRateProviderGetter(), _userAgentPicker(), cancellationToken).ConfigureAwait(false);
+		var newExchangeRate = await _provider(cancellationToken).ConfigureAwait(false);
 		if (newExchangeRate.Rate != UsdExchangeRate && newExchangeRate.Rate > 0m)
 		{
 			UsdExchangeRate = newExchangeRate.Rate;
 			_eventBus.Publish(new ExchangeRateChanged(newExchangeRate.Rate));
-			Logger.LogInfo($"Fetched exchange rate from {_exchangeRateProviderGetter()}: {newExchangeRate.Rate}.");
 		}
 
 		await Task.Delay(TimeSpan.FromSeconds(Random.Shared.Next(120)), cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
This PR makes the `ExchangeRateProvider` implement the exact same pattern than `FeeRateEstimationProvider` what makes easier to compose them to create a chain of providers.