### PR TITLE
set DownloadNewVersion to false by default

### DIFF
--- a/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
@@ -18,7 +18,7 @@ public static class PersistentConfigManager
 		UseTor : "Enabled",
 		TerminateTorOnExit : false,
 		TorBridges : [],
-		DownloadNewVersion : true,
+		DownloadNewVersion : false,
 		UseBitcoinRpc : false,
 		BitcoinRpcCredentialString : string.Empty,
 		BitcoinRpcUri : Constants.DefaultMainNetBitcoinRpcUri.ToString(),

--- a/WalletWasabi.Tests/UnitTests/Bases/PersistentConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Bases/PersistentConfigManagerTests.cs
@@ -47,7 +47,7 @@ public class PersistentConfigManagerTests
 			  "UseTor": "Enabled",
 			  "TerminateTorOnExit": false,
 			  "TorBridges": [],
-			  "DownloadNewVersion": true,
+			  "DownloadNewVersion": false,
 			  "UseBitcoinRpc": false,
 			  "BitcoinRpcCredentialString": "",
 			  "BitcoinRpcEndPoint": "http://localhost:8332",


### PR DESCRIPTION
There are endless reasons to not have auto updates (enabled by default) in software that stores people's money.

Although we do it in a reasonable way: check signature etc.
It is still a huge attack vector and not worth the risks.

Additionally, a user who only builds from source, for example as he does not want to run pre-built binaries, will have the Wasabi binary downloaded when there is a new release. Without his intention, just because it's the default setting.