### PR TITLE
Add log entries about the fee and exchange rate providers

### DIFF
--- a/WalletWasabi/Wallets/Exchange/ExchangeRateProvider.cs
+++ b/WalletWasabi/Wallets/Exchange/ExchangeRateProvider.cs
@@ -78,7 +78,11 @@ public static class ExchangeRateProviders
 		return Result<decimal, Exception>
 			.Catch(() => extractor(json))
 			.Match(
-				rate => new ExchangeRate("USD", rate),
+				rate =>
+				{
+					Logger.LogInfo($"Fetched exchange rate from {providerName}: {rate}.");
+					return new ExchangeRate("USD", rate);
+				},
 				e => throw new InvalidOperationException($"Error parsing exchange rate provider response. {e}"));
 	}
 


### PR DESCRIPTION
Add log entries to know where the fee rate estimations and exchange rate come from.

```
2025-09-05 22:35:23.008 [11] INFO       FeeRateProviders.RpcAsync (52)  Fetched fee rate from RPC node: 20.048 Sat/B.
2025-09-05 22:35:27.116 [11] INFO       ExchangeRateProvider.GetExchangeRateAsync (83)  Fetched exchange rate from Blockstream: 110811.37.
```