### PR TITLE
[trivial] searchbar: lowercase coordinator writing

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
@@ -13,7 +13,7 @@ namespace WalletWasabi.Fluent.ViewModels.Settings;
 [AppLifetime]
 [NavigationMetaData(
 	Title = "Coordinator",
-	Caption = "Manage Coordinator settings",
+	Caption = "Manage coordinator settings",
 	Order = 2,
 	Category = "Settings",
 	Keywords =


### PR DESCRIPTION
Shouldn't be written with uppercase

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/a33b07ed-6341-4f32-8ab0-df315147e13c" />
