### PR TITLE
WW 💚 Arti

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <!-- Core libraries. -->
     <PackageVersion Include="WabiSabi" Version="1.0.1.2" />
     <PackageVersion Include="NBitcoin" Version="10.0.7" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2 " />
     <!-- UI. -->
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <!-- Core libraries. -->
     <PackageVersion Include="WabiSabi" Version="1.0.1.2" />
     <PackageVersion Include="NBitcoin" Version="10.0.3" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2 " />
     <!-- UI. -->
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />

--- a/WalletWasabi.Client/Configuration/Config.cs
+++ b/WalletWasabi.Client/Configuration/Config.cs
@@ -33,6 +33,7 @@ public class Config
 		Data = new() {
 			[nameof(Network)] = GetNetworkValue("Network", PersistentConfig.Network.ToString(), []),
 			[nameof(CoordinatorUri)] = GetStringValue("CoordinatorUri", PersistentConfig.CoordinatorUri, cliArgs),
+			[nameof(TorBackend)] = GetTorBackendValue("TorBackend", TorBackend.CTor, cliArgs),
 			[nameof(UseTor)] = GetTorModeValue("UseTor", PersistentConfig.UseTor, cliArgs),
 			[nameof(TorFolder)] = GetNullableStringValue("TorFolder", null, cliArgs),
 			[nameof(TorSocksPort)] = GetLongValue("TorSocksPort", TorSettings.DefaultSocksPort, cliArgs),
@@ -86,6 +87,7 @@ public class Config
 		{
 			[nameof(Network)] = "The Bitcoin network to use: main, testnet, signet, or regtest",
 			[nameof(CoordinatorUri)] = "The coordinator server's URL to connect to",
+			[nameof(TorBackend)] = "Tor backend to route communication through",
 			[nameof(UseTor)] = "All the communications go through the Tor network",
 			[nameof(TorFolder)] = "Folder where Tor binary is located",
 			[nameof(TorSocksPort)] = "Tor is started to listen with the specified SOCKS5 port",
@@ -120,6 +122,7 @@ public class Config
 	public Network Network => GetEffectiveValue<Network>(nameof(Network));
 
 	public string CoordinatorUri => GetEffectiveValue<string>(nameof(CoordinatorUri));
+	public TorBackend TorBackend => GetEffectiveValue<TorBackend>(nameof(TorBackend));
 	public TorMode UseTor => Network == Network.RegTest ? TorMode.Disabled : GetEffectiveValue<TorMode>(nameof(UseTor));
 	public string? TorFolder => GetEffectiveValue<string?>(nameof(TorFolder));
 	public int TorSocksPort => GetEffectiveValue<int>(nameof(TorSocksPort));
@@ -322,6 +325,21 @@ public class Config
 		return new LogModeArrayValue(arrayValues, arrayValues, ValueSource.Disk);
 	}
 
+	private static TorBackendValue GetTorBackendValue(string key, TorBackend defaultValue, string[] cliArgs)
+	{
+		if (GetOverrideValue(key, cliArgs, out string? overrideValue, out ValueSource? valueSource))
+		{
+			if (!Enum.TryParse(overrideValue, ignoreCase: true, out TorBackend mode))
+			{
+				throw new NotSupportedException($"Tor backend '{overrideValue}' is not supported.");
+			}
+
+			return new TorBackendValue(defaultValue, mode, valueSource.Value);
+		}
+
+		return new TorBackendValue(defaultValue, defaultValue, ValueSource.Disk);
+	}
+
 	private static TorModeValue GetTorModeValue(string key, object value, string[] cliArgs)
 	{
 		TorMode computedValue;
@@ -458,6 +476,7 @@ public class Config
 	private record NullableStringValue(string? Value, string? EffectiveValue, ValueSource ValueSource) : ITypedValue<string?>;
 	private record StringArrayValue(string[] Value, string[] EffectiveValue, ValueSource ValueSource) : ITypedValue<string[]>;
 	private record LogModeArrayValue(LogMode[] Value, LogMode[] EffectiveValue, ValueSource ValueSource) : ITypedValue<LogMode[]>;
+	private record TorBackendValue(TorBackend Value, TorBackend EffectiveValue, ValueSource ValueSource) : ITypedValue<TorBackend>;
 	private record TorModeValue(TorMode Value, TorMode EffectiveValue, ValueSource ValueSource) : ITypedValue<TorMode>;
 	private record NetworkValue(Network Value, Network EffectiveValue, ValueSource ValueSource) : ITypedValue<Network>;
 	private record MoneyValue(Money Value, Money EffectiveValue, ValueSource ValueSource) : ITypedValue<Money>;

--- a/WalletWasabi.Client/Configuration/Config.cs
+++ b/WalletWasabi.Client/Configuration/Config.cs
@@ -33,6 +33,7 @@ public class Config
 		Data = new() {
 			[ nameof(Network)] = GetNetworkValue("Network", PersistentConfig.Network.ToString(), []),
 			[ nameof(CoordinatorUri)] = GetStringValue("CoordinatorUri", PersistentConfig.CoordinatorUri, cliArgs),
+			[ nameof(TorBackend)] = GetTorBackendValue("TorBackend", TorBackend.CTor, cliArgs),
 			[ nameof(UseTor)] = GetTorModeValue("UseTor", PersistentConfig.UseTor, cliArgs),
 			[ nameof(TorFolder)] = GetNullableStringValue("TorFolder", null, cliArgs),
 			[ nameof(TorSocksPort)] = GetLongValue("TorSocksPort", TorSettings.DefaultSocksPort, cliArgs),
@@ -86,6 +87,7 @@ public class Config
 		{
 			[ nameof(Network)] = "The Bitcoin network to use: main, testnet, signet, or regtest",
 			[ nameof(CoordinatorUri)] = "The coordinator server's URL to connect to",
+			[ nameof(TorBackend)] = "Tor backend to route communication through",
 			[ nameof(UseTor)] = "All the communications go through the Tor network",
 			[ nameof(TorFolder)] = "Folder where Tor binary is located",
 			[ nameof(TorSocksPort)] = "Tor is started to listen with the specified SOCKS5 port",
@@ -120,6 +122,7 @@ public class Config
 	public Network Network => GetEffectiveValue<Network>(nameof(Network));
 
 	public string CoordinatorUri => GetEffectiveValue<string>(nameof(CoordinatorUri));
+	public TorBackend TorBackend => GetEffectiveValue<TorBackend>(nameof(TorBackend));
 	public TorMode UseTor => Network == Network.RegTest ? TorMode.Disabled : GetEffectiveValue<TorMode>(nameof(UseTor));
 	public string? TorFolder => GetEffectiveValue<string?>(nameof(TorFolder));
 	public int TorSocksPort => GetEffectiveValue<int>(nameof(TorSocksPort));
@@ -320,6 +323,21 @@ public class Config
 		return new LogModeArrayValue(arrayValues, arrayValues, ValueSource.Disk);
 	}
 
+	private static TorBackendValue GetTorBackendValue(string key, TorBackend defaultValue, string[] cliArgs)
+	{
+		if (GetOverrideValue(key, cliArgs, out string? overrideValue, out ValueSource? valueSource))
+		{
+			if (!Enum.TryParse(overrideValue, ignoreCase: true, out TorBackend mode))
+			{
+				throw new NotSupportedException($"Tor backend '{overrideValue}' is not supported.");
+			}
+
+			return new TorBackendValue(defaultValue, mode, valueSource.Value);
+		}
+
+		return new TorBackendValue(defaultValue, defaultValue, ValueSource.Disk);
+	}
+
 	private static TorModeValue GetTorModeValue(string key, object value, string[] cliArgs)
 	{
 		TorMode computedValue;
@@ -456,6 +474,7 @@ public class Config
 	private record NullableStringValue(string? Value, string? EffectiveValue, ValueSource ValueSource) : ITypedValue<string?>;
 	private record StringArrayValue(string[] Value, string[] EffectiveValue, ValueSource ValueSource) : ITypedValue<string[]>;
 	private record LogModeArrayValue(LogMode[] Value, LogMode[] EffectiveValue, ValueSource ValueSource) : ITypedValue<LogMode[]>;
+	private record TorBackendValue(TorBackend Value, TorBackend EffectiveValue, ValueSource ValueSource) : ITypedValue<TorBackend>;
 	private record TorModeValue(TorMode Value, TorMode EffectiveValue, ValueSource ValueSource) : ITypedValue<TorMode>;
 	private record NetworkValue(Network Value, Network EffectiveValue, ValueSource ValueSource) : ITypedValue<Network>;
 	private record MoneyValue(Money Value, Money EffectiveValue, ValueSource ValueSource) : ITypedValue<Money>;

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -58,6 +58,7 @@ public class Global
 		DataDir = dataDir;
 		Config = config;
 		TorSettings = new TorSettings(
+			config.TorBackend,
 			DataDir,
 			distributionFolderPath: EnvironmentHelpers.GetFullBaseDirectory(),
 			terminateOnExit: Config.TerminateTorOnExit,

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -56,6 +56,7 @@ public class Global
 		DataDir = dataDir;
 		Config = config;
 		TorSettings = new TorSettings(
+			config.TorBackend,
 			DataDir,
 			distributionFolderPath: EnvironmentHelpers.GetFullBaseDirectory(),
 			terminateOnExit: Config.TerminateTorOnExit,

--- a/WalletWasabi.Client/packages.lock.json
+++ b/WalletWasabi.Client/packages.lock.json
@@ -202,6 +202,7 @@
       "walletwasabi": {
         "type": "Project",
         "dependencies": {
+          "BouncyCastle.Cryptography": "[2.6.2, )",
           "Microsoft.AspNetCore.WebUtilities": "[10.0.2, )",
           "Microsoft.Data.Sqlite": "[10.0.2, )",
           "Microsoft.Extensions.Caching.Abstractions": "[10.0.2, )",
@@ -213,6 +214,12 @@
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
         }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "CentralTransitive",
+        "requested": "[2.6.2, )",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "CentralTransitive",

--- a/WalletWasabi.Coordinator/Startup.cs
+++ b/WalletWasabi.Coordinator/Startup.cs
@@ -59,7 +59,7 @@ public class Startup(IConfiguration configuration)
 		WabiSabiConfig config = WabiSabiConfig.LoadFile(Path.Combine(dataDir, "Config.json"));
 		services.AddSingleton(config);
 
-		var torSetting = new TorSettings(dataDir,
+		var torSetting = new TorSettings(TorBackend.CTor, dataDir,
 			distributionFolderPath: EnvironmentHelpers.GetFullBaseDirectory(),
 			true, TorMode.Enabled, 37155, 37156);
 

--- a/WalletWasabi.Daemon/packages.lock.json
+++ b/WalletWasabi.Daemon/packages.lock.json
@@ -189,6 +189,7 @@
       "walletwasabi": {
         "type": "Project",
         "dependencies": {
+          "BouncyCastle.Cryptography": "[2.6.2, )",
           "Microsoft.AspNetCore.WebUtilities": "[10.0.2, )",
           "Microsoft.Data.Sqlite": "[10.0.2, )",
           "Microsoft.Extensions.Caching.Abstractions": "[10.0.2, )",
@@ -207,6 +208,12 @@
           "Microsoft.Extensions.Caching.Memory": "[10.0.2, )",
           "WalletWasabi": "[1.0.0, )"
         }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "CentralTransitive",
+        "requested": "[2.6.2, )",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "CentralTransitive",

--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -556,6 +556,7 @@
       "walletwasabi": {
         "type": "Project",
         "dependencies": {
+          "BouncyCastle.Cryptography": "[2.6.2, )",
           "Microsoft.AspNetCore.WebUtilities": "[10.0.2, )",
           "Microsoft.Data.Sqlite": "[10.0.2, )",
           "Microsoft.Extensions.Caching.Abstractions": "[10.0.2, )",
@@ -658,6 +659,12 @@
         "dependencies": {
           "Avalonia": "11.3.14"
         }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "CentralTransitive",
+        "requested": "[2.6.2, )",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
       },
       "DynamicData": {
         "type": "CentralTransitive",

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -624,6 +624,7 @@
       "walletwasabi": {
         "type": "Project",
         "dependencies": {
+          "BouncyCastle.Cryptography": "[2.6.2, )",
           "Microsoft.AspNetCore.WebUtilities": "[10.0.2, )",
           "Microsoft.Data.Sqlite": "[10.0.2, )",
           "Microsoft.Extensions.Caching.Abstractions": "[10.0.2, )",
@@ -642,6 +643,12 @@
           "Microsoft.Extensions.Caching.Memory": "[10.0.2, )",
           "WalletWasabi": "[1.0.0, )"
         }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "CentralTransitive",
+        "requested": "[2.6.2, )",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "CentralTransitive",

--- a/WalletWasabi.Tests/Helpers/Common.cs
+++ b/WalletWasabi.Tests/Helpers/Common.cs
@@ -22,7 +22,7 @@ public static class Common
 	public static string TorDistributionFolder => Path.Combine(EnvironmentHelpers.GetFullBaseDirectory(), "TorDaemons");
 
 	/// <remarks>Tor is instructed to terminate on exit because this Tor instance would prevent running your Wasabi Wallet where Tor is started with data in a different folder.</remarks>
-	public static TorSettings TorSettings => new(DataDir, TorDistributionFolder, terminateOnExit: true);
+	public static TorSettings TorSettings => new(TorBackend.CTor, DataDir, TorDistributionFolder, terminateOnExit: true);
 
 	public static string DataDir => EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Tests"));
 

--- a/WalletWasabi.Tests/UnitTests/Tor/TorManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorManagerTests.cs
@@ -26,7 +26,7 @@ public class TorManagerTests
 		// Tor settings.
 		string dataDir = Path.Combine("temp", "tempDataDir");
 		string distributionFolder = "tempDistributionDir";
-		TorSettings settings = new(dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
+		TorSettings settings = new(TorBackend.CTor, dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
 
 		var processManager = new TestProcessManager(settings, new EventBus())
 		{
@@ -34,7 +34,7 @@ public class TorManagerTests
 			WaitForTorProcessDelay = TimeSpan.FromSeconds(2),
 			IsTorRunningAsyncResult = false,
 			EnsureRunningAsyncResult = true,
-			InitTorControlAsyncResult = new TorControlClient(pipeReader: new Pipe().Reader, pipeWriter: new Pipe().Writer)  // (1)
+			InitTorControlAsyncResult = new TorControlClient(TorBackend.CTor, pipeReader: new Pipe().Reader, pipeWriter: new Pipe().Writer)  // (1)
 		};
 
 		await using (TorManager manager = new(settings, processManager))
@@ -69,7 +69,7 @@ public class TorManagerTests
 		// Tor settings.
 		string dataDir = Path.Combine("temp", "tempDataDir");
 		string distributionFolder = "tempDistributionDir";
-		TorSettings settings = new(dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
+		TorSettings settings = new(TorBackend.CTor, dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
 
 		var processManager = new TestProcessManager(settings, new EventBus())
 		{

--- a/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorSettingsTests.cs
@@ -15,7 +15,7 @@ public class TorSettingsTests
 		string dataDir = Path.Combine("temp", "tempDataDir");
 		string distributionFolder = "tempDistributionDir";
 
-		TorSettings settings = new(dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
+		TorSettings settings = new(TorBackend.CTor, dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
 
 		string arguments = settings.GetCmdArguments();
 

--- a/WalletWasabi/BundledApps/Binaries/linux-x64/Tor/LICENSE-MIT
+++ b/WalletWasabi/BundledApps/Binaries/linux-x64/Tor/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright 2019-2025, The Tor Project, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/WalletWasabi/BundledApps/Binaries/win-x64/Tor/LICENSE-MIT
+++ b/WalletWasabi/BundledApps/Binaries/win-x64/Tor/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright 2019-2025, The Tor Project, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/WalletWasabi/Tor/Control/Messages/ArtiJsonMessage.cs
+++ b/WalletWasabi/Tor/Control/Messages/ArtiJsonMessage.cs
@@ -1,0 +1,5 @@
+namespace WalletWasabi.Tor.Control.Messages;
+
+public record ArtiJsonMessage(string Json) : ITorControlReply
+{
+}

--- a/WalletWasabi/Tor/Control/Messages/ITorControlReply.cs
+++ b/WalletWasabi/Tor/Control/Messages/ITorControlReply.cs
@@ -1,0 +1,5 @@
+namespace WalletWasabi.Tor.Control.Messages;
+
+public interface ITorControlReply
+{
+}

--- a/WalletWasabi/Tor/Control/Messages/TorControlReply.cs
+++ b/WalletWasabi/Tor/Control/Messages/TorControlReply.cs
@@ -22,7 +22,7 @@ namespace WalletWasabi.Tor.Control.Messages;
 /// </code>
 /// </remarks>
 /// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">Section 2.3</seealso>
-public record TorControlReply
+public record TorControlReply : ITorControlReply
 {
 	private static readonly ReadOnlyCollection<string> NoLines = new List<string>().AsReadOnly();
 

--- a/WalletWasabi/Tor/Control/Rpc/ArtiJsonRpc.cs
+++ b/WalletWasabi/Tor/Control/Rpc/ArtiJsonRpc.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using WalletWasabi.Tor.Control.Messages;
+
+namespace WalletWasabi.Tor.Control.Rpc;
+
+public record JsonRpcRequest(
+	[property: JsonPropertyName("id")] int Id,
+	[property: JsonPropertyName("obj")] string Obj,
+	[property: JsonPropertyName("method")] string Method,
+	[property: JsonPropertyName("params")] IImmutableDictionary<string, object> Params
+);
+
+public record JsonRpcError(
+	[property: JsonPropertyName("code")] int Code,
+	[property: JsonPropertyName("message")] string Message,
+	[property: JsonPropertyName("data")] object? Data = null
+);
+
+public record JsonRpcResponse<T>(
+	[property: JsonPropertyName("jsonrpc")] string JsonRpc = "2.0",
+	[property: JsonPropertyName("result")] T? Result = default,
+	[property: JsonPropertyName("error")] JsonRpcError? Error = null,
+	[property: JsonPropertyName("id")] object? Id = null) : ITorControlReply
+{
+	public bool Deconstruct([NotNullWhen(true)] out T? result, [NotNullWhen(false)] out JsonRpcError? error)
+	{
+		result = Result;
+		error = Error;
+
+		return Error is null;
+	}
+}
+
+public sealed record CookieAuthChallengeResult(
+    [property: JsonPropertyName("cookie_auth")]
+    string CookieAuth,
+
+    [property: JsonPropertyName("server_addr")]
+    string ServerAddress,
+
+    [property: JsonPropertyName("server_mac")]
+    string ServerMac,
+
+    [property: JsonPropertyName("server_nonce")]
+    string ServerNonce
+);
+
+public record AuthSessionResult(
+    [property: JsonPropertyName("session")]
+	string Session
+);
+
+public record GetClientResult(
+    [property: JsonPropertyName("id")]
+	string Id
+);
+
+
+public record GetClientStatusResult(
+	[property: JsonPropertyName("ready")]
+	bool Ready,
+	[property: JsonPropertyName("fraction")]
+	double Fraction,
+	[property: JsonPropertyName("blocked")]
+	object? Blocked
+);

--- a/WalletWasabi/Tor/Control/TorControlClient.cs
+++ b/WalletWasabi/Tor/Control/TorControlClient.cs
@@ -1,17 +1,20 @@
 using Nito.AsyncEx;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using WalletWasabi.Logging;
 using WalletWasabi.Tor.Control.Exceptions;
 using WalletWasabi.Tor.Control.Messages;
+using WalletWasabi.Tor.Control.Rpc;
 using WalletWasabi.Tor.Control.Utils;
 
 namespace WalletWasabi.Tor.Control;
@@ -27,32 +30,51 @@ public class TorControlClient : IAsyncDisposable
 	/// <remarks>This helps with graceful stopping of the reader loop.</remarks>
 	private volatile bool _readLastSyncReply;
 
-	public TorControlClient(TcpClient tcpClient) :
-		this(PipeReader.Create(tcpClient.GetStream()), PipeWriter.Create(tcpClient.GetStream()))
+	public TorControlClient(TorBackend torBackend, Stream stream) :
+		this(torBackend, PipeReader.Create(stream), PipeWriter.Create(stream))
 	{
-		_tcpClient = tcpClient;
 	}
 
-	internal TorControlClient(PipeReader pipeReader, PipeWriter pipeWriter)
+	internal TorControlClient(TorBackend torBackend, PipeReader pipeReader, PipeWriter pipeWriter)
 	{
 		_tcpClient = null;
+		_torBackend = torBackend;
 		_pipeReader = pipeReader;
 		_pipeWriter = pipeWriter;
 
-		_syncChannel = Channel.CreateUnbounded<TorControlReply>(Options);
-		AsyncChannels = new List<Channel<TorControlReply>>();
+		_syncChannel = Channel.CreateUnbounded<ITorControlReply>(Options);
+		AsyncChannels = new List<Channel<ITorControlReply>>();
 		_readerLoopTask = Task.Run(ReaderLoopAsync);
 	}
 
 	private readonly TcpClient? _tcpClient;
+	private readonly TorBackend _torBackend;
 	private readonly PipeReader _pipeReader;
 	private readonly PipeWriter _pipeWriter;
 	private readonly CancellationTokenSource _readerCts = new();
 	private readonly Task _readerLoopTask;
 
+	private volatile string _rpcSessionId = string.Empty;
+
+	public string RpcSessionId
+	{
+		get => _rpcSessionId;
+		set => _rpcSessionId = value;
+	}
+
+	private volatile string _rpcClientId = string.Empty;
+
+	public string RpcClientId
+	{
+		get => _rpcClientId;
+		set => _rpcClientId = value;
+	}
+
+	private int _lastRpcId = 0;
+
 	/// <summary>Channel only for synchronous replies from Tor control.</summary>
 	/// <remarks>Typically, there is at most one message in the channel at a time.</remarks>
-	private readonly Channel<TorControlReply> _syncChannel;
+	private readonly Channel<ITorControlReply> _syncChannel;
 
 	/// <summary>Guards <see cref="AsyncChannels"/>.</summary>
 	private readonly Lock _asyncChannelsLock = new();
@@ -62,7 +84,7 @@ public class TorControlClient : IAsyncDisposable
 	/// Guarded by <see cref="_asyncChannelsLock"/>.
 	/// <para>This list should be used only in a copy-on-write way to avoid iterating a modified list.</para>
 	/// </remarks>
-	private List<Channel<TorControlReply>> AsyncChannels { get; set; }
+	private List<Channel<ITorControlReply>> AsyncChannels { get; set; }
 
 	/// <summary>Lock to when sending a request to Tor control and waiting for a reply.</summary>
 	/// <remarks>Tor control protocol does not provide a foolproof way to recognize that a response belongs to a request.</remarks>
@@ -87,6 +109,9 @@ public class TorControlClient : IAsyncDisposable
 			}
 		}
 	}
+
+	private int IncrementAndGetNextRpcRequestId()
+		=> Interlocked.Increment(ref _lastRpcId);
 
 	/// <summary>
 	/// Gets the value of zero or more configuration variable(s).
@@ -268,10 +293,99 @@ public class TorControlClient : IAsyncDisposable
 		await _pipeWriter.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(command)), linkedCts.Token).ConfigureAwait(false);
 		await _pipeWriter.FlushAsync(linkedCts.Token).ConfigureAwait(false);
 
-		TorControlReply reply = await _syncChannel.Reader.ReadAsync(linkedCts.Token).ConfigureAwait(false);
+		ITorControlReply reply = await _syncChannel.Reader.ReadAsync(linkedCts.Token).ConfigureAwait(false);
 		Logger.LogTrace($"Client: Reply: '{reply}'");
 
+		return (TorControlReply)reply;
+	}
+
+	public async Task<JsonRpcResponse<T>> SendRpcRequestAsync<T>(JsonRpcRequest request, CancellationToken cancellationToken)
+	{
+		string jsonRequest = JsonSerializer.Serialize(request);
+		return await SendRpcRequestAsync<T>(jsonRequest, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async Task<JsonRpcResponse<T>> SendRpcRequestAsync<T>(string jsonRequest, CancellationToken cancellationToken)
+	{
+		using IDisposable _ = await _messageLock.LockAsync(cancellationToken).ConfigureAwait(false);
+		return await SendRpcRequestNoLockAsync<T>(jsonRequest, cancellationToken).ConfigureAwait(false);
+	}
+
+	/// <remarks>Lock <see cref="_messageLock"/> must be acquired by the caller.</remarks>
+	private async Task<JsonRpcResponse<T>> SendRpcRequestNoLockAsync<T>(string jsonRequest, CancellationToken cancellationToken)
+	{
+		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_readerCts.Token, cancellationToken);
+
+		Logger.LogTrace($"Client: About to RPC request command: '{jsonRequest.TrimEnd()}'");
+		await _pipeWriter.WriteAsync(new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes(jsonRequest)), linkedCts.Token).ConfigureAwait(false);
+		await _pipeWriter.FlushAsync(linkedCts.Token).ConfigureAwait(false);
+
+		var reply = await _syncChannel.Reader.ReadAsync(linkedCts.Token).ConfigureAwait(false);
+		var message = (ArtiJsonMessage)reply;
+		var replyObj = JsonSerializer.Deserialize<JsonRpcResponse<T>>(message.Json)!;
+
+		Logger.LogTrace($"Server: Received reply: '{message.Json}'");
+
+		return replyObj;
+	}
+
+	/// <summary>
+	/// Return current bootstrap and health information for a client.
+	/// </summary>
+	public async Task<JsonRpcResponse<GetClientStatusResult>> GetClientStatusRpcAsync(CancellationToken cancellationToken)
+	{
+		int id = IncrementAndGetNextRpcRequestId();
+		string json = $$"""{"id": {{id}},"obj":"{{RpcClientId}}","method":"arti:get_client_status","params":{} }""";
+		var response = await SendRpcRequestAsync<GetClientStatusResult>(json, cancellationToken).ConfigureAwait(false);
+
+		return response;
+	}
+
+	/// <summary>
+	/// Delivers updates about a client's bootstrap and health information.
+	/// </summary>
+	public async Task<JsonRpcResponse<object>> StartWatchingClientStatusRpcAsync(CancellationToken cancellationToken)
+	{
+		int id = IncrementAndGetNextRpcRequestId();
+		string json = $$"""{"id": {{id}},"obj":"{{RpcClientId}}","method":"arti:watch_client_status","params":{} }""";
+		var reply = await SendRpcRequestAsync<object>(json, cancellationToken).ConfigureAwait(false);
+
 		return reply;
+	}
+
+	public JsonRpcRequest CreateInherentAuthRpcRequest()
+	{
+		int id = IncrementAndGetNextRpcRequestId();
+		var @params = ImmutableDictionary<string, object>.Empty
+			.Add("scheme", "auth:inherent");
+
+		return new JsonRpcRequest(id, "connection", "auth:authenticate", @params);
+	}
+
+	public JsonRpcRequest CreateCookieAuthBeginRpcRequest(string clientNonce)
+	{
+		int id = IncrementAndGetNextRpcRequestId();
+		var @params = ImmutableDictionary<string, object>.Empty
+			.Add("client_nonce", clientNonce);
+
+		return new JsonRpcRequest(id, "connection", "auth:cookie_begin", @params);
+	}
+
+	public JsonRpcRequest CreateCookieAuthContinueRpcRequest(string rpcObject, string clientMac)
+	{
+		int id = IncrementAndGetNextRpcRequestId();
+		var @params = ImmutableDictionary<string, object>.Empty
+			.Add("client_mac", clientMac);
+
+		return new JsonRpcRequest(id, rpcObject, "auth:cookie_continue", @params);
+	}
+
+	public JsonRpcRequest CreateGetClientRpcRequest(string rpcSessionId)
+	{
+		int id = IncrementAndGetNextRpcRequestId();
+		var @params = ImmutableDictionary<string, object>.Empty;
+	
+		return new JsonRpcRequest(id, rpcSessionId, "arti:get_client", @params);
 	}
 
 	/// <summary>Allows the caller to read Tor events using <c>await foreach</c>.</summary>
@@ -284,10 +398,10 @@ public class TorControlClient : IAsyncDisposable
 	/// }
 	/// </code>
 	/// </example>
-	public async IAsyncEnumerable<TorControlReply> ReadEventsAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+	public async IAsyncEnumerable<ITorControlReply> ReadEventsAsync([EnumeratorCancellation] CancellationToken cancellationToken)
 	{
-		Channel<TorControlReply> channel = Channel.CreateUnbounded<TorControlReply>(Options);
-		List<Channel<TorControlReply>> newList;
+		Channel<ITorControlReply> channel = Channel.CreateUnbounded<ITorControlReply>(Options);
+		List<Channel<ITorControlReply>> newList;
 
 		try
 		{
@@ -302,7 +416,7 @@ public class TorControlClient : IAsyncDisposable
 			}
 
 			Logger.LogTrace($"ReadEventsAsync: subscribers: {newList.Count}.");
-			await foreach (TorControlReply item in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+			await foreach (ITorControlReply item in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
 			{
 				yield return item;
 			}
@@ -460,29 +574,50 @@ public class TorControlClient : IAsyncDisposable
 
 		try
 		{
-			while (!_readerCts.IsCancellationRequested)
+			if (_torBackend == TorBackend.CTor)
 			{
-				TorControlReply reply = await TorControlReplyReader.ReadReplyAsync(_pipeReader, _readerCts.Token).ConfigureAwait(false);
-
-				if (reply.StatusCode == StatusCode.AsynchronousEventNotify)
+				while (!_readerCts.IsCancellationRequested)
 				{
-					List<Channel<TorControlReply>> list;
+					TorControlReply reply = await TorControlReplyReader.ReadReplyAsync(_pipeReader, _readerCts.Token).ConfigureAwait(false);
 
-					lock (_asyncChannelsLock)
+					if (reply.StatusCode == StatusCode.AsynchronousEventNotify)
 					{
-						list = AsyncChannels;
+						List<Channel<ITorControlReply>> list;
+
+						lock (_asyncChannelsLock)
+						{
+							list = AsyncChannels;
+						}
+
+						// Notify every "subscriber" who reads all Tor events.
+						foreach (Channel<ITorControlReply> channel in list)
+						{
+							await channel.Writer.WriteAsync(reply, _readerCts.Token).ConfigureAwait(false);
+						}
 					}
-
-					// Notify every "subscriber" who reads all Tor events.
-					foreach (Channel<TorControlReply> channel in list)
+					else
 					{
-						await channel.Writer.WriteAsync(reply, _readerCts.Token).ConfigureAwait(false);
+						// Propagate a response back to the requester.
+						await _syncChannel.Writer.WriteAsync(reply, _readerCts.Token).ConfigureAwait(false);
+
+						if (_readLastSyncReply)
+						{
+							Logger.LogTrace("Request to read last message was issued. No more message reading.");
+							break;
+						}
 					}
 				}
-				else
+			}
+			else
+			{
+				while (!_readerCts.IsCancellationRequested)
 				{
+					string json = await TorControlReplyReader.ReadRpcMessageAsync(_pipeReader, _readerCts.Token).ConfigureAwait(false);
+					Logger.LogTrace($"RPC incoming message: {json}");
+
 					// Propagate a response back to the requester.
-					await _syncChannel.Writer.WriteAsync(reply, _readerCts.Token).ConfigureAwait(false);
+					var message = new ArtiJsonMessage(json);
+					await _syncChannel.Writer.WriteAsync(message, _readerCts.Token).ConfigureAwait(false);
 
 					if (_readLastSyncReply)
 					{

--- a/WalletWasabi/Tor/Control/TorControlClientFactory.cs
+++ b/WalletWasabi/Tor/Control/TorControlClientFactory.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using Org.BouncyCastle.Crypto.Digests;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography;
@@ -6,10 +7,11 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Tor.Control.Exceptions;
+using WalletWasabi.Tor.Control.Rpc;
 using WalletWasabi.Tor.Control.Messages;
+using System.Globalization;
 
 namespace WalletWasabi.Tor.Control;
 
@@ -23,6 +25,10 @@ public partial class TorControlClientFactory
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">Section 3.24. AUTHCHALLENGE</seealso>
 	private static byte[] ClientHmacKey = Encoding.ASCII.GetBytes("Tor safe cookie authentication controller-to-server hash");
 
+	/// <summary>Customization bytes used by Arti when hashing using TupleHash.</summary>
+	/// <seealso href="https://gitlab.torproject.org/tpo/core/arti/-/blob/main/doc/dev/rpc-book/src/rpc-cookie-spec.md#preliminaries"/>
+	private static byte[] ArtiTupleHashCustomization = Encoding.ASCII.GetBytes("arti-rpc-cookie-v1");
+
 	public TorControlClientFactory(IRandom? random = null)
 	{
 		_random = random ?? new UnsecureRandom();
@@ -34,12 +40,12 @@ public partial class TorControlClientFactory
 	/// <summary>Connects to Tor Control endpoint and authenticates using safe-cookie mechanism.</summary>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section 3.5</seealso>
 	/// <exception cref="TorControlException">If TCP connection cannot be established OR if authentication fails for some reason.</exception>
-	public async Task<TorControlClient> ConnectAndAuthenticateAsync(EndPoint endPoint, string cookieString, CancellationToken cancellationToken)
+	public async Task<TorControlClient> ConnectAndAuthenticateAsync(TorBackend backend, EndPoint endPoint, string? cookieString, CancellationToken cancellationToken)
 	{
-		TcpClient tcpClient;
+		NetworkStream socket;
 		try
 		{
-			tcpClient = await TcpClientConnector.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
+			socket = await TcpClientConnector.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
 		}
 		catch (Exception e)
 		{
@@ -50,14 +56,39 @@ public partial class TorControlClientFactory
 
 		try
 		{
-			TorControlClient controlClient = clientToDispose = new(tcpClient);
+			TorControlClient controlClient = clientToDispose = new(backend, socket);
 
-			await AuthSafeCookieOrThrowAsync(controlClient, cookieString, cancellationToken).ConfigureAwait(false);
+			if (backend == TorBackend.CTor)
+			{
+				if (cookieString is null)
+				{
+					throw new TorControlException("CTor implementation requires a cookie string for SAFECOOKIE authentication.");
+				}
+
+				await AuthSafeCookieOrThrowAsync(controlClient, cookieString, cancellationToken).ConfigureAwait(false);
+			}
+			else
+			{
+				int? port = endPoint switch
+				{
+					DnsEndPoint p => p.Port,
+					IPEndPoint p => p.Port,
+					_ => null,
+				};
+
+				var rpcObjectId = await ArtiAuthOrThrowAsync(controlClient, port, cookieString, cancellationToken).ConfigureAwait(false);
+				controlClient.RpcSessionId = rpcObjectId;
+			}
 
 			// All good, do not dispose.
 			clientToDispose = null;
 
 			return controlClient;
+		}
+		catch (Exception e)
+		{
+			Logger.LogError("Cookie authentication failed.", e);
+			throw;
 		}
 		finally
 		{
@@ -70,7 +101,97 @@ public partial class TorControlClientFactory
 		}
 	}
 
-	/// <summary>Authenticates client using SAFE-COOKIE.</summary>
+	/// <summary>Authenticates Arti client using SAFE-COOKIE or UNIX socket domain.</summary>
+	/// <exception cref="TorControlException">If authentication fails for some reason.</exception>
+	internal async Task<string> ArtiAuthOrThrowAsync(TorControlClient controlClient, int? rpcPort, string? cookieString, CancellationToken cancellationToken)
+	{
+		byte[] nonceBytes = new byte[32];
+		_random.GetBytes(nonceBytes);
+		string clientNonce = Convert.ToHexString(nonceBytes);
+
+		string rpcSessionId;
+
+		// Cookie authentication.
+		if (cookieString is not null)
+		{
+			if (rpcPort is null)
+			{
+				throw new TorControlException("RPC port is null.");
+			}			
+
+			var authRequest = controlClient.CreateCookieAuthBeginRpcRequest(clientNonce);
+			var authChallengeReply = await controlClient.SendRpcRequestAsync<CookieAuthChallengeResult>(authRequest, cancellationToken).ConfigureAwait(false);
+
+			if (!authChallengeReply.Deconstruct(out var authChallengeResult, out var _))
+			{
+				Logger.LogError($"Received invalid reply for our auth:cookie_begin: '{authChallengeReply}'");
+				throw new TorControlException("Invalid status code in auth:cookie_begin reply.");
+			}
+
+			var serverHash = ComputeTupleHash(rpcPort.Value, cookieString, "Server", clientNonce, authChallengeResult.ServerNonce);
+			var serverHashStr = Convert.ToHexString(serverHash);
+
+			if (authChallengeResult.ServerMac != serverHashStr)
+			{
+				Logger.LogError($"Server MAC is different than ours: '{authChallengeResult.ServerMac} != {serverHashStr}'");
+				throw new TorControlException("Different server MAC.");
+			}
+
+			var clientHash = ComputeTupleHash(rpcPort.Value, cookieString, "Client", clientNonce, authChallengeResult.ServerNonce);
+			var clientHashStr = Convert.ToHexString(clientHash);
+
+			Logger.LogTrace($"Authenticate using server hash: '{clientHashStr}'.");
+			var continueRequest = controlClient.CreateCookieAuthContinueRpcRequest(authChallengeResult.CookieAuth, clientHashStr);
+			var authenticationResponse = await controlClient.SendRpcRequestAsync<AuthSessionResult>(continueRequest, cancellationToken).ConfigureAwait(false);
+
+			if (!authenticationResponse.Deconstruct(out var result, out var error))
+			{
+				Logger.LogError($"Error: '{error}'");
+				throw new TorControlException("Invalid status in AUTHENTICATE reply.");
+			}
+
+			rpcSessionId = result.Session;
+		}
+		else
+		{
+			// Authentication was proved by accessing the RPC by its UNIX socket domain file.
+			var authRequest = controlClient.CreateInherentAuthRpcRequest();
+			var authenticationResponse = await controlClient.SendRpcRequestAsync<AuthSessionResult>(authRequest, cancellationToken).ConfigureAwait(false);
+
+			if (!authenticationResponse.Deconstruct(out var result, out var error))
+			{
+				Logger.LogError($"Error: '{error}'");
+				throw new TorControlException("Invalid status in AUTHENTICATE reply.");
+			}
+
+			rpcSessionId = result.Session;
+		}
+
+		string rpcClientId;
+
+		// Get a client ID.
+		{
+			var request = controlClient.CreateGetClientRpcRequest(rpcSessionId);
+			var clientResponse = await controlClient.SendRpcRequestAsync<GetClientResult>(request, cancellationToken).ConfigureAwait(false);
+
+			if (!clientResponse.Deconstruct(out var result, out var error))
+			{
+				Logger.LogError($"Error: '{error}'");
+				throw new TorControlException("Invalid status in AUTHENTICATE reply.");
+			}
+
+			rpcClientId = result.Id;
+		}
+
+		controlClient.RpcSessionId = rpcSessionId;
+		controlClient.RpcClientId = rpcClientId;
+
+		Logger.LogDebug($"Session ID: {rpcSessionId}.");
+		Logger.LogDebug($"Client ID: {rpcClientId}.");
+		return rpcSessionId;
+	}
+
+	/// <summary>Authenticates C Tor client using SAFE-COOKIE.</summary>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section 3.24 for SAFECOOKIE authentication.</seealso>
 	/// <seealso href="https://github.com/torproject/stem/blob/63a476056017dda5ede35efc4e4f7acfcc1d7d1a/stem/connection.py#L893">Python implementation.</seealso>
 	/// <exception cref="TorControlException">If authentication fails for some reason.</exception>
@@ -120,6 +241,23 @@ public partial class TorControlClientFactory
 		}
 
 		return controlClient;
+	}
+
+	/// <summary>Computes the tuple hash used in Arti's RPC cookie authentication.</summary>
+	private static byte[] ComputeTupleHash(int rpcPort, string cookieString, string side, string clientNonce, string serverNonce)
+	{
+		var tupleHash = new TupleHash(bitLength: 128, S: ArtiTupleHashCustomization);
+		tupleHash.BlockUpdate(Convert.FromHexString(cookieString));
+		tupleHash.BlockUpdate(Encoding.ASCII.GetBytes(side));
+		tupleHash.BlockUpdate(Encoding.ASCII.GetBytes(string.Create(CultureInfo.InvariantCulture, $"inet:127.0.0.1:{rpcPort}")));
+		tupleHash.BlockUpdate(Convert.FromHexString(clientNonce));
+		tupleHash.BlockUpdate(Convert.FromHexString(serverNonce));
+
+		var digestSize = tupleHash.GetDigestSize();
+		var hash = new byte[digestSize];
+		tupleHash.DoFinal(hash, 0);
+
+		return hash;
 	}
 
 	[GeneratedRegex("^AUTHCHALLENGE SERVERHASH=([a-fA-F0-9]+) SERVERNONCE=([a-fA-F0-9]+)$")]

--- a/WalletWasabi/Tor/Control/TorControlClientFactory.cs
+++ b/WalletWasabi/Tor/Control/TorControlClientFactory.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using Org.BouncyCastle.Crypto.Digests;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography;
@@ -6,10 +7,11 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Tor.Control.Exceptions;
+using WalletWasabi.Tor.Control.Rpc;
 using WalletWasabi.Tor.Control.Messages;
+using System.Globalization;
 
 namespace WalletWasabi.Tor.Control;
 
@@ -23,6 +25,10 @@ public partial class TorControlClientFactory
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">Section 3.24. AUTHCHALLENGE</seealso>
 	private static byte[] ClientHmacKey = Encoding.ASCII.GetBytes("Tor safe cookie authentication controller-to-server hash");
 
+	/// <summary>Customization bytes used by Arti when hashing using TupleHash.</summary>
+	/// <seealso href="https://gitlab.torproject.org/tpo/core/arti/-/blob/main/doc/dev/rpc-book/src/rpc-cookie-spec.md#preliminaries"/>
+	private static byte[] ArtiTupleHashCustomization = Encoding.ASCII.GetBytes("arti-rpc-cookie-v1");
+
 	public TorControlClientFactory(IRandom? random = null)
 	{
 		_random = random ?? new UnsecureRandom();
@@ -34,12 +40,14 @@ public partial class TorControlClientFactory
 	/// <summary>Connects to Tor Control endpoint and authenticates using safe-cookie mechanism.</summary>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section 3.5</seealso>
 	/// <exception cref="TorControlException">If TCP connection cannot be established OR if authentication fails for some reason.</exception>
-	public async Task<TorControlClient> ConnectAndAuthenticateAsync(EndPoint endPoint, string cookieString, CancellationToken cancellationToken)
+	public async Task<TorControlClient> ConnectAndAuthenticateAsync(TorBackend backend, EndPoint endPoint, string? cookieString, CancellationToken cancellationToken)
 	{
-		TcpClient tcpClient;
+		NetworkStream socket;
 		try
 		{
-			tcpClient = await TcpClientConnector.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
+#pragma warning disable CA2000 // Dispose objects before losing scope - TODO FIX.
+			socket = await TcpClientConnector.ConnectAsync(endPoint, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2000 // Dispose objects before losing scope
 		}
 		catch (Exception e)
 		{
@@ -50,14 +58,39 @@ public partial class TorControlClientFactory
 
 		try
 		{
-			TorControlClient controlClient = clientToDispose = new(tcpClient);
+			TorControlClient controlClient = clientToDispose = new(backend, socket);
 
-			await AuthSafeCookieOrThrowAsync(controlClient, cookieString, cancellationToken).ConfigureAwait(false);
+			if (backend == TorBackend.CTor)
+			{
+				if (cookieString is null)
+				{
+					throw new TorControlException("CTor implementation requires a cookie string for SAFECOOKIE authentication.");
+				}
+
+				await AuthSafeCookieOrThrowAsync(controlClient, cookieString, cancellationToken).ConfigureAwait(false);
+			}
+			else
+			{
+				int? port = endPoint switch
+				{
+					DnsEndPoint p => p.Port,
+					IPEndPoint p => p.Port,
+					_ => null,
+				};
+
+				var rpcObjectId = await ArtiAuthOrThrowAsync(controlClient, port, cookieString, cancellationToken).ConfigureAwait(false);
+				controlClient.RpcSessionId = rpcObjectId;
+			}
 
 			// All good, do not dispose.
 			clientToDispose = null;
 
 			return controlClient;
+		}
+		catch (Exception e)
+		{
+			Logger.LogError("Cookie authentication failed.", e);
+			throw;
 		}
 		finally
 		{
@@ -70,7 +103,97 @@ public partial class TorControlClientFactory
 		}
 	}
 
-	/// <summary>Authenticates client using SAFE-COOKIE.</summary>
+	/// <summary>Authenticates Arti client using SAFE-COOKIE or UNIX socket domain.</summary>
+	/// <exception cref="TorControlException">If authentication fails for some reason.</exception>
+	internal async Task<string> ArtiAuthOrThrowAsync(TorControlClient controlClient, int? rpcPort, string? cookieString, CancellationToken cancellationToken)
+	{
+		byte[] nonceBytes = new byte[32];
+		_random.GetBytes(nonceBytes);
+		string clientNonce = Convert.ToHexString(nonceBytes);
+
+		string rpcSessionId;
+
+		// Cookie authentication.
+		if (cookieString is not null)
+		{
+			if (rpcPort is null)
+			{
+				throw new TorControlException("RPC port is null.");
+			}			
+
+			var authRequest = controlClient.CreateCookieAuthBeginRpcRequest(clientNonce);
+			var authChallengeReply = await controlClient.SendRpcRequestAsync<CookieAuthChallengeResult>(authRequest, cancellationToken).ConfigureAwait(false);
+
+			if (!authChallengeReply.Deconstruct(out var authChallengeResult, out var _))
+			{
+				Logger.LogError($"Received invalid reply for our auth:cookie_begin: '{authChallengeReply}'");
+				throw new TorControlException("Invalid status code in auth:cookie_begin reply.");
+			}
+
+			var serverHash = ComputeTupleHash(rpcPort.Value, cookieString, "Server", clientNonce, authChallengeResult.ServerNonce);
+			var serverHashStr = Convert.ToHexString(serverHash);
+
+			if (authChallengeResult.ServerMac != serverHashStr)
+			{
+				Logger.LogError($"Server MAC is different than ours: '{authChallengeResult.ServerMac} != {serverHashStr}'");
+				throw new TorControlException("Different server MAC.");
+			}
+
+			var clientHash = ComputeTupleHash(rpcPort.Value, cookieString, "Client", clientNonce, authChallengeResult.ServerNonce);
+			var clientHashStr = Convert.ToHexString(clientHash);
+
+			Logger.LogTrace($"Authenticate using server hash: '{clientHashStr}'.");
+			var continueRequest = controlClient.CreateCookieAuthContinueRpcRequest(authChallengeResult.CookieAuth, clientHashStr);
+			var authenticationResponse = await controlClient.SendRpcRequestAsync<AuthSessionResult>(continueRequest, cancellationToken).ConfigureAwait(false);
+
+			if (!authenticationResponse.Deconstruct(out var result, out var error))
+			{
+				Logger.LogError($"Error: '{error}'");
+				throw new TorControlException("Invalid status in AUTHENTICATE reply.");
+			}
+
+			rpcSessionId = result.Session;
+		}
+		else
+		{
+			// Authentication was proved by accessing the RPC by its UNIX socket domain file.
+			var authRequest = controlClient.CreateInherentAuthRpcRequest();
+			var authenticationResponse = await controlClient.SendRpcRequestAsync<AuthSessionResult>(authRequest, cancellationToken).ConfigureAwait(false);
+
+			if (!authenticationResponse.Deconstruct(out var result, out var error))
+			{
+				Logger.LogError($"Error: '{error}'");
+				throw new TorControlException("Invalid status in AUTHENTICATE reply.");
+			}
+
+			rpcSessionId = result.Session;
+		}
+
+		string rpcClientId;
+
+		// Get a client ID.
+		{
+			var request = controlClient.CreateGetClientRpcRequest(rpcSessionId);
+			var clientResponse = await controlClient.SendRpcRequestAsync<GetClientResult>(request, cancellationToken).ConfigureAwait(false);
+
+			if (!clientResponse.Deconstruct(out var result, out var error))
+			{
+				Logger.LogError($"Error: '{error}'");
+				throw new TorControlException("Invalid status in AUTHENTICATE reply.");
+			}
+
+			rpcClientId = result.Id;
+		}
+
+		controlClient.RpcSessionId = rpcSessionId;
+		controlClient.RpcClientId = rpcClientId;
+
+		Logger.LogDebug($"Session ID: {rpcSessionId}.");
+		Logger.LogDebug($"Client ID: {rpcClientId}.");
+		return rpcSessionId;
+	}
+
+	/// <summary>Authenticates C Tor client using SAFE-COOKIE.</summary>
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">See section 3.24 for SAFECOOKIE authentication.</seealso>
 	/// <seealso href="https://github.com/torproject/stem/blob/63a476056017dda5ede35efc4e4f7acfcc1d7d1a/stem/connection.py#L893">Python implementation.</seealso>
 	/// <exception cref="TorControlException">If authentication fails for some reason.</exception>
@@ -120,6 +243,23 @@ public partial class TorControlClientFactory
 		}
 
 		return controlClient;
+	}
+
+	/// <summary>Computes the tuple hash used in Arti's RPC cookie authentication.</summary>
+	private static byte[] ComputeTupleHash(int rpcPort, string cookieString, string side, string clientNonce, string serverNonce)
+	{
+		var tupleHash = new TupleHash(bitLength: 128, S: ArtiTupleHashCustomization);
+		tupleHash.BlockUpdate(Convert.FromHexString(cookieString));
+		tupleHash.BlockUpdate(Encoding.ASCII.GetBytes(side));
+		tupleHash.BlockUpdate(Encoding.ASCII.GetBytes(string.Create(CultureInfo.InvariantCulture, $"inet:127.0.0.1:{rpcPort}")));
+		tupleHash.BlockUpdate(Convert.FromHexString(clientNonce));
+		tupleHash.BlockUpdate(Convert.FromHexString(serverNonce));
+
+		var digestSize = tupleHash.GetDigestSize();
+		var hash = new byte[digestSize];
+		tupleHash.DoFinal(hash, 0);
+
+		return hash;
 	}
 
 	[GeneratedRegex("^AUTHCHALLENGE SERVERHASH=([a-fA-F0-9]+) SERVERNONCE=([a-fA-F0-9]+)$")]

--- a/WalletWasabi/Tor/README.md
+++ b/WalletWasabi/Tor/README.md
@@ -1,0 +1,95 @@
+This document describes how to build and run [Arti](https://arti.torproject.org/), a new implementation of [C Tor](https://gitlab.torproject.org/tpo/core/tor).
+
+## Arti
+
+Arti is a complete rewrite of C Tor written in Rust. As of 2025, it is not possible to dowload compiled binaries with RPC support, so one must [compile](https://arti.torproject.org/guides/compiling-arti) it oneself.
+
+### How to Build and Run Arti from Source
+
+Install Rust compiler by following instructions from https://rustup.rs/.
+
+#### GNU/Linux
+
+```bash
+cd ~/projects
+git clone https://gitlab.torproject.org/tpo/core/arti.git     # Check out tag 2.3.0
+cd arti
+
+cargo build --package arti --features="rpc,static"            # Build for the DEBUG configuration. Note that the RPC feature is OFF by default, so we ask for it.
+./target/debug/arti proxy                                     # Run Arti compiled for the DEBUG configuration; CTRL+C to terminate the app.
+
+cargo build --package arti --release --features="rpc,static"  # Compile for the RELEASE configuration
+./target/release/arti proxy                                   # Run Arti compiled for the RELEASE configuration; CTRL+C to terminate the app.
+```
+
+An alternative that does not require the `static` feature (i.e. `--features="rpc,static"` -> `--features="rpc"`) is:
+
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt install build-essential libssl-dev pkg-config libsqlite3-dev
+cargo build --package arti --release --features=rpc
+./target/release/arti proxy
+```
+
+
+#### Windows
+
+```powershell
+cd X:\projects
+git clone https://gitlab.torproject.org/tpo/core/arti.git     # Check out tag 2.3.0
+cd arti
+
+cargo build --package arti --features="rpc,static"            # Build for the DEBUG configuration. Note that the RPC feature is OFF by default, so we ask for it.
+./target/debug/arti proxy                                     # Run Arti compiled for the DEBUG configuration; CTRL+C to terminate the app.
+
+cargo build --package arti --release --features="rpc,static"  # Build for the RELEASE configuration.
+./target/release/arti proxy                                   # Run Arti compiled for the RELEASE configuration; CTRL+C to terminate the app.
+```
+
+An [alternative](https://tor.stackexchange.com/questions/22950/how-to-compile-arti-on-windows/22952#22952) that does not require the `static` feature is:
+
+1. Download source from [source](https://www.sqlite.org/download.html) (https://www.sqlite.org/download.html)
+   For example: [source](https://www.sqlite.org/2020/sqlite-amalgamation-3310100.zip) `https://www.sqlite.org/2020/sqlite-amalgamation-3310100.zip`
+2. Download binary from [binary](https://www.sqlite.org/download.html)
+   For example: [binary](https://www.sqlite.org/2020/sqlite-dll-win64-x64-3310100.zip) `https://www.sqlite.org/2020/sqlite-dll-win64-x64-3310100.zip`
+3. Extract both archives to the same directory
+4. Open **Developer Command Prompt for VS 2017** by typing _Developer Command_ in Windows Search
+5. Go to directory where you've extracted **source code** and **binary** files (via opened cmd)
+6. Run `lib /DEF:sqlite3.def /OUT:sqlite3.lib /MACHINE:x64`
+
+
+### Debug Arti in Visual Studio Code
+
+1. Install [`rust-analyzer extension`](https://rust-analyzer.github.io/book/vs_code.html) and [`CodeLLDB`](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extensions in your Visual Studio Code
+2. Modify `launch.json` as follows:
+   ```json
+   {
+      // Use IntelliSense to learn about possible attributes.
+      // Hover to view descriptions of existing attributes.
+      // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+      "version": "0.2.0",
+      "configurations": [
+         {
+         "type": "lldb",
+         "request": "launch",
+         "name": "Debug",
+         "cargo": { "args": ["build", "--bin=arti", "--features=rpc"] },
+         "args": [
+            "proxy", 
+            "-o", "rpc.enable=true",
+            "-o", "application.permit_debugging=true"
+         ],
+         "cwd": "${workspaceFolder}",
+         "sourceLanguages": ["rust"]
+         }
+      ]
+   }
+   ```
+3. In Visual Studio Code, open the Command Palette in VS Code (Ctrl+Shift+P or Cmd+Shift+P on macOS) -> Select `Preferences: Open Workspace Settings (JSON)` and set the contents of the file to be:
+   ```json
+   {
+      "rust-analyzer.cargo.features": ["rpc"]
+   }
+   ```
+   (This enables intellisense Arti's RPC code in VS Code; otherwise it would not work.)

--- a/WalletWasabi/Tor/README.md
+++ b/WalletWasabi/Tor/README.md
@@ -1,0 +1,95 @@
+This document describes how to build and run [Arti](https://arti.torproject.org/), a new implementation of [C Tor](https://gitlab.torproject.org/tpo/core/tor).
+
+## Arti
+
+Arti is a complete rewrite of C Tor written in Rust. As of 2025, it is not possible to dowload compiled binaries with RPC support, so one must [compile](https://arti.torproject.org/guides/compiling-arti) it oneself.
+
+### How to Build and Run Arti from Source
+
+Install Rust compiler by following instructions from https://rustup.rs/.
+
+#### GNU/Linux
+
+```bash
+cd ~/projects
+git clone https://gitlab.torproject.org/tpo/core/arti.git     # Check out tag 2.5.0
+cd arti
+
+cargo build --package arti --features="rpc,static"            # Build for the DEBUG configuration. Note that the RPC feature is OFF by default, so we ask for it.
+./target/debug/arti proxy                                     # Run Arti compiled for the DEBUG configuration; CTRL+C to terminate the app.
+
+cargo build --package arti --release --features="rpc,static"  # Compile for the RELEASE configuration
+./target/release/arti proxy                                   # Run Arti compiled for the RELEASE configuration; CTRL+C to terminate the app.
+```
+
+An alternative that does not require the `static` feature (i.e. `--features="rpc,static"` -> `--features="rpc"`) is:
+
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt install build-essential libssl-dev pkg-config libsqlite3-dev
+cargo build --package arti --release --features=rpc
+./target/release/arti proxy
+```
+
+
+#### Windows
+
+```powershell
+cd X:\projects
+git clone https://gitlab.torproject.org/tpo/core/arti.git     # Check out tag 2.5.0
+cd arti
+
+cargo build --package arti --features="rpc,static"            # Build for the DEBUG configuration. Note that the RPC feature is OFF by default, so we ask for it.
+./target/debug/arti proxy                                     # Run Arti compiled for the DEBUG configuration; CTRL+C to terminate the app.
+
+cargo build --package arti --release --features="rpc,static"  # Build for the RELEASE configuration.
+./target/release/arti proxy                                   # Run Arti compiled for the RELEASE configuration; CTRL+C to terminate the app.
+```
+
+An [alternative](https://tor.stackexchange.com/questions/22950/how-to-compile-arti-on-windows/22952#22952) that does not require the `static` feature is:
+
+1. Download source from [source](https://www.sqlite.org/download.html) (https://www.sqlite.org/download.html)
+   For example: [source](https://www.sqlite.org/2020/sqlite-amalgamation-3310100.zip) `https://www.sqlite.org/2020/sqlite-amalgamation-3310100.zip`
+2. Download binary from [binary](https://www.sqlite.org/download.html)
+   For example: [binary](https://www.sqlite.org/2020/sqlite-dll-win64-x64-3310100.zip) `https://www.sqlite.org/2020/sqlite-dll-win64-x64-3310100.zip`
+3. Extract both archives to the same directory
+4. Open **Developer Command Prompt for VS 2017** by typing _Developer Command_ in Windows Search
+5. Go to directory where you've extracted **source code** and **binary** files (via opened cmd)
+6. Run `lib /DEF:sqlite3.def /OUT:sqlite3.lib /MACHINE:x64`
+
+
+### Debug Arti in Visual Studio Code
+
+1. Install [`rust-analyzer extension`](https://rust-analyzer.github.io/book/vs_code.html) and [`CodeLLDB`](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extensions in your Visual Studio Code
+2. Modify `launch.json` as follows:
+   ```json
+   {
+      // Use IntelliSense to learn about possible attributes.
+      // Hover to view descriptions of existing attributes.
+      // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+      "version": "0.2.0",
+      "configurations": [
+         {
+         "type": "lldb",
+         "request": "launch",
+         "name": "Debug",
+         "cargo": { "args": ["build", "--bin=arti", "--features=rpc"] },
+         "args": [
+            "proxy", 
+            "-o", "rpc.enable=true",
+            "-o", "application.permit_debugging=true"
+         ],
+         "cwd": "${workspaceFolder}",
+         "sourceLanguages": ["rust"]
+         }
+      ]
+   }
+   ```
+3. In Visual Studio Code, open the Command Palette in VS Code (Ctrl+Shift+P or Cmd+Shift+P on macOS) -> Select `Preferences: Open Workspace Settings (JSON)` and set the contents of the file to be:
+   ```json
+   {
+      "rust-analyzer.cargo.features": ["rpc"]
+   }
+   ```
+   (This enables intellisense Arti's RPC code in VS Code; otherwise it would not work.)

--- a/WalletWasabi/Tor/TorBackend.cs
+++ b/WalletWasabi/Tor/TorBackend.cs
@@ -1,0 +1,7 @@
+namespace WalletWasabi.Tor;
+
+public enum TorBackend
+{
+	Arti,
+	CTor
+}

--- a/WalletWasabi/Tor/TorManager.cs
+++ b/WalletWasabi/Tor/TorManager.cs
@@ -204,45 +204,53 @@ public class TorManager : IAsyncDisposable
 					Logger.LogInfo($"Tor is already running on {_settings.SocksEndpoint}");
 					controlClient = await _processManager.InitTorControlAsync(cancellationToken).ConfigureAwait(false);
 
-					// Tor process can crash even between these two commands too.
-					int processId = await controlClient.GetTorProcessIdAsync(cancellationToken).ConfigureAwait(false);
-
-					process = Process.GetProcessById(processId);
-
-					try
+					if (_settings.TorBackend == TorBackend.CTor)
 					{
-						// Note: This is a workaround how to check whether we have sufficient permissions for the process.
-						// Especially, we want to make sure that Tor is running under our user and not a different one.
-						// Example situation: Tor is run under admin account but then the app is run under a non-privileged account.
-						nint _ = process.Handle;
+						// Tor process can crash even between these two commands too.
+						int processId = await controlClient.GetTorProcessIdAsync(cancellationToken).ConfigureAwait(false);
+
+						process = Process.GetProcessById(processId);
+
+						try
+						{
+							// Note: This is a workaround how to check whether we have sufficient permissions for the process.
+							// Especially, we want to make sure that Tor is running under our user and not a different one.
+							// Example situation: Tor is run under admin account but then the app is run under a non-privileged account.
+							nint _ = process.Handle;
+						}
+						catch (Exception ex)
+						{
+							throw new NotSupportedException(TorProcessStartedByDifferentUser, ex);
+						}
+
+						TorControlReply clientTransportPluginReply = await controlClient.GetConfAsync(keyword: "ClientTransportPlugin", cancellationToken).ConfigureAwait(false);
+						if (!clientTransportPluginReply.Success)
+						{
+							throw new InvalidOperationException("Tor control failed to report the current transport plugin.");
+						}
+
+						// Check if the bridges in the running Tor instance are the same as user requested.
+						TorControlReply bridgeReply = await controlClient.GetConfAsync(keyword: "Bridge", cancellationToken).ConfigureAwait(false);
+						if (!bridgeReply.Success)
+						{
+							throw new InvalidOperationException("Tor control failed to report active bridges.");
+						}
+
+						// Compare as two unordered sets.
+						string[] currentBridges = bridgeReply.ResponseLines.Where(x => x != "Bridge").Select(x => x.Split('=', 2)[1]).Order().ToArray();
+						bool areBridgesAsRequired = currentBridges.SequenceEqual(_settings.Bridges.Order());
+
+						if (!areBridgesAsRequired)
+						{
+							Logger.LogInfo("Tor bridges of the running Tor instance are different than required. Restarting Tor.");
+							await controlClient.SignalShutdownAsync(cancellationToken).ConfigureAwait(false);
+							continue;
+						}
 					}
-					catch (Exception ex)
+					else
 					{
-						throw new NotSupportedException(TorProcessStartedByDifferentUser, ex);
-					}
-
-					TorControlReply clientTransportPluginReply = await controlClient.GetConfAsync(keyword: "ClientTransportPlugin", cancellationToken).ConfigureAwait(false);
-					if (!clientTransportPluginReply.Success)
-					{
-						throw new InvalidOperationException("Tor control failed to report the current transport plugin.");
-					}
-
-					// Check if the bridges in the running Tor instance are the same as user requested.
-					TorControlReply bridgeReply = await controlClient.GetConfAsync(keyword: "Bridge", cancellationToken).ConfigureAwait(false);
-					if (!bridgeReply.Success)
-					{
-						throw new InvalidOperationException("Tor control failed to report active bridges.");
-					}
-
-					// Compare as two unordered sets.
-					string[] currentBridges = bridgeReply.ResponseLines.Where(x => x != "Bridge").Select(x => x.Split('=', 2)[1]).Order().ToArray();
-					bool areBridgesAsRequired = currentBridges.SequenceEqual(_settings.Bridges.Order());
-
-					if (!areBridgesAsRequired)
-					{
-						Logger.LogInfo("Tor bridges of the running Tor instance are different than required. Restarting Tor.");
-						await controlClient.SignalShutdownAsync(cancellationToken).ConfigureAwait(false);
-						continue;
+						// There is no API to get Arti's process ID, so we can't monitor it properly.
+						// Arti with Tor Bridges is not supported yet.
 					}
 				}
 				else
@@ -264,6 +272,19 @@ public class TorManager : IAsyncDisposable
 				}
 
 				Logger.LogInfo("Tor is running.");
+				if (_settings.TorBackend == TorBackend.Arti)
+				{
+					var clientStatus = await controlClient.GetClientStatusRpcAsync(cancellationToken).ConfigureAwait(false);
+					if (!clientStatus.Deconstruct(out var result, out var error))
+					{
+						Logger.LogError($"Client status RPC failed with error: {error}");
+						throw new InvalidOperationException("Client status RPC request failed.");
+					}
+
+					// TODO
+					// Logger.LogInfo("Watch events.");
+					// var watchResponse = await controlClient.StartWatchingClientStatusRpcAsync(cancellationToken).ConfigureAwait(false);
+				}
 
 				// Only now we know that Tor process is fully started.
 				lock (_stateLock)
@@ -274,7 +295,16 @@ public class TorManager : IAsyncDisposable
 					_tcs.SetResult((cts.Token, controlClient));
 				}
 
-				await _processManager.WaitForProcessExitAsync(process, cancellationToken).ConfigureAwait(false);
+				// If we have a process instance, then we can wait for it to exist, otherwise we just wait indefinitely until cancellation is requested.
+				// TODO: Figure out, how to retrieve already-running Arti's process ID.
+				if (process is not null)
+				{
+					await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+				}
+				else
+				{
+					await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+				}
 
 				Logger.LogDebug("Tor process exited.");
 			}

--- a/WalletWasabi/Tor/TorManager.cs
+++ b/WalletWasabi/Tor/TorManager.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.BundledApps;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Tor.Control;
@@ -204,45 +205,53 @@ public class TorManager : IAsyncDisposable
 					Logger.LogInfo($"Tor is already running on {_settings.SocksEndpoint}");
 					controlClient = await _processManager.InitTorControlAsync(cancellationToken).ConfigureAwait(false);
 
-					// Tor process can crash even between these two commands too.
-					int processId = await controlClient.GetTorProcessIdAsync(cancellationToken).ConfigureAwait(false);
-
-					process = Process.GetProcessById(processId);
-
-					try
+					if (_settings.TorBackend == TorBackend.CTor)
 					{
-						// Note: This is a workaround how to check whether we have sufficient permissions for the process.
-						// Especially, we want to make sure that Tor is running under our user and not a different one.
-						// Example situation: Tor is run under admin account but then the app is run under a non-privileged account.
-						nint _ = process.Handle;
+						// Tor process can crash even between these two commands too.
+						int processId = await controlClient.GetTorProcessIdAsync(cancellationToken).ConfigureAwait(false);
+
+						process = Process.GetProcessById(processId);
+
+						try
+						{
+							// Note: This is a workaround how to check whether we have sufficient permissions for the process.
+							// Especially, we want to make sure that Tor is running under our user and not a different one.
+							// Example situation: Tor is run under admin account but then the app is run under a non-privileged account.
+							nint _ = process.Handle;
+						}
+						catch (Exception ex)
+						{
+							throw new NotSupportedException(TorProcessStartedByDifferentUser, ex);
+						}
+
+						TorControlReply clientTransportPluginReply = await controlClient.GetConfAsync(keyword: "ClientTransportPlugin", cancellationToken).ConfigureAwait(false);
+						if (!clientTransportPluginReply.Success)
+						{
+							throw new InvalidOperationException("Tor control failed to report the current transport plugin.");
+						}
+
+						// Check if the bridges in the running Tor instance are the same as user requested.
+						TorControlReply bridgeReply = await controlClient.GetConfAsync(keyword: "Bridge", cancellationToken).ConfigureAwait(false);
+						if (!bridgeReply.Success)
+						{
+							throw new InvalidOperationException("Tor control failed to report active bridges.");
+						}
+
+						// Compare as two unordered sets.
+						string[] currentBridges = bridgeReply.ResponseLines.Where(x => x != "Bridge").Select(x => x.Split('=', 2)[1]).Order().ToArray();
+						bool areBridgesAsRequired = currentBridges.SequenceEqual(_settings.Bridges.Order());
+
+						if (!areBridgesAsRequired)
+						{
+							Logger.LogInfo("Tor bridges of the running Tor instance are different than required. Restarting Tor.");
+							await controlClient.SignalShutdownAsync(cancellationToken).ConfigureAwait(false);
+							continue;
+						}
 					}
-					catch (Exception ex)
+					else
 					{
-						throw new NotSupportedException(TorProcessStartedByDifferentUser, ex);
-					}
-
-					TorControlReply clientTransportPluginReply = await controlClient.GetConfAsync(keyword: "ClientTransportPlugin", cancellationToken).ConfigureAwait(false);
-					if (!clientTransportPluginReply.Success)
-					{
-						throw new InvalidOperationException("Tor control failed to report the current transport plugin.");
-					}
-
-					// Check if the bridges in the running Tor instance are the same as user requested.
-					TorControlReply bridgeReply = await controlClient.GetConfAsync(keyword: "Bridge", cancellationToken).ConfigureAwait(false);
-					if (!bridgeReply.Success)
-					{
-						throw new InvalidOperationException("Tor control failed to report active bridges.");
-					}
-
-					// Compare as two unordered sets.
-					string[] currentBridges = bridgeReply.ResponseLines.Where(x => x != "Bridge").Select(x => x.Split('=', 2)[1]).Order().ToArray();
-					bool areBridgesAsRequired = currentBridges.SequenceEqual(_settings.Bridges.Order());
-
-					if (!areBridgesAsRequired)
-					{
-						Logger.LogInfo("Tor bridges of the running Tor instance are different than required. Restarting Tor.");
-						await controlClient.SignalShutdownAsync(cancellationToken).ConfigureAwait(false);
-						continue;
+						// There is no API to get Arti's process ID, so we can't monitor it properly.
+						// Arti with Tor Bridges is not supported yet.
 					}
 				}
 				else
@@ -264,6 +273,19 @@ public class TorManager : IAsyncDisposable
 				}
 
 				Logger.LogInfo("Tor is running.");
+				if (_settings.TorBackend == TorBackend.Arti)
+				{
+					var clientStatus = await controlClient.GetClientStatusRpcAsync(cancellationToken).ConfigureAwait(false);
+					if (!clientStatus.Deconstruct(out var result, out var error))
+					{
+						Logger.LogError($"Client status RPC failed with error: {error}");
+						throw new InvalidOperationException("Client status RPC request failed.");
+					}
+
+					// TODO
+					// Logger.LogInfo("Watch events.");
+					// var watchResponse = await controlClient.StartWatchingClientStatusRpcAsync(cancellationToken).ConfigureAwait(false);
+				}
 
 				// Only now we know that Tor process is fully started.
 				lock (_stateLock)
@@ -274,7 +296,16 @@ public class TorManager : IAsyncDisposable
 					_tcs.SetResult((cts.Token, controlClient));
 				}
 
-				await _processManager.WaitForProcessExitAsync(process, cancellationToken).ConfigureAwait(false);
+				// If we have a process instance, then we can wait for it to exist, otherwise we just wait indefinitely until cancellation is requested.
+				// TODO: Figure out, how to retrieve already-running Arti's process ID.
+				if (process is not null)
+				{
+					await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+				}
+				else
+				{
+					await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+				}
 
 				Logger.LogDebug("Tor process exited.");
 			}

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -38,7 +38,7 @@ public class TorProcessManager
 			WorkingDirectory = _settings.TorBinaryDir
 		};
 
-		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		if (_settings.TorBackend == TorBackend.CTor && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
 			var env = startInfo.EnvironmentVariables;
 
@@ -49,7 +49,10 @@ public class TorProcessManager
 			Logger.LogDebug($"Environment variable 'LD_LIBRARY_PATH' set to: '{env["LD_LIBRARY_PATH"]}'.");
 		}
 
-		Logger.LogInfo(_settings.IsCustomTorFolder ? $"Starting Tor process in folder '{_settings.TorBinaryDir}'…" : "Starting Tor process…");
+		Logger.LogInfo(_settings.IsCustomTorFolder
+			? $"Starting Tor process in folder '{_settings.TorBinaryDir}' with arguments '{arguments}'…"
+			: $"Starting Tor process with arguments '{arguments}'…");
+
 		var process = new Process()
 		{
 			StartInfo = startInfo,
@@ -144,7 +147,7 @@ public class TorProcessManager
 
 	public virtual Process[] GetTorProcesses()
 	{
-		return Process.GetProcessesByName(TorSettings.TorBinaryFileName);
+		return Process.GetProcessesByName(_settings.TorBinaryFileName);
 	}
 
 	/// <summary>Connects to Tor control using a TCP client or throws <see cref="TorControlException"/>.</summary>
@@ -152,18 +155,33 @@ public class TorProcessManager
 	/// <seealso href="https://gitweb.torproject.org/torspec.git/tree/control-spec.txt">This method follows instructions in 3.23. TAKEOWNERSHIP.</seealso>
 	public virtual async Task<TorControlClient> InitTorControlAsync(CancellationToken token)
 	{
-		// If the cookie file does not exist, we know our Tor starting procedure is corrupted somehow. Best to start from scratch.
-		if (!File.Exists(_settings.CookieAuthFilePath))
-		{
-			throw new TorControlException("Cookie file does not exist.");
-		}
+		string? cookieString = null;
 
-		// Get cookie.
-		string cookieString = Convert.ToHexString(File.ReadAllBytes(_settings.CookieAuthFilePath));
+		if (_settings.CookieAuthFilePath is not null)
+		{
+			// If the cookie file does not exist, we know our Tor starting procedure is corrupted somehow. Best to start from scratch.
+			if (!File.Exists(_settings.CookieAuthFilePath))
+			{
+				throw new TorControlException("Cookie file does not exist.");
+			}
+
+			if (_settings.TorBackend == TorBackend.CTor)
+			{
+				cookieString = Convert.ToHexString(File.ReadAllBytes(_settings.CookieAuthFilePath));
+			}
+			else
+			{
+				var cookieBytes = File.ReadAllBytes(_settings.CookieAuthFilePath);
+
+				// See https://gitlab.torproject.org/tpo/core/arti/-/blob/6d9ee5587fdbb6028ed9cfa2a6049e2418ba583a/crates/tor-rpc-connect/src/auth/cookie.rs#L42.
+				var artiPrefix = "====== arti-rpc-cookie-v1 ======";
+				cookieString = Convert.ToHexString(cookieBytes[artiPrefix.Length..]);
+			}
+		}
 
 		// Authenticate.
 		TorControlClientFactory factory = new();
-		TorControlClient client = await factory.ConnectAndAuthenticateAsync(_settings.ControlEndpoint, cookieString, token).ConfigureAwait(false);
+		TorControlClient client = await factory.ConnectAndAuthenticateAsync(_settings.TorBackend, _settings.ControlEndpoint, cookieString, token).ConfigureAwait(false);
 
 		if (_settings.TerminateOnExit)
 		{

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -1,8 +1,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Runtime.InteropServices;
+using System.Net.Sockets;
 using WalletWasabi.BundledApps;
+using System.Runtime.InteropServices;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -15,9 +16,6 @@ namespace WalletWasabi.Tor;
 /// </summary>
 public class TorSettings
 {
-	/// <summary>Tor binary file name without extension.</summary>
-	public const string TorBinaryFileName = "tor";
-
 	/// <summary>Default port assigned to Tor SOCKS5 for the Wasabi's bundled Tor.</summary>
 	public const int DefaultSocksPort = 37150;
 
@@ -25,6 +23,7 @@ public class TorSettings
 	public const int DefaultControlPort = 37151;
 
 	public TorSettings(
+		TorBackend backend,
 		string dataDir,
 		string distributionFolderPath,
 		bool terminateOnExit,
@@ -36,6 +35,7 @@ public class TorSettings
 		int? owningProcessId = null,
 		bool log = true)
 	{
+		TorBackend = backend;
 		IsCustomTorFolder = torFolder is not null;
 
 		bool defaultWasabiTorPorts = socksPort == DefaultSocksPort && controlPort == DefaultControlPort;
@@ -60,15 +60,35 @@ public class TorSettings
 		TorBinaryFilePath = GetTorBinaryFilePath(TorBinaryDir);
 		TorTransportPluginsDir = Path.Combine(TorBinaryDir, "PluggableTransports");
 
-		TorDataDir = Path.Combine(dataDir, "tordata2");
+		TorDataDir = Path.Combine(dataDir, $"tordata-{backend}");
+		SocksPort = socksPort;
 		SocksEndpoint = new IPEndPoint(IPAddress.Loopback, socksPort);
-		ControlEndpoint = new IPEndPoint(IPAddress.Loopback, controlPort);
+
+		if (TorBackend == TorBackend.Arti && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "arti", "rpc", "arti_rpc_socket");
+			ControlEndpoint = new UnixDomainSocketEndPoint(path);
+		}
+		else
+		{
+			ControlEndpoint = new IPEndPoint(IPAddress.Loopback, controlPort);
+		}
+
 		Bridges = bridges ?? [];
 		OwningProcessId = owningProcessId;
 
-		CookieAuthFilePath = defaultWasabiTorPorts
-			? Path.Combine(dataDir, $"control_auth_cookie")
-			: Path.Combine(dataDir, $"control_auth_cookie_{socksPort}_{controlPort}");
+		if (TorBackend == TorBackend.CTor)
+		{
+			CookieAuthFilePath = defaultWasabiTorPorts
+				? Path.Combine(dataDir, $"control_auth_cookie")
+				: Path.Combine(dataDir, $"control_auth_cookie_{socksPort}_{controlPort}");
+		}
+		else
+		{
+			CookieAuthFilePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+				? Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "torproject", "Arti", "data", "rpc", "arti_rpc_cookie")
+				: null;
+		}
 
 		LogFilePath = Path.Combine(dataDir, "TorLogs.txt");
 		IoHelpers.EnsureContainingDirectoryExists(LogFilePath);
@@ -87,7 +107,12 @@ public class TorSettings
 		_geoIp6Path = Path.Combine(DistributionFolder, "Tor", "Geoip", "geoip6");
 	}
 
+	public TorBackend TorBackend { get; }
+
 	public TorMode TorMode { get; }
+
+	/// <summary>Tor binary file name without extension.</summary>
+	public string TorBinaryFileName => TorBackend == TorBackend.CTor ? "tor" : "arti";
 
 	/// <summary><c>true</c> if user specified a custom Tor folder to run a (possibly) different Tor binary than the bundled Tor, <c>false</c> otherwise.</summary>
 	public bool IsCustomTorFolder { get; }
@@ -126,11 +151,14 @@ public class TorSettings
 	/// <summary>Full path to executable file that is used to start Tor process.</summary>
 	public string TorBinaryFilePath { get; }
 
-	/// <summary>Full path to Tor cookie file.</summary>
-	public string CookieAuthFilePath { get; }
+	/// <summary>Full path to Tor cookie file, or <c>null</c> if UNIX domain socket endpoint is used.</summary>
+	public string? CookieAuthFilePath { get; }
 
 	/// <summary>Tor SOCKS5 endpoint.</summary>
 	public EndPoint SocksEndpoint { get; }
+
+	/// <summary>Tor SOCKS5 port.</summary>
+	public int SocksPort { get; }
 
 	/// <summary>Tor control endpoint.</summary>
 	public EndPoint ControlEndpoint { get; }
@@ -138,7 +166,7 @@ public class TorSettings
 	private readonly string _geoIp6Path;
 
 	/// <returns>Full path to Tor binary for selected <paramref name="platform"/>.</returns>
-	public static string GetTorBinaryFilePath(string path, OSPlatform? platform = null)
+	public string GetTorBinaryFilePath(string path, OSPlatform? platform = null)
 	{
 		return Path.Combine(path, BundledAppHelpers.GetFilenameWithExtension(TorBinaryFileName, platform));
 	}
@@ -154,89 +182,118 @@ public class TorSettings
 			port = 9051; // Standard port for Tor control.
 		}
 
-		bool useBridges = Bridges.Length > 0;
+		List<string> arguments;
 
-		// `--SafeLogging 0` is useful for debugging to avoid "[scrubbed]" redactions in Tor log.
-		List<string> arguments = [
-			$"--LogTimeGranularity 1",
-			$"--TruncateLogFile 1",
-			$"--UseBridges {(useBridges ? "1" : "0")}",
-			$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
-			$"--SocksTimeout 30", // Default is 2 minutes.
-			$"--CookieAuthentication 1",
-			$"--ControlPort {port}",
-			$"--CookieAuthFile \"{CookieAuthFilePath}\"",
-			$"--DataDirectory \"{TorDataDir}\"",
-			$"--GeoIPFile \"{_geoIpPath}\"",
-			$"--GeoIPv6File \"{_geoIp6Path}\"",
-			$"--NumEntryGuards 3",
-			$"--NumPrimaryGuards 3",
-			$"--ConfluxEnabled 1",
-			$"--ConfluxClientUX throughput"
-		];
 
-		if (useBridges)
+		if (TorBackend == TorBackend.CTor)
 		{
-			HashSet<string> usedPlugins = [];
+			bool useBridges = Bridges.Length > 0;
 
-			foreach (string bridge in Bridges)
+			// `--SafeLogging 0` is useful for debugging to avoid "[scrubbed]" redactions in Tor log.
+			arguments = [
+				$"--LogTimeGranularity 1",
+				$"--TruncateLogFile 1",
+				$"--UseBridges {(useBridges ? "1" : "0")}",
+				$"--SOCKSPort \"{SocksEndpoint} ExtendedErrors KeepAliveIsolateSOCKSAuth\"",
+				$"--SocksTimeout 30", // Default is 2 minutes.
+				$"--CookieAuthentication 1",
+				$"--ControlPort {port}",
+				$"--CookieAuthFile \"{CookieAuthFilePath}\"",
+				$"--DataDirectory \"{TorDataDir}\"",
+				$"--GeoIPFile \"{_geoIpPath}\"",
+				$"--GeoIPv6File \"{_geoIp6Path}\"",
+				$"--NumEntryGuards 3",
+				$"--NumPrimaryGuards 3",
+				$"--ConfluxEnabled 1",
+				$"--ConfluxClientUX throughput"
+			];
+
+			if (useBridges)
 			{
-				if (bridge.Contains('\'') || bridge.Contains('"'))
+				HashSet<string> usedPlugins = [];
+
+				foreach (string bridge in Bridges)
 				{
-					Logger.LogError($"Skipping bridge '{bridge}' because it contains a quote or an apostrophe.");
-					continue;
+					if (bridge.Contains('\'') || bridge.Contains('"'))
+					{
+						Logger.LogError($"Skipping bridge '{bridge}' because it contains a quote or an apostrophe.");
+						continue;
+					}
+
+					if (bridge.StartsWith("obfs4 ", StringComparison.Ordinal))
+					{
+						usedPlugins.Add("obfs4");
+					}
+					else if (bridge.StartsWith("webtunnel ", StringComparison.Ordinal))
+					{
+						usedPlugins.Add("webtunnel");
+					}
+					else if (bridge.StartsWith("snowflake ", StringComparison.Ordinal))
+					{
+						usedPlugins.Add("snowflake");
+					}
+					else
+					{
+						throw new NotSupportedException($"Bridge transport of bridge '{bridge}' is not supported.");
+					}
+
+					arguments.Add($"--Bridge \"{bridge}\"");
 				}
 
-				if (bridge.StartsWith("obfs4 ", StringComparison.Ordinal))
+				foreach (string plugin in usedPlugins)
 				{
-					usedPlugins.Add("obfs4");
-				}
-				else if (bridge.StartsWith("webtunnel ", StringComparison.Ordinal))
-				{
-					usedPlugins.Add("webtunnel");
-				}
-				else if (bridge.StartsWith("snowflake ", StringComparison.Ordinal))
-				{
-					usedPlugins.Add("snowflake");
-				}
-				else
-				{
-					throw new NotSupportedException($"Bridge transport of bridge '{bridge}' is not supported.");
-				}
+					string fileNameWithoutExtension = plugin switch
+					{
+						"obfs4" => "lyrebird", // obfs4 was renamed to lyrebird.
+						"webtunnel" => "webtunnel-client",
+						"snowflake" => "lyrebird",
+						_ => throw new NotSupportedException($"Unknown Tor pluggable transport '{plugin}'."),
+					};
 
-				arguments.Add($"--Bridge \"{bridge}\"");
+					string filename = BundledAppHelpers.GetCurrentPlatform() == OSPlatform.Windows ? $"{fileNameWithoutExtension}.exe" : $"{fileNameWithoutExtension}";
+					string path = Path.Combine(TorTransportPluginsDir, filename);
+
+					if (!File.Exists(path))
+					{
+						throw new NotSupportedException($"Tor bridge plugin was not found '{path}'.");
+					}
+
+					arguments.Add($"--ClientTransportPlugin \"{plugin} exec {path}\"");
+				}
 			}
+		}
+		else
+		{
+			arguments = [
+				"proxy",
+				"-o", "rpc.enable=true",
+				"-o", "logging.log_sensitive_information=true",
+				"-o", $"\"proxy.socks_listen = {SocksPort}\"",
 
-			foreach (string plugin in usedPlugins)
-			{
-				string fileNameWithoutExtension = plugin switch
-				{
-					"obfs4" => "lyrebird", // obfs4 was renamed to lyrebird.
-					"webtunnel" => "webtunnel-client",
-					"snowflake" => "lyrebird",
-					_ => throw new NotSupportedException($"Unknown Tor pluggable transport '{plugin}'."),
-				};
-
-				string filename = BundledAppHelpers.GetCurrentPlatform() == OSPlatform.Windows ? $"{fileNameWithoutExtension}.exe" : $"{fileNameWithoutExtension}";
-				string path = Path.Combine(TorTransportPluginsDir, filename);
-
-				if (!File.Exists(path))
-				{
-					throw new NotSupportedException($"Tor bridge plugin was not found '{path}'.");
-				}
-
-				arguments.Add($"--ClientTransportPlugin \"{plugin} exec {path}\"");
-			}
+				// TODO
+				//"-o", $"storage.cache_dir=\"{Path.Combine(TorDataDir, "cache").Replace("\\", "\\\\")}\"",
+				//"-o", $"storage.state_dir=\"{Path.Combine(TorDataDir, "state").Replace("\\", "\\\\")}\""
+			];
 		}
 
 		if (Log)
 		{
-			arguments.Add($"--Log \"notice file {LogFilePath}\"");
+			if (TorBackend == TorBackend.CTor)
+			{
+				arguments.Add($"--Log \"notice file {LogFilePath}\"");
+			}
+			else
+			{
+				arguments.AddRange(["--log-level", "debug"]);
+			}
 		}
 
-		if (TerminateOnExit && OwningProcessId is not null)
+		if (TorBackend == TorBackend.CTor)
 		{
-			arguments.Add($"__OwningControllerProcess {OwningProcessId}");
+			if (TerminateOnExit && OwningProcessId is not null)
+			{
+				arguments.Add($"__OwningControllerProcess {OwningProcessId}");
+			}
 		}
 
 		return string.Join(" ", arguments);

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -22,6 +22,7 @@
 
 	<ItemGroup>
 		<!-- TODO: Workaround for incompatible package Microsoft.AspNetCore.Mvc.NewtonsoftJson -->
+		<PackageReference Include="BouncyCastle.Cryptography" />
 		<PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "BouncyCastle.Cryptography": {
+        "type": "Direct",
+        "requested": "[2.6.2, )",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "Direct",
         "requested": "[10.0.2, )",


### PR DESCRIPTION
The PR researches feasibility of transition from [C Tor](https://gitlab.torproject.org/tpo/core/tor) to [Arti](https://arti.torproject.org/).

* [Why?](https://gitlab.torproject.org/tpo/core/arti#why-rewrite-tor-in-rust)
* Issues?[^1][^2][^3]
* Next steps?[^4]

### To Run

```bash
cd WalletWasabi.Fluent.Desktop
dotnet run -f net10.0 -- --TorBackend=Arti --TorSocksPort=9150 --TorControlPort=9180
```

### RPC Authentication

There are two ways to authenticate to Arti's RPC server. 

Arti running on a GNU/linux machine defaults to listening on a Unix Domain Socket file (`~/.local/share/torproject/Arti/data/rpc/arti_rpc_cookie`). Successfully connecting to the UDS file proves that the current linux user has access to the file and the authentication is trivially finished with just sending:

```s
# Client asks for authentication.
{"id": 1,"obj":"connection","method":"auth:authenticate","params":{"scheme":"auth:inherent"} }
# Arti server returns an RPC session ID.
{"id": 1,"result":{"session":"$Pw2Qb/2imXENiD1PhyiGc0/C8udsQhoChNyqoxUnP9r6S0Sk/BPSQPpLRKX8E9JB"}}
# Client asks for an RPC client ID using the just-received RPC session ID.
{"id": 2,"obj":"$Pw2Qb/2imXENiD1PhyiGc0/C8udsQhoChNyqoxUnP9r6S0Sk/BPSQPpLRKX8E9JB","method":"arti:get_client","params":{} }
# Arti server returns an RPC client ID.
{"id": 2,"result":{"id":"$+INYzDjCi5O+tfQPTJirGywkD+QWnLH2c5OQ9Db9J6wpBfIxRlERNikF8jJGURE5"}}
```

The Windows OS has a different file permission model, so Arti defaults to an RPC authentication based on a series of RPC messages:

```s
# Client asks for cookie authentication to begin.
{"id":1,"obj":"connection","method":"auth:cookie_begin","params":{"client_nonce":"9DDC1B1B2723AE73DBD58BF6E19887CF4E19E3CBE941AF44FD540D332993D12D"}}
# Arti server replies.
{"id":1,"result":{"cookie_auth":"3fvOz6naC5zd-87QqdoLnQ","server_addr":"inet:127.0.0.1:9180","server_mac":"DE251AC0603A961850B846999C63B0D9CFA07F21364AF3698F4D047AE307066B","server_nonce":"110FC7B25FD668A687431D2F73A0C162F9E4A2CF73C94E7E88097A71B74ED660"}}
# Client sends `client_mac` value. 
{"id":2,"obj":"3fvOz6naC5zd-87QqdoLnQ","method":"auth:cookie_continue","params":{"client_mac":"4E64A5D7CB071DA7F504EC283910C020768E472B706FBEA5A8EC8296EE0A6C94"}}
# Arti server returns an RPC session ID.
{"id":2,"result":{"session":"$/bb1kjiQd+c1HhExFJWOnCwkD+QWnLH2c5OQ9Db9J6xo0NTxRGXYCmjQ1PJEZdgM"}}
# Client asks for an RPC client ID using the just-received RPC session ID.
{"id": 3,"obj":"$/bb1kjiQd+c1HhExFJWOnCwkD+QWnLH2c5OQ9Db9J6xo0NTxRGXYCmjQ1PJEZdgM","method":"arti:get_client","params":{} }
# Arti server returns an RPC client ID.
{"id":3,"result":{"id":"$+INYzDjCi5O+tfQPTJirGywkD+QWnLH2c5OQ9Db9J6wpBfIxRlERNikF8jJGURE5"}}
```
Spec: https://gitlab.torproject.org/tpo/core/arti/-/blob/main/doc/dev/rpc-book/src/rpc-cookie-spec.md#in-arti-rpc

### Limitations

* RPC port can be only `9180`. Is there a good way to do it?

### Ideas

* https://gitlab.torproject.org/tpo/core/arti/-/blob/main/CHANGELOG.md?ref_type=heads#rpc-development 
    > Support for deferred bootstraping.  Programs can use this to create Arti in mode
that will not use the network, and then later enable network support after having
configured Arti to their liking. ([!4056 (merged)](https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/4056))


Merry Christmas 🎄 

[^1]: Compile Arti yourself using `cargo build --package arti --release --features="rpc,static"`. Do not trust binaries in this PR.
[^2]: Not tested on macOS at all. RPC authentication worked for me on GNU/Linux and Windows.
[^3]: [BouncyCastle.Cryptography](https://www.bouncycastle.org/download/bouncy-castle-c/) package is used to compute `TupleHash` SHA3 derived function. Is there .NET API for it? [Not](https://github.com/dotnet/runtime/issues/20342) really. [But](https://github.com/dotnet/runtime/discussions/123625#discussioncomment-16243127) there is a [proposal](https://github.com/dotnet/runtime/issues/125890) now.
[^4]: Yes. M-m-many.