### PR TITLE
Refactor CoinJoinManager to use MailboxProcessor architecture

### DIFF
--- a/Contrib/Tests/regtest-coinjoin-test.sh
+++ b/Contrib/Tests/regtest-coinjoin-test.sh
@@ -9,26 +9,105 @@ BITCOIN_RPC_PORT=18443
 BITCOIN_P2P_PORT=18444
 COORDINATOR_PORT=37126
 WALLET_RPC_PORT=37128
+TEST_TIMEOUT=600
 
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
 NC='\033[0m' # No Color
 
+# Print functions
+print_header() {
+    echo -e "\n${BOLD}${BLUE}═══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BOLD}${BLUE}  $1${NC}"
+    echo -e "${BOLD}${BLUE}═══════════════════════════════════════════════════════════════${NC}\n"
+}
+
+print_step() {
+    echo -e "${CYAN}▶${NC} ${BOLD}$1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+print_info() {
+    echo -e "${YELLOW}ℹ${NC} $1"
+}
+
+# Cleanup function
 cleanup() {
-    kill $COORDINATOR_PID
-    kill $WALLET_PID
-    bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest stop
-    rm -rf $WASABI_DATADIR/Client/Wallets
-    rm -rf $BITCOIN_DATADIR
-    exit
+    print_header "Cleaning up..."
+
+    if [ -n "$COORDINATOR_PID" ]; then
+        kill $COORDINATOR_PID 2>/dev/null || true
+        print_info "Stopped coordinator (PID: $COORDINATOR_PID)"
+    fi
+
+    if [ -n "$WALLET_PID" ]; then
+        kill $WALLET_PID 2>/dev/null || true
+        print_info "Stopped wallet daemon (PID: $WALLET_PID)"
+    fi
+
+    if bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest stop 2>/dev/null; then
+        print_info "Stopped Bitcoin node"
+        sleep 2
+    fi
+
+    rm -rf $WASABI_DATADIR/Client/Wallets 2>/dev/null || true
+    rm -rf $BITCOIN_DATADIR 2>/dev/null || true
+
+    print_success "Cleanup complete"
 }
 trap cleanup EXIT
 
-echo -e "${YELLOW}Starting Bitcoin node in regtest...${NC}"
+# Helper function for Bitcoin CLI
+btc_cli() {
+    bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest "$@"
+}
+
+# Helper function with wallet
+btc_cli_wallet() {
+    bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest -rpcwallet="default" "$@"
+}
+
+# Wait for service with timeout
+wait_for_service() {
+    local description=$1
+    local check_command=$2
+    local timeout=${3:-30}
+
+    print_step "Waiting for $description..."
+
+    for i in $(seq 1 $timeout); do
+        if eval "$check_command" &>/dev/null; then
+            print_success "$description is ready"
+            return 0
+        fi
+        printf "${YELLOW}.${NC}"
+        sleep 1
+    done
+
+    echo
+    print_error "Timeout waiting for $description"
+    return 1
+}
+
+# Start Bitcoin node
+print_header "Starting Bitcoin Node"
+
+print_step "Creating data directory"
 mkdir -p "$BITCOIN_DATADIR"
 
+print_step "Starting bitcoind in regtest mode"
 bitcoind \
   -regtest \
   -datadir="$BITCOIN_DATADIR" \
@@ -43,44 +122,36 @@ bitcoind \
 
 sleep 3
 
-echo -e "${GREEN}Bitcoin node started${NC}"
+wait_for_service "Bitcoin RPC" "btc_cli getblockchaininfo" || exit 1
 
-# Wait for bitcoin to be ready
-echo -e "${YELLOW}Waiting for Bitcoin RPC to be ready...${NC}"
-for i in {1..30}; do
-  if bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest getblockchaininfo &>/dev/null; then
-    echo -e "${GREEN}Bitcoin RPC is ready${NC}"
-    break
-  fi
-  sleep 1
-done
+print_step "Creating default wallet"
+btc_cli createwallet "default" > /dev/null 2>&1 || true
 
-# Create default wallet
-echo -e "${YELLOW}Creating default wallet...${NC}"
-bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest createwallet "default" > /dev/null 2>&1 || true
+print_step "Loading default wallet"
+btc_cli loadwallet "default" > /dev/null 2>&1 || true
 
-# Create default wallet
-echo -e "${YELLOW}Loading default wallet...${NC}"
-bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest loadwallet "default" > /dev/null 2>&1 || true
+print_step "Generating 150 initial blocks"
+ADDR=$(btc_cli_wallet getnewaddress)
+btc_cli generatetoaddress 150 "$ADDR" > /dev/null
+print_success "Initial blockchain setup complete"
 
-# Generate some blocks to have coins
-echo -e "${YELLOW}Generating initial blocks...${NC}"
-bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest generatetoaddress 150 $(bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest -rpcwallet="default" getnewaddress) > /dev/null
+# Start Wasabi Coordinator
+print_header "Starting Wasabi Coordinator"
 
-echo -e "${YELLOW}Starting Wasabi Coordinator...${NC}"
-mkdir -p "$WASABI_DATADIR/Coordinator"
-
-# Start coordinator in background
 WASABI_COORDINATOR_DATADIR="$WASABI_DATADIR/Coordinator"
 WASABI_COORDINATOR_LOGFILE="$WASABI_COORDINATOR_DATADIR/Logs.txt"
-rm ""$WASABI_COORDINATOR_LOGFILE""
 
+print_step "Creating coordinator directory"
+mkdir -p "$WASABI_COORDINATOR_DATADIR"
+rm -f "$WASABI_COORDINATOR_LOGFILE"
+
+print_step "Generating coordinator configuration"
 cat > $WASABI_COORDINATOR_DATADIR/Config.json << EOF
 {
   "Network": "RegTest",
   "MainNetBitcoinRpcUri": "http://localhost:$BITCOIN_RPC_PORT",
   "TestNetBitcoinRpcUri": "http://localhost:$BITCOIN_RPC_PORT",
-  "RegTestBitcoinRpcUri": "http://localhost:$BITCOIN_RPC_PORT",
+  "RegTestBitcoinRpcUri": "http://localhost:$BITCOIN_RPC_PORT/",
   "BitcoinRpcConnectionString": "regtest:regtest",
   "ConfirmationTarget": 108,
   "DoSSeverity": "0.10",
@@ -136,109 +207,200 @@ cat > $WASABI_COORDINATOR_DATADIR/Config.json << EOF
 }
 EOF
 
+print_step "Launching coordinator process"
 dotnet run --project WalletWasabi.Coordinator -- \
+  --urls="http://localhost:$COORDINATOR_PORT" \
   --datadir="$WASABI_COORDINATOR_DATADIR" &> /dev/null &
 COORDINATOR_PID=$!
+print_success "Coordinator started (PID: $COORDINATOR_PID)"
 
 sleep 5
-echo -e "${GREEN}Coordinator started (PID: $COORDINATOR_PID)${NC}"
 
-echo -e "${YELLOW}Starting Wasabi Wallet Client${NC}"
+# Start Wasabi Wallet Client
+print_header "Starting Wasabi Wallet Daemon"
 
+print_step "Creating client directory"
 mkdir -p "$WASABI_DATADIR/Client"
 
-# Start wallet daemon
+print_step "Launching wallet daemon"
 dotnet run --project WalletWasabi.Daemon -- \
   --network=regtest \
   --coordinatorUri="http://127.0.0.1:$COORDINATOR_PORT" \
-  --usebitcoinrpc=true \
-  --bitcoinrpcendpoint="http://127.0.0.1:$BITCOIN_RPC_PORT/" \
-  --bitcoinrpccredentialstring="regtest:regtest" \
   --rpcport=$WALLET_RPC_PORT \
   --datadir="$WASABI_DATADIR/Client" \
   --jsonrpcserverenabled=true \
   --maxcoinjoinminingfeerate=500 \
   --absolutemininputcount=4 \
+  --usebitcoinrpc=true \
+  --bitcoinrpccredentialstring="regtest:regtest" \
+  --bitcoinrpcendpoint="http://localhost:$BITCOIN_RPC_PORT" \
   --usetor="disabled" &> /dev/null &
 
 WALLET_PID=$!
+print_success "Wallet daemon started (PID: $WALLET_PID)"
+
 sleep 3
 
-echo -e "${YELLOW}Creating Wasabi Wallets${NC}"
+wait_for_service "Wallet RPC" \
+  "curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/ -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"listwallets\",\"params\":[]}' | grep -q result" \
+  || exit 1
 
-# Function to start a wallet and perform coinjoin
+# Wait for filter synchronization to complete
+print_step "Waiting for filter synchronization..."
+for retry in {1..5}; do
+    FILTERS_LEFT=$(curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/ \
+        -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","id":"1","method":"getstatus","params":[]}' | jq -r '.result.filtersLeft // 999')
+
+    if [ "$FILTERS_LEFT" = "0" ]; then
+        break
+    fi
+    printf "${YELLOW}.${NC}"
+    sleep 1
+done
+echo
+print_success "Filters synchronized"
+
+# Create and fund wallets
+print_header "Creating and Funding Wallets"
+
 create_and_fund_wallet() {
-  local wallet_name=$1
-  local wallet_num=$2
+    local wallet_name=$1
+    printf "${CYAN}▶${NC} Creating $wallet_name... "
 
-  echo -e "${YELLOW}Create wallet $wallet_name...${NC}"
-  curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/ \
-    -H "Content-Type: application/json" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"createwallet\",\"params\":[\"$wallet_name\", \"\"]}" | jq -r '.result'
+    # Create wallet (just creates the wallet file, doesn't load it)
+    curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/ \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"createwallet\",\"params\":[\"$wallet_name\", \"\"]}" | jq -r '.result' > /dev/null
 
-  echo -e "${YELLOW}Generating addresses for $wallet_name...${NC}"
-  for (( i = 0; i < 4; i++ )); do
-    local address=$(curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/$wallet_name \
-      -H "Content-Type: application/json" \
-      -d '{"jsonrpc":"2.0","id":"1","method":"getnewaddress","params":["label"]}' | jq -r '.result.address')
+    printf "${GREEN}✓${NC} Loading... "
 
-    echo -e "${YELLOW}Sending funds to $wallet_name ($address)...${NC}"
-    bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest -rpcwallet="default"\
-      sendtoaddress "$address" 1.0 > /dev/null
-  done
+    # Load the wallet (this starts the wallet asynchronously)
+    curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/ \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"loadwallet\",\"params\":[\"$wallet_name\"]}" > /dev/null
+
+    # Wait for wallet to be fully loaded (poll getwalletinfo until loaded: true)
+    local loaded=false
+    for retry in {1..120}; do
+        local wallet_info=$(curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/$wallet_name \
+            -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","id":"1","method":"getwalletinfo","params":[]}')
+
+        local is_loaded=$(echo "$wallet_info" | jq -r '.result.loaded // false')
+
+        if [ "$is_loaded" = "true" ]; then
+            loaded=true
+            break
+        fi
+        printf "${YELLOW}.${NC}"
+        sleep 1
+    done
+
+    if [ "$loaded" = "false" ]; then
+        echo -e "\n${RED}✗${NC} Wallet $wallet_name failed to load after 120 seconds"
+        return 1
+    fi
+
+    echo
+    printf "${GREEN}✓${NC} Loaded! Funding... "
+
+    # Generate addresses and fund them
+    for (( i = 0; i < 4; i++ )); do
+        local address=$(curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/$wallet_name \
+            -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","id":"1","method":"getnewaddress","params":["label"]}' | jq -r '.result.address')
+
+        if [ "$address" = "null" ] || [ -z "$address" ]; then
+            echo -e "\n${RED}✗${NC} Failed to get address from $wallet_name"
+            return 1
+        fi
+
+        btc_cli_wallet sendtoaddress "$address" 1.0 > /dev/null
+    done
+
+    echo -e "${GREEN}✓${NC}"
 }
 
-start_coinjoin()
-{
-  local wallet_name=$1
-  echo -e "${YELLOW}Starting coinjoin...${NC}"
-  curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/$wallet_name \
-      -H "Content-Type: application/json" \
-      -d '{"jsonrpc":"2.0","id":"1","method":"startcoinjoin","params":[]}' > /dev/null
-
-  echo -e "${GREEN}Coinjoin initiated for $wallet_name${NC}"
+start_coinjoin() {
+    local wallet_name=$1
+    curl -s -X POST http://127.0.0.1:$WALLET_RPC_PORT/$wallet_name \
+        -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","id":"1","method":"startcoinjoin","params":[]}' > /dev/null
 }
 
-# Start multiple wallets and initiate coinjoins
-echo -e "${YELLOW}Starting multiple wallets and initiating coinjoins...${NC}"
+NUM_WALLETS=5
 
-for (( i = 0; i < 5; i++ )); do
-  create_and_fund_wallet "wallet$i" &
-  sleep 2
+for (( wi = 0; wi < $NUM_WALLETS; wi++ )); do
+    create_and_fund_wallet "wallet$wi"
+    sleep 1
 done
 
-echo -e "${GREEN}Wallets created and well funded${NC}"
+print_success "All $NUM_WALLETS wallets created and funded"
 
-# Generate a block to confirm
-echo -e "${YELLOW}Mine a new block to confirm all transactions${NC}"
-bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest \
-  generatetoaddress 1 $(bitcoin-cli -regtest -rpcport=$BITCOIN_RPC_PORT -rpcuser=regtest -rpcpassword=regtest -rpcwallet="default" getnewaddress) > /dev/null
+# Generate a block to confirm all transactions
+print_header "Confirming Transactions"
+
+print_step "Mining block to confirm funding transactions"
+ADDR=$(btc_cli_wallet getnewaddress)
+btc_cli generatetoaddress 1 "$ADDR" > /dev/null
+print_success "Transactions confirmed"
 
 sleep 2
 
-echo -e "${YELLOW}Starting coinjoins...${NC}"
-for (( i = 0; i < 5; i++ )); do
-  start_coinjoin "wallet$i" &
-  sleep 2
+# Start coinjoins
+print_header "Starting CoinJoin Operations"
+
+for (( i = 0; i < $NUM_WALLETS; i++ )); do
+    printf "${CYAN}[$((i+1))/$NUM_WALLETS]${NC} Starting coinjoin for wallet$i... "
+    start_coinjoin "wallet$i"
+    echo -e "${GREEN}✓${NC}"
+    sleep 2
 done
 
-echo -e "${GREEN}All wallets started and coinjoins initiated${NC}"
-echo -e "${YELLOW}Bitcoin node PID: $BITCOIN_PID${NC}"
-echo -e "${YELLOW}Coordinator PID: $COORDINATOR_PID${NC}"
-echo -e "${YELLOW}Bitcoin datadir: $BITCOIN_DATADIR${NC}"
-echo -e "${YELLOW}Wasabi datadir: $WASABI_DATADIR${NC}"
+print_success "All coinjoins initiated"
 
+# Display runtime information
+print_header "Runtime Information"
+print_info "Coordinator PID: $COORDINATOR_PID"
+print_info "Wallet Daemon PID: $WALLET_PID"
+print_info "Bitcoin Datadir: $BITCOIN_DATADIR"
+print_info "Wasabi Datadir: $WASABI_DATADIR"
 
-# Keep script running
-echo -e "${GREEN}Setup complete. Press Ctrl+C to stop all services.${NC}"
-TEST_TIMEOUT=600
+# Wait for coinjoin completion
+print_header "Monitoring CoinJoin Progress"
 
-timeout $TEST_TIMEOUT tail -f "$WASABI_COORDINATOR_LOGFILE" | grep -q "Successfully broadcast the coinjoin"
+print_step "Waiting for coordinator log file"
+for i in {1..10}; do
+    if [ -f "$WASABI_COORDINATOR_LOGFILE" ]; then
+        print_success "Log file found"
+        break
+    fi
+    printf "${YELLOW}.${NC}"
+    sleep 1
+done
+echo
 
-if [ $? -eq 0 ]; then
-  echo -e "${GREEN}WE HAVE A COINJOIN!!!!${NC}"
-else
-  echo "${RED}Timeout: No coinjoin after $TEST_TIMEOUT seconds"
-  exit 1
+if [ ! -f "$WASABI_COORDINATOR_LOGFILE" ]; then
+    print_error "Coordinator log file not found at $WASABI_COORDINATOR_LOGFILE"
+    exit 1
 fi
 
+print_step "Monitoring for successful coinjoin broadcast (timeout: ${TEST_TIMEOUT}s)"
+echo
+
+# Monitor with visual feedback
+if timeout $TEST_TIMEOUT grep -q "Successfully broadcast the coinjoin" <(tail -f "$WASABI_COORDINATOR_LOGFILE"); then
+    echo
+    print_header "SUCCESS!"
+    echo -e "${GREEN}${BOLD}  ✓ CoinJoin successfully broadcast!${NC}"
+    echo -e "${GREEN}${BOLD}  ✓ Test completed successfully${NC}"
+    print_header ""
+    exit 0
+else
+    echo
+    print_header "FAILURE"
+    print_error "Timeout: No coinjoin after $TEST_TIMEOUT seconds"
+    print_info "Check coordinator logs at: $WASABI_COORDINATOR_LOGFILE"
+    exit 1
+fi

--- a/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Daemon/Rpc/WasabiJsonRpcService.cs
@@ -118,7 +118,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("getwalletinfo")]
-	public JsonRpcResult WalletInfo()
+	public async Task<JsonRpcResult> WalletInfo()
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 
@@ -163,7 +163,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 			info["balance"] = activeWallet.Coins
 				.Where(c => !c.IsSpent())
 				.Sum(c => c.Amount.Satoshi);
-			info["coinjoinStatus"] = GetCoinjoinStatus(activeWallet);
+			info["coinjoinStatus"] = await GetCoinjoinStatusAsync(activeWallet).ConfigureAwait(false);
 		}
 
 		return info;
@@ -577,10 +577,10 @@ public class WasabiJsonRpcService : IJsonRpcService
 		return coinJoinManager;
 	}
 
-	private string GetCoinjoinStatus(Wallet wallet)
+	private async Task<string> GetCoinjoinStatusAsync(Wallet wallet)
 	{
 		var coinJoinManager = GetCoinJoinManager();
-		var walletCoinjoinClientState = coinJoinManager.GetCoinjoinClientState(wallet.WalletId);
+		var walletCoinjoinClientState = await coinJoinManager.GetCoinjoinClientStateAsync(wallet.WalletId, CancellationToken.None).ConfigureAwait(false);
 		return walletCoinjoinClientState switch
 		{
 			CoinJoinClientState.Idle => "Idle",

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -1,11 +1,9 @@
 using Microsoft.Extensions.Hosting;
 using NBitcoin;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
@@ -16,6 +14,7 @@ using WalletWasabi.Logging;
 using WalletWasabi.Services;
 using WalletWasabi.WabiSabi.Client.Banning;
 using WalletWasabi.WabiSabi.Client.CoinJoin.Client;
+using WalletWasabi.WabiSabi.Client.CoinJoin.Manager;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
@@ -55,22 +54,15 @@ public class CoinJoinManager : BackgroundService
 	private readonly CoinJoinConfiguration _coinJoinConfiguration;
 	private uint _serverTipHeight;
 
-	/// <summary>
-	/// The Dictionary is used for tracking the wallets that are blocked from CJs by UI.
-	/// The state holder has 3 boolean value, the first one indicates if the CJ needs to be restarted or not after leaving the blocking UI dialogs.
-	/// The other 2 is only needed not to loose the StopWhenAllMixed and OverridePlebStop configuration.
-	/// Right now, the Shutdown prevention and the Send workflow can block the CJs.
-	/// </summary>
-	private ConcurrentDictionary<WalletId, UiBlockedStateHolder> WalletsBlockedByUi { get; } = new();
-
 	public CoinJoinClientState HighestCoinJoinClientState => CoinJoinClientStates.Values.Any()
 		? CoinJoinClientStates.Values.Select(x => x.CoinJoinClientState).MaxBy(s => (int)s)
 		: CoinJoinClientState.Idle;
 
 	private ImmutableDictionary<WalletId, CoinJoinClientStateHolder> CoinJoinClientStates { get; set; } = ImmutableDictionary<WalletId, CoinJoinClientStateHolder>.Empty;
 
-	private readonly Channel<CoinJoinCommand> _commandChannel = Channel.CreateUnbounded<CoinJoinCommand>();
 	private readonly IDisposable _serverTipHeightChangeSubscription;
+
+	private MailboxProcessor<CoinJoinMessage>? _mailboxProcessor;
 
 	private static bool IsUnderPlebStop(SmartCoin[] coinCandidates, Money plebStopThreshold) => coinCandidates.Sum(x => x.Amount) < plebStopThreshold;
 
@@ -87,220 +79,711 @@ public class CoinJoinManager : BackgroundService
 			Logger.LogDebug("Do not override PlebStop anymore, confirmed balance no longer below the threshold.", wallet);
 		}
 
-		await _commandChannel.Writer.WriteAsync(new StartCoinJoinCommand(wallet, outputWallet, stopWhenAllMixed, overridePlebStop), cancellationToken).ConfigureAwait(false);
+		// Use MailboxProcessor instead of old channel
+		_mailboxProcessor?.Post(new StartCoinJoin(wallet, outputWallet, stopWhenAllMixed, overridePlebStop));
 	}
 
 	public async Task StopAsync(Wallet wallet, CancellationToken cancellationToken)
 	{
-		await _commandChannel.Writer.WriteAsync(new StopCoinJoinCommand(wallet), cancellationToken).ConfigureAwait(false);
+		// Use MailboxProcessor instead of old channel
+		_mailboxProcessor?.Post(new StopCoinJoin(wallet));
 	}
 
-	public CoinJoinClientState GetCoinjoinClientState(WalletId walletId)
+	public async Task<CoinJoinClientState> GetCoinjoinClientStateAsync(WalletId walletId, CancellationToken cancellationToken = default)
 	{
-		if (CoinJoinClientStates.TryGetValue(walletId, out var coinJoinClientStateHolder))
+		if (_mailboxProcessor is null)
 		{
-			return coinJoinClientStateHolder.CoinJoinClientState;
+			// Fallback to old logic during transition
+			if (CoinJoinClientStates.TryGetValue(walletId, out var coinJoinClientStateHolder))
+			{
+				return coinJoinClientStateHolder.CoinJoinClientState;
+			}
+			throw new ArgumentException($"Wallet {walletId} is not tracked.");
 		}
-		throw new ArgumentException($"Wallet {walletId} is not tracked.");
+
+		return await _mailboxProcessor.PostAndReplyAsync<CoinJoinClientState>(
+			replyChannel => new GetCoinJoinState(walletId, replyChannel),
+			cancellationToken).ConfigureAwait(false);
 	}
 
 	#endregion Public API (Start | Stop | TryGetWalletStatus)
 
 	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
 	{
-		// Detects and notifies about wallets that can participate in a coinjoin.
-		var walletsMonitoringTask = Task.Run(() => MonitorWalletsAsync(stoppingToken), stoppingToken);
+		// Start MailboxProcessor-based architecture
+		StartMailboxProcessor(stoppingToken);
 
-		// Coinjoin handling Start / Stop and finalization.
-		var monitorAndHandleCoinjoinsTask = MonitorAndHandleCoinJoinsAsync(stoppingToken);
+		// Start periodic timers - these will post messages to the mailbox
+		var walletMonitorTask = RunWalletMonitorTimerAsync(stoppingToken);
+		var finalizationTask = RunFinalizationTimerAsync(stoppingToken);
+		var restartCheckTask = RunRestartCheckTimerAsync(stoppingToken);
 
-		await Task.WhenAny(walletsMonitoringTask, monitorAndHandleCoinjoinsTask).ConfigureAwait(false);
-
-		await WaitAndHandleResultOfTasksAsync(nameof(walletsMonitoringTask), walletsMonitoringTask).ConfigureAwait(false);
-		await WaitAndHandleResultOfTasksAsync(nameof(monitorAndHandleCoinjoinsTask), monitorAndHandleCoinjoinsTask).ConfigureAwait(false);
+		// Wait for completion
+		await Task.WhenAll(walletMonitorTask, finalizationTask, restartCheckTask).ConfigureAwait(false);
 	}
 
-	private async Task MonitorWalletsAsync(CancellationToken stoppingToken)
+	#region New MailboxProcessor Architecture
+
+	private void StartMailboxProcessor(CancellationToken stoppingToken)
 	{
-		var trackedWallets = new Dictionary<WalletId, IWallet>();
-		while (!stoppingToken.IsCancellationRequested)
-		{
-			var mixableWallets = await GetMixableWalletsAsync().ConfigureAwait(false);
-
-			// Notifies when a wallet meets the criteria for participating in a coinjoin.
-			var openedWallets = mixableWallets.Where(x => !trackedWallets.ContainsKey(x.Key)).ToImmutableList();
-			foreach (var openedWallet in openedWallets.Select(x => x.Value))
+		_mailboxProcessor = new MailboxProcessor<CoinJoinMessage>(
+			async (mailbox, ct) =>
 			{
-				trackedWallets.Add(openedWallet.WalletId, openedWallet);
-				NotifyMixableWalletLoaded(openedWallet);
-			}
-
-			// Notifies when a wallet no longer meets the criteria for participating in a coinjoin.
-			var closedWallets = trackedWallets.Where(x => !mixableWallets.ContainsKey(x.Key)).ToImmutableList();
-			foreach (var closedWallet in closedWallets.Select(x => x.Value))
-			{
-				NotifyMixableWalletUnloaded(closedWallet);
-				trackedWallets.Remove(closedWallet.WalletId);
-			}
-			await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken).ConfigureAwait(false);
-		}
-	}
-
-	private async Task MonitorAndHandleCoinJoinsAsync(CancellationToken stoppingToken)
-	{
-		// This is a shared resource and that's why it is concurrent. Alternatives are locking structures,
-		// using a single lock around its access or use a channel.
-		var trackedCoinJoins = new ConcurrentDictionary<WalletId, CoinJoinTracker>();
-		var trackedAutoStarts = new ConcurrentDictionary<IWallet, TrackedAutoStart>();
-
-		var commandsHandlingTask = Task.Run(() => HandleCoinJoinCommandsAsync(trackedCoinJoins, trackedAutoStarts, stoppingToken), stoppingToken);
-		var monitorCoinJoinTask = Task.Run(() => MonitorAndHandlingCoinJoinFinalizationAsync(trackedCoinJoins, trackedAutoStarts, stoppingToken), stoppingToken);
-
-		await Task.WhenAny(commandsHandlingTask, monitorCoinJoinTask).ConfigureAwait(false);
-
-		await WaitAndHandleResultOfTasksAsync(nameof(commandsHandlingTask), commandsHandlingTask).ConfigureAwait(false);
-		await WaitAndHandleResultOfTasksAsync(nameof(monitorCoinJoinTask), monitorCoinJoinTask).ConfigureAwait(false);
-	}
-
-	private async Task HandleCoinJoinCommandsAsync(ConcurrentDictionary<WalletId, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
-	{
-		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(ArenaRequestHandlerFactory, _roundStatusProvider, _coinJoinConfiguration, stoppingToken);
-
-		async void StartCoinJoinCommand(StartCoinJoinCommand startCommand)
-		{
-			var walletToStart = startCommand.Wallet;
-
-			if (trackedCoinJoins.TryGetValue(walletToStart.WalletId, out var tracker))
-			{
-				if (startCommand.StopWhenAllMixed != tracker.StopWhenAllMixed)
+				var state = ManagerState.Empty;
+				while (!ct.IsCancellationRequested)
 				{
-					tracker.StopWhenAllMixed = startCommand.StopWhenAllMixed;
-					Logger.LogDebug(FormatLog($"Cannot start coinjoin, because it is already running - but updated the value of {nameof(startCommand.StopWhenAllMixed)} to {startCommand.StopWhenAllMixed}.", walletToStart));
-				}
-				else
-				{
-					Logger.LogDebug(FormatLog("Cannot start coinjoin, because it is already running.", walletToStart));
-				}
-
-				// On cancelling the shutdown prevention, we need to set it back to false, otherwise we won't continue CJing.
-				tracker.IsStopped = false;
-
-				return;
-			}
-
-			async Task<IEnumerable<SmartCoin>> SanityChecksAndGetCoinCandidatesFunc()
-			{
-				if (WalletsBlockedByUi.ContainsKey(walletToStart.WalletId))
-				{
-					throw new CoinJoinClientException(CoinjoinError.UserInSendWorkflow);
-				}
-
-				var coinSelectionResult = await SelectCandidateCoinsAsync(walletToStart).ConfigureAwait(false);
-				var coinCandidates = coinSelectionResult.CandidateCoins;
-
-				if (IsUnderPlebStop(coinCandidates, walletToStart.PlebStopThreshold) && !startCommand.OverridePlebStop)
-				{
-					Logger.LogTrace(FormatLog("PlebStop preventing coinjoin.", walletToStart));
-
-					if(!IsUnderPlebStop(coinCandidates.Union(coinSelectionResult.UnconfirmedCoins).ToArray(), walletToStart.PlebStopThreshold))
+					try
 					{
-						throw new CoinJoinClientException(CoinjoinError.NotEnoughConfirmedUnprivateBalance);
+						var msg = await mailbox.ReceiveAsync(ct).ConfigureAwait(false);
+						state = await HandleMessageAsync(msg, state, ct).ConfigureAwait(false);
+
+						// Update public properties from state
+							CoinJoinClientStates = state.CoinJoinClientStates;
+						CoinsInCriticalPhase = state.CoinsInCriticalPhase;
 					}
-
-					throw new CoinJoinClientException(CoinjoinError.NotEnoughUnprivateBalance);
-				}
-
-				// If there are pending payments, ignore already achieved privacy.
-				if (!walletToStart.BatchedPayments.AreTherePendingPayments)
-				{
-					// If all coins are already private, then don't mix.
-					if (await walletToStart.IsWalletPrivateAsync().ConfigureAwait(false))
+					catch (OperationCanceledException) when (ct.IsCancellationRequested)
 					{
-						Logger.LogTrace(FormatLog("All mixed!", walletToStart));
-						throw new CoinJoinClientException(CoinjoinError.AllCoinsPrivate);
+						// Normal cancellation
 					}
-
-					// If all coin candidates are private it makes no sense to mix.
-					if (coinCandidates.All(x => x.IsPrivate(walletToStart.AnonScoreTarget)))
+					catch (Exception ex)
 					{
-						throw new CoinJoinClientException(
-							CoinjoinError.NoCoinsEligibleToMix,
-							$"All coin candidates are already private and {nameof(startCommand.StopWhenAllMixed)} was {startCommand.StopWhenAllMixed}");
+						Logger.LogError($"Error handling CoinJoinMessage: {ex}");
 					}
 				}
+			},
+			stoppingToken);
 
-				NotifyWalletStartedCoinJoin(walletToStart);
+		_mailboxProcessor.Start();
 
-				return coinCandidates;
-			}
+		// Start periodic timers - these will post messages to the mailbox
+		_ = Task.Run(() => RunWalletMonitorTimerAsync(stoppingToken), stoppingToken);
+		_ = Task.Run(() => RunFinalizationTimerAsync(stoppingToken), stoppingToken);
+		_ = Task.Run(() => RunRestartCheckTimerAsync(stoppingToken), stoppingToken);
+	}
 
-			var coinJoinTracker = await coinJoinTrackerFactory.CreateAndStartAsync(walletToStart, startCommand.OutputWallet, SanityChecksAndGetCoinCandidatesFunc, startCommand.StopWhenAllMixed, startCommand.OverridePlebStop).ConfigureAwait(false);
-
-			if (!trackedCoinJoins.TryAdd(walletToStart.WalletId, coinJoinTracker))
+	private async Task RunWalletMonitorTimerAsync(CancellationToken ct)
+	{
+		try
+		{
+			using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+			while (!ct.IsCancellationRequested && await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
 			{
-				// This should never happen.
-				Logger.LogError(FormatLog($"{nameof(CoinJoinTracker)} was already added.", walletToStart));
-				coinJoinTracker.Stop();
-				coinJoinTracker.Dispose();
-				return;
+				_mailboxProcessor?.Post(new UpdateWalletStates());
+			}
+		}
+		catch (OperationCanceledException) when (ct.IsCancellationRequested)
+		{
+			// Normal cancellation
+		}
+	}
+
+	private async Task RunFinalizationTimerAsync(CancellationToken ct)
+	{
+		try
+		{
+			using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+			while (!ct.IsCancellationRequested && await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+			{
+				_mailboxProcessor?.Post(new CheckFinalization());
+			}
+		}
+		catch (OperationCanceledException) when (ct.IsCancellationRequested)
+		{
+			// Normal cancellation
+		}
+	}
+
+	private async Task RunRestartCheckTimerAsync(CancellationToken ct)
+	{
+		try
+		{
+			using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+			while (!ct.IsCancellationRequested && await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+			{
+				_mailboxProcessor?.Post(new CheckScheduledRestarts());
+			}
+		}
+		catch (OperationCanceledException) when (ct.IsCancellationRequested)
+		{
+			// Normal cancellation
+		}
+	}
+
+	private async Task<ManagerState> HandleMessageAsync(
+		CoinJoinMessage msg,
+		ManagerState state,
+		CancellationToken cancellationToken)
+	{
+		return msg switch
+		{
+			StartCoinJoin start => await HandleStartCoinJoinAsync(start, state, cancellationToken).ConfigureAwait(false),
+			StopCoinJoin stop => HandleStopCoinJoin(stop, state),
+			UpdateWalletStates => await HandleUpdateWalletStatesAsync(state).ConfigureAwait(false),
+			CheckFinalization => await HandleCheckFinalizationAsync(state, cancellationToken).ConfigureAwait(false),
+			CheckScheduledRestarts => HandleCheckScheduledRestarts(state),
+			WalletEnteredSendWorkflowMsg entered => HandleWalletEnteredSendWorkflow(entered, state),
+			WalletLeftSendWorkflowMsg left => HandleWalletLeftSendWorkflow(left, state),
+			WalletEnteredSendingMsg entering => await HandleWalletEnteredSendingAsync(entering, state).ConfigureAwait(false),
+			SignalStopAllCoinjoins => await HandleSignalStopAllCoinjoinsAsync(state, cancellationToken).ConfigureAwait(false),
+			RestartAbortedCoinjoins => HandleRestartAbortedCoinjoins(state),
+			GetCoinJoinState query => HandleGetCoinJoinStateQuery(query, state),
+			_ => state
+		};
+	}
+
+	private async Task<ManagerState> HandleStartCoinJoinAsync(StartCoinJoin msg, ManagerState state, CancellationToken ct)
+	{
+		var wallet = msg.Wallet;
+		var outputWallet = msg.OutputWallet;
+		var stopWhenAllMixed = msg.StopWhenAllMixed;
+		var overridePlebStop = msg.OverridePlebStop;
+
+		// Check if already running
+		if (state.TrackedCoinJoins.TryGetValue(wallet.WalletId, out var existingTracker))
+		{
+			if (stopWhenAllMixed != existingTracker.StopWhenAllMixed)
+			{
+				existingTracker.StopWhenAllMixed = stopWhenAllMixed;
+				Logger.LogDebug(FormatLog($"Cannot start coinjoin, because it is already running - but updated the value of {nameof(stopWhenAllMixed)} to {stopWhenAllMixed}.", wallet));
+			}
+			else
+			{
+				Logger.LogDebug(FormatLog("Cannot start coinjoin, because it is already running.", wallet));
 			}
 
-			coinJoinTracker.WalletCoinJoinProgressChanged += CoinJoinTracker_WalletCoinJoinProgressChanged;
-
-			var registrationTimeout = TimeSpan.MaxValue;
-			NotifyCoinJoinStarted(walletToStart, registrationTimeout);
-
-			Logger.LogDebug(FormatLog($"{nameof(CoinJoinClient)} started.", walletToStart));
-			Logger.LogDebug(FormatLog($"{nameof(startCommand.StopWhenAllMixed)}:'{startCommand.StopWhenAllMixed}' {nameof(startCommand.OverridePlebStop)}:'{startCommand.OverridePlebStop}'.", walletToStart));
-
-			// In case there was another start scheduled just remove it.
-			TryRemoveTrackedAutoStart(trackedAutoStarts, walletToStart);
+			// On cancelling the shutdown prevention, we need to set it back to false
+			existingTracker.IsStopped = false;
+			return state;
 		}
 
-		void StopCoinJoinCommand(StopCoinJoinCommand stopCommand)
+		// Sanity checks and coin selection
+		async Task<IEnumerable<SmartCoin>> SanityChecksAndGetCoinCandidatesFunc()
 		{
-			var walletToStop = stopCommand.Wallet;
-
-			var autoStartRemoved = TryRemoveTrackedAutoStart(trackedAutoStarts, walletToStop);
-
-			if (trackedCoinJoins.TryGetValue(walletToStop.WalletId, out var coinJoinTrackerToStop))
+			if (state.WalletsBlockedByUi.ContainsKey(wallet.WalletId))
 			{
-				coinJoinTrackerToStop.Stop();
-				if (coinJoinTrackerToStop.InCriticalCoinJoinState)
+				throw new CoinJoinClientException(CoinjoinError.UserInSendWorkflow);
+			}
+
+			var coinSelectionResult = await SelectCandidateCoinsAsync(wallet).ConfigureAwait(false);
+			var coinCandidates = coinSelectionResult.CandidateCoins;
+
+			if (IsUnderPlebStop(coinCandidates, wallet.PlebStopThreshold) && !overridePlebStop)
+			{
+				Logger.LogTrace(FormatLog("PlebStop preventing coinjoin.", wallet));
+
+				if (!IsUnderPlebStop(coinCandidates.Union(coinSelectionResult.UnconfirmedCoins).ToArray(), wallet.PlebStopThreshold))
 				{
-					Logger.LogWarning(FormatLog("Coinjoin is in critical phase, it cannot be stopped - it won't restart later.", walletToStop));
+					throw new CoinJoinClientException(CoinjoinError.NotEnoughConfirmedUnprivateBalance);
+				}
+
+				throw new CoinJoinClientException(CoinjoinError.NotEnoughUnprivateBalance);
+			}
+
+			// If there are pending payments, ignore already achieved privacy
+			if (!wallet.BatchedPayments.AreTherePendingPayments)
+			{
+				// If all coins are already private, then don't mix
+				if (await wallet.IsWalletPrivateAsync().ConfigureAwait(false))
+				{
+					Logger.LogTrace(FormatLog("All mixed!", wallet));
+					throw new CoinJoinClientException(CoinjoinError.AllCoinsPrivate);
+				}
+
+				// If all coin candidates are private it makes no sense to mix
+				if (coinCandidates.All(x => x.IsPrivate(wallet.AnonScoreTarget)))
+				{
+					throw new CoinJoinClientException(
+						CoinjoinError.NoCoinsEligibleToMix,
+						$"All coin candidates are already private and {nameof(stopWhenAllMixed)} was {stopWhenAllMixed}");
 				}
 			}
-			else if (autoStartRemoved)
-			{
-				NotifyWalletStoppedCoinJoin(walletToStop);
-			}
+
+			NotifyWalletStartedCoinJoin(wallet);
+
+			return coinCandidates;
 		}
 
-		while (!stoppingToken.IsCancellationRequested)
+		// Create tracker
+		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(ArenaRequestHandlerFactory, _roundStatusProvider, _coinJoinConfiguration, ct);
+		var coinJoinTracker = await coinJoinTrackerFactory.CreateAndStartAsync(
+			wallet,
+			outputWallet,
+			SanityChecksAndGetCoinCandidatesFunc,
+			stopWhenAllMixed,
+			overridePlebStop).ConfigureAwait(false);
+
+		// Subscribe to progress events
+		coinJoinTracker.WalletCoinJoinProgressChanged += CoinJoinTracker_WalletCoinJoinProgressChanged;
+
+		var registrationTimeout = TimeSpan.MaxValue;
+		NotifyCoinJoinStarted(wallet, registrationTimeout);
+
+		Logger.LogDebug(FormatLog($"{nameof(CoinJoinClient)} started.", wallet));
+		Logger.LogDebug(FormatLog($"{nameof(stopWhenAllMixed)}:'{stopWhenAllMixed}' {nameof(overridePlebStop)}:'{overridePlebStop}'.", wallet));
+
+		// Update state: add tracker, remove scheduled restart if exists
+		return state with
 		{
-			var command = await _commandChannel.Reader.ReadAsync(stoppingToken).ConfigureAwait(false);
-
-			switch (command)
-			{
-				case StartCoinJoinCommand startCommand:
-					StartCoinJoinCommand(startCommand);
-					break;
-
-				case StopCoinJoinCommand stopCommand:
-					StopCoinJoinCommand(stopCommand);
-					break;
-			}
-		}
-
-		foreach (var trackedAutoStart in trackedAutoStarts.Values)
-		{
-			trackedAutoStart.CancellationTokenSource.Cancel();
-			trackedAutoStart.CancellationTokenSource.Dispose();
-		}
-
-		await WaitAndHandleResultOfTasksAsync(nameof(trackedAutoStarts), trackedAutoStarts.Values.Select(x => x.Task).ToArray()).ConfigureAwait(false);
+			TrackedCoinJoins = state.TrackedCoinJoins.SetItem(wallet.WalletId, coinJoinTracker),
+			ScheduledRestarts = state.ScheduledRestarts.Remove(wallet.WalletId)
+		};
 	}
+
+	private ManagerState HandleStopCoinJoin(StopCoinJoin msg, ManagerState state)
+	{
+		var wallet = msg.Wallet;
+		var updatedScheduledRestarts = state.ScheduledRestarts;
+		var scheduledRestartRemoved = false;
+
+		// Remove scheduled restart if exists
+		if (state.ScheduledRestarts.ContainsKey(wallet.WalletId))
+		{
+			updatedScheduledRestarts = updatedScheduledRestarts.Remove(wallet.WalletId);
+			scheduledRestartRemoved = true;
+		}
+
+		// Stop active tracker if exists
+		if (state.TrackedCoinJoins.TryGetValue(wallet.WalletId, out var tracker))
+		{
+			tracker.Stop();
+			if (tracker.InCriticalCoinJoinState)
+			{
+				Logger.LogWarning(FormatLog("Coinjoin is in critical phase, it cannot be stopped - it won't restart later.", wallet));
+			}
+		}
+		else if (scheduledRestartRemoved)
+		{
+			// Only notify if we removed a scheduled restart but there was no active tracker
+			NotifyWalletStoppedCoinJoin(wallet);
+		}
+
+		return state with { ScheduledRestarts = updatedScheduledRestarts };
+	}
+
+	private async Task<ManagerState> HandleUpdateWalletStatesAsync(ManagerState state)
+	{
+		var mixableWallets = await GetMixableWalletsAsync().ConfigureAwait(false);
+
+		// Identify newly opened wallets (not in TrackedWallets)
+		var openedWallets = mixableWallets.Where(x => !state.TrackedWallets.ContainsKey(x.Key)).ToImmutableList();
+		foreach (var openedWallet in openedWallets.Select(x => x.Value))
+		{
+			NotifyMixableWalletLoaded(openedWallet);
+		}
+
+		// Identify newly closed wallets (in TrackedWallets but not mixable)
+		var closedWallets = state.TrackedWallets.Where(x => !mixableWallets.ContainsKey(x.Key)).ToImmutableList();
+		foreach (var closedWallet in closedWallets.Select(x => x.Value))
+		{
+			NotifyMixableWalletUnloaded(closedWallet);
+		}
+
+		// Update TrackedWallets immutably
+		return state with { TrackedWallets = mixableWallets };
+	}
+
+	private async Task<ManagerState> HandleCheckFinalizationAsync(ManagerState state, CancellationToken ct)
+	{
+		// Find completed coinjoins
+		var finishedCoinJoins = state.TrackedCoinJoins
+			.Where(x => x.Value.IsCompleted)
+			.Select(x => x.Value)
+			.ToImmutableArray();
+
+		var updatedTrackedCoinJoins = state.TrackedCoinJoins;
+		var updatedScheduledRestarts = state.ScheduledRestarts;
+
+		// Handle each finished coinjoin
+		foreach (var finishedCoinJoin in finishedCoinJoins)
+		{
+			var wallet = finishedCoinJoin.Wallet;
+			var shouldScheduleRestart = await HandleFinalizationLogicAsync(finishedCoinJoin, ct).ConfigureAwait(false);
+
+			// Remove from tracked coinjoins
+			updatedTrackedCoinJoins = updatedTrackedCoinJoins.Remove(wallet.WalletId);
+
+			// Schedule restart if needed
+			if (shouldScheduleRestart)
+			{
+				var scheduledFor = DateTimeOffset.UtcNow.AddSeconds(30);
+				var scheduledRestart = new ScheduledRestart(
+					wallet,
+					finishedCoinJoin.OutputWallet,
+					finishedCoinJoin.StopWhenAllMixed,
+					finishedCoinJoin.OverridePlebStop,
+					scheduledFor,
+					Guid.NewGuid());
+
+				updatedScheduledRestarts = updatedScheduledRestarts.SetItem(wallet.WalletId, scheduledRestart);
+			}
+
+			// Cleanup tracker
+			finishedCoinJoin.WalletCoinJoinProgressChanged -= CoinJoinTracker_WalletCoinJoinProgressChanged;
+			finishedCoinJoin.Dispose();
+		}
+
+		// Update CoinJoinClientStates and CoinsInCriticalPhase
+		var wallets = await _walletProvider.GetWalletsAsync().ConfigureAwait(false);
+		var updatedCoinJoinClientStates = BuildCoinJoinClientStates(wallets, updatedTrackedCoinJoins, updatedScheduledRestarts);
+		var updatedCoinsInCriticalPhase = BuildCoinsInCriticalPhase(wallets, updatedTrackedCoinJoins);
+
+		return state with
+		{
+			TrackedCoinJoins = updatedTrackedCoinJoins,
+			ScheduledRestarts = updatedScheduledRestarts,
+			CoinJoinClientStates = updatedCoinJoinClientStates,
+			CoinsInCriticalPhase = updatedCoinsInCriticalPhase
+		};
+	}
+
+	// Returns true if should schedule restart
+	private async Task<bool> HandleFinalizationLogicAsync(CoinJoinTracker finishedCoinJoin, CancellationToken ct)
+	{
+		var wallet = finishedCoinJoin.Wallet;
+		var destinationProvider = finishedCoinJoin.OutputWallet.OutputProvider.DestinationProvider;
+		var batchedPayments = wallet.BatchedPayments;
+		CoinJoinClientException? cjClientException = null;
+		var forceStop = false;
+
+		try
+		{
+			var result = await finishedCoinJoin.CoinJoinTask.ConfigureAwait(false);
+			if (result is SuccessfulCoinJoinResult successfulCoinjoin)
+			{
+				_coinRefrigerator.Freeze(successfulCoinjoin.Coins);
+				batchedPayments.MovePaymentsToFinished(successfulCoinjoin.UnsignedCoinJoin.GetHash());
+				MarkDestinationsUsed(destinationProvider, successfulCoinjoin.OutputScripts);
+				Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} finished. Coinjoin transaction was broadcast.", wallet));
+			}
+			else
+			{
+				Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} finished. Coinjoin transaction was not broadcast.", wallet));
+			}
+		}
+		catch (UnknownRoundEndingException ex)
+		{
+			_coinRefrigerator.Freeze(ex.Coins);
+			MarkDestinationsUsed(destinationProvider, ex.OutputScripts);
+			Logger.LogDebug(FormatLog(ex.ToString(), wallet));
+		}
+		catch (CoinJoinClientException clientException)
+		{
+			cjClientException = clientException;
+			if (cjClientException.CoinjoinError is CoinjoinError.CoordinatorLiedAboutInputs)
+			{
+				Logger.LogError(cjClientException);
+				forceStop = true;
+			}
+			else
+			{
+				Logger.LogDebug(cjClientException);
+			}
+		}
+		catch (InvalidOperationException ioe)
+		{
+			Logger.LogWarning(ioe);
+		}
+		catch (OperationCanceledException)
+		{
+			if (finishedCoinJoin.IsStopped)
+			{
+				Logger.LogInfo($"{nameof(CoinJoinClient)} stopped.", wallet);
+			}
+			else
+			{
+				Logger.LogInfo($"{nameof(CoinJoinClient)} was cancelled.", wallet);
+			}
+		}
+		catch (UnexpectedRoundPhaseException e)
+		{
+			Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} failed with exception: '{e}'", wallet));
+		}
+		catch (WabiSabiProtocolException wpe) when (wpe.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
+		{
+			Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} failed with: '{wpe.Message}'", wallet));
+		}
+		catch (Exception e)
+		{
+			Logger.LogError(FormatLog($"{nameof(CoinJoinClient)} failed with exception: '{e}'", wallet));
+		}
+		finally
+		{
+			batchedPayments.MovePaymentsToPending();
+		}
+
+		// Ban coins if needed
+		if (finishedCoinJoin.BannedCoins.Count != 0)
+		{
+			foreach (var info in finishedCoinJoin.BannedCoins)
+			{
+				_coinPrison.Ban(info.Coin, info.BanUntilUtc);
+			}
+		}
+
+		NotifyCoinJoinCompletion(finishedCoinJoin);
+
+		// Decide if should schedule restart
+		if (forceStop || finishedCoinJoin.IsStopped || ct.IsCancellationRequested)
+		{
+			NotifyWalletStoppedCoinJoin(wallet);
+			return false; // Don't restart
+		}
+		else if (await wallet.IsWalletPrivateAsync().ConfigureAwait(false))
+		{
+			NotifyCoinJoinStartError(wallet, CoinjoinError.AllCoinsPrivate);
+			if (!finishedCoinJoin.StopWhenAllMixed)
+			{
+				// In auto CJ mode we never stop trying
+				return true; // Schedule restart
+			}
+			else
+			{
+				// We finished with CJ permanently
+				NotifyWalletStoppedCoinJoin(wallet);
+				return false;
+			}
+		}
+		else if (cjClientException is not null)
+		{
+			// Keep trying, so CJ starts automatically when the wallet becomes mixable again
+			NotifyCoinJoinStartError(wallet, cjClientException.CoinjoinError);
+			return true; // Schedule restart
+		}
+		else
+		{
+			Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} restart automatically.", wallet));
+			return true; // Schedule restart
+		}
+	}
+
+	private ImmutableDictionary<WalletId, CoinJoinClientStateHolder> BuildCoinJoinClientStates(
+		IEnumerable<IWallet> wallets,
+		ImmutableDictionary<WalletId, CoinJoinTracker> trackedCoinJoins,
+		ImmutableDictionary<WalletId, ScheduledRestart> scheduledRestarts)
+	{
+		var coinJoinClientStates = ImmutableDictionary.CreateBuilder<WalletId, CoinJoinClientStateHolder>();
+
+		foreach (var wallet in wallets)
+		{
+			CoinJoinClientStateHolder state = new(CoinJoinClientState.Idle, StopWhenAllMixed: true, OverridePlebStop: false, OutputWallet: wallet);
+
+			if (trackedCoinJoins.TryGetValue(wallet.WalletId, out var coinJoinTracker) && !coinJoinTracker.IsCompleted)
+			{
+				var trackerState = coinJoinTracker.InCriticalCoinJoinState
+					? CoinJoinClientState.InCriticalPhase
+					: CoinJoinClientState.InProgress;
+
+				state = new(trackerState, coinJoinTracker.StopWhenAllMixed, coinJoinTracker.OverridePlebStop, coinJoinTracker.OutputWallet);
+			}
+			else if (scheduledRestarts.TryGetValue(wallet.WalletId, out var scheduledRestart))
+			{
+				state = new(CoinJoinClientState.InSchedule, scheduledRestart.StopWhenAllMixed, scheduledRestart.OverridePlebStop, scheduledRestart.OutputWallet);
+			}
+
+			coinJoinClientStates.Add(wallet.WalletId, state);
+		}
+
+		return coinJoinClientStates.ToImmutable();
+	}
+
+	private ImmutableDictionary<WalletId, ImmutableList<SmartCoin>> BuildCoinsInCriticalPhase(
+		IEnumerable<IWallet> wallets,
+		ImmutableDictionary<WalletId, CoinJoinTracker> trackedCoinJoins)
+	{
+		var coinsUsedInCoinjoins = ImmutableDictionary.CreateBuilder<WalletId, ImmutableList<SmartCoin>>();
+
+		foreach (var wallet in wallets)
+		{
+			ImmutableList<SmartCoin> coinsInCoinjoin = ImmutableList<SmartCoin>.Empty;
+
+			if (trackedCoinJoins.TryGetValue(wallet.WalletId, out var coinJoinTracker) && !coinJoinTracker.IsCompleted)
+			{
+				coinsInCoinjoin = coinJoinTracker.CoinsInCriticalPhase;
+			}
+
+			coinsUsedInCoinjoins.Add(wallet.WalletId, coinsInCoinjoin);
+		}
+
+		return coinsUsedInCoinjoins.ToImmutable();
+	}
+
+	private ManagerState HandleCheckScheduledRestarts(ManagerState state)
+	{
+		var now = DateTimeOffset.UtcNow;
+		var updatedScheduledRestarts = state.ScheduledRestarts;
+
+		foreach (var (walletId, scheduledRestart) in state.ScheduledRestarts)
+		{
+			if (now >= scheduledRestart.ScheduledFor)
+			{
+				// Time to restart - post the start message
+				_mailboxProcessor?.Post(new StartCoinJoin(
+					scheduledRestart.Wallet,
+					scheduledRestart.OutputWallet,
+					scheduledRestart.StopWhenAllMixed,
+					scheduledRestart.OverridePlebStop));
+
+				// Remove from scheduled restarts
+				updatedScheduledRestarts = updatedScheduledRestarts.Remove(walletId);
+			}
+		}
+
+		if (updatedScheduledRestarts != state.ScheduledRestarts)
+		{
+			return state with { ScheduledRestarts = updatedScheduledRestarts };
+		}
+
+		return state;
+	}
+
+
+	private ManagerState HandleWalletEnteredSendWorkflow(WalletEnteredSendWorkflowMsg msg, ManagerState state)
+	{
+		if (state.CoinJoinClientStates.TryGetValue(msg.WalletId, out var stateHolder))
+		{
+			var blockedState = new UiBlockedStateHolder(
+				NeedRestart: false,
+				stateHolder.StopWhenAllMixed,
+				stateHolder.OverridePlebStop,
+				stateHolder.OutputWallet);
+
+			return state with
+			{
+				WalletsBlockedByUi = state.WalletsBlockedByUi.SetItem(msg.WalletId, blockedState)
+			};
+		}
+		return state;
+	}
+
+	private ManagerState HandleWalletLeftSendWorkflow(WalletLeftSendWorkflowMsg msg, ManagerState state)
+	{
+		var wallet = msg.Wallet;
+
+		if (!state.WalletsBlockedByUi.TryGetValue(wallet.WalletId, out var stateHolder))
+		{
+			Logger.LogDebug(FormatLog("Wallet was not in send workflow but left it.", wallet));
+			return state;
+		}
+
+		if (stateHolder.NeedRestart)
+		{
+			// Post start message
+			_mailboxProcessor?.Post(new StartCoinJoin(
+				wallet,
+				stateHolder.OutputWallet,
+				stateHolder.StopWhenAllMixed,
+				stateHolder.OverridePlebStop));
+		}
+
+		return state with
+		{
+			WalletsBlockedByUi = state.WalletsBlockedByUi.Remove(wallet.WalletId)
+		};
+	}
+
+	private Task<ManagerState> HandleWalletEnteredSendingAsync(WalletEnteredSendingMsg msg, ManagerState state)
+	{
+		var wallet = msg.Wallet;
+
+		if (!state.WalletsBlockedByUi.ContainsKey(wallet.WalletId))
+		{
+			Logger.LogDebug(FormatLog("Wallet tried to enter sending but it was not in the send workflow.", wallet));
+			return Task.FromResult(state);
+		}
+
+		if (!state.CoinJoinClientStates.TryGetValue(wallet.WalletId, out var stateHolder))
+		{
+			Logger.LogDebug(FormatLog("Wallet tried to enter sending but state was missing.", wallet));
+			return Task.FromResult(state);
+		}
+
+		// Evaluate and set if we should restart after the send workflow
+		if (stateHolder.CoinJoinClientState is not CoinJoinClientState.Idle)
+		{
+			var updatedBlockedState = new UiBlockedStateHolder(
+				NeedRestart: true,
+				stateHolder.StopWhenAllMixed,
+				stateHolder.OverridePlebStop,
+				stateHolder.OutputWallet);
+
+			// Post stop message
+			_mailboxProcessor?.Post(new StopCoinJoin(wallet));
+
+			return Task.FromResult(state with
+			{
+				WalletsBlockedByUi = state.WalletsBlockedByUi.SetItem(wallet.WalletId, updatedBlockedState)
+			});
+		}
+
+		return Task.FromResult(state);
+	}
+
+	private async Task<ManagerState> HandleSignalStopAllCoinjoinsAsync(ManagerState state, CancellationToken ct)
+	{
+		var wallets = await _walletProvider.GetWalletsAsync().ConfigureAwait(false);
+		var updatedBlockedByUi = state.WalletsBlockedByUi;
+
+		foreach (var wallet in wallets)
+		{
+			if (state.CoinJoinClientStates.TryGetValue(wallet.WalletId, out var stateHolder) &&
+				stateHolder.CoinJoinClientState is not CoinJoinClientState.Idle)
+			{
+				var blockedState = new UiBlockedStateHolder(
+					true,
+					stateHolder.StopWhenAllMixed,
+					stateHolder.OverridePlebStop,
+					stateHolder.OutputWallet);
+
+				updatedBlockedByUi = updatedBlockedByUi.SetItem(wallet.WalletId, blockedState);
+
+				// Post stop message
+				_mailboxProcessor?.Post(new StopCoinJoin(wallet));
+			}
+		}
+
+		return state with { WalletsBlockedByUi = updatedBlockedByUi };
+	}
+
+	private ManagerState HandleRestartAbortedCoinjoins(ManagerState state)
+	{
+		var updatedBlockedByUi = state.WalletsBlockedByUi;
+
+		foreach (var (walletId, blockedState) in state.WalletsBlockedByUi)
+		{
+			if (blockedState.NeedRestart)
+			{
+				// Find the wallet
+				if (state.TrackedWallets.TryGetValue(walletId, out var wallet))
+				{
+					// Post start message
+					_mailboxProcessor?.Post(new StartCoinJoin(
+						wallet,
+						blockedState.OutputWallet,
+						blockedState.StopWhenAllMixed,
+						blockedState.OverridePlebStop));
+
+					updatedBlockedByUi = updatedBlockedByUi.Remove(walletId);
+				}
+			}
+		}
+
+		return state with { WalletsBlockedByUi = updatedBlockedByUi };
+	}
+
+	private ManagerState HandleGetCoinJoinStateQuery(GetCoinJoinState query, ManagerState state)
+	{
+		if (state.CoinJoinClientStates.TryGetValue(query.WalletId, out var stateHolder))
+		{
+			query.Reply.Reply(stateHolder.CoinJoinClientState);
+		}
+		else
+		{
+			query.Reply.Reply(CoinJoinClientState.Idle);
+		}
+		return state;
+	}
+
+	#endregion New MailboxProcessor Architecture
 
 private record CoinSelectionResult(SmartCoin[] CandidateCoins, SmartCoin[] BannedCoins, SmartCoin[] ImmatureCoins, SmartCoin[] UnconfirmedCoins, SmartCoin[] ExcludedCoins)
 {
@@ -384,283 +867,6 @@ private async Task<CoinSelectionResult> SelectCandidateCoinsAsync(IWallet wallet
 
 }
 
-	private bool TryRemoveTrackedAutoStart(ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, IWallet wallet)
-	{
-		if (trackedAutoStarts.TryRemove(wallet, out var trackedAutoStart))
-		{
-			trackedAutoStart.CancellationTokenSource.Cancel();
-			trackedAutoStart.CancellationTokenSource.Dispose();
-			return true;
-		}
-		return false;
-	}
-
-	private void ScheduleRestartAutomatically(IWallet walletToStart, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, bool stopWhenAllMixed, bool overridePlebStop, IWallet outputWallet, CancellationToken stoppingToken)
-	{
-		var skipDelay = false;
-		if (trackedAutoStarts.TryGetValue(walletToStart, out var trackedAutoStart))
-		{
-			if (stopWhenAllMixed == trackedAutoStart.StopWhenAllMixed && overridePlebStop == trackedAutoStart.OverridePlebStop && outputWallet.WalletId == trackedAutoStart.OutputWallet.WalletId)
-			{
-				Logger.LogDebug(FormatLog("AutoStart was already scheduled", walletToStart));
-				return;
-			}
-
-			Logger.LogDebug(FormatLog("AutoStart was already scheduled with different parameters, cancel the last task and do not wait.", walletToStart));
-			TryRemoveTrackedAutoStart(trackedAutoStarts, walletToStart);
-			skipDelay = true;
-		}
-
-		NotifyWalletStartedCoinJoin(walletToStart);
-
-#pragma warning disable CA2000 // Dispose objects before losing scope
-		var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
-#pragma warning restore CA2000 // Dispose objects before losing scope
-
-		var restartTask = new Task(
-			async () =>
-			{
-				try
-				{
-					if (!skipDelay)
-					{
-						await Task.Delay(TimeSpan.FromSeconds(30), linkedCts.Token).ConfigureAwait(false);
-					}
-				}
-				catch (OperationCanceledException)
-				{
-					return;
-				}
-				finally
-				{
-					linkedCts.Dispose();
-				}
-
-				if (trackedAutoStarts.TryRemove(walletToStart, out _))
-				{
-					await StartAsync(walletToStart, outputWallet, stopWhenAllMixed, overridePlebStop, stoppingToken).ConfigureAwait(false);
-				}
-				else
-				{
-					Logger.LogInfo(FormatLog("AutoStart was already handled.", walletToStart));
-				}
-			},
-			linkedCts.Token);
-
-		if (trackedAutoStarts.TryAdd(walletToStart, new TrackedAutoStart(restartTask, stopWhenAllMixed, overridePlebStop, outputWallet, linkedCts)))
-		{
-			restartTask.Start();
-		}
-		else
-		{
-			Logger.LogInfo(FormatLog("AutoCoinJoin task was already added.", walletToStart));
-		}
-	}
-
-	private async Task MonitorAndHandlingCoinJoinFinalizationAsync(ConcurrentDictionary<WalletId, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, CancellationToken stoppingToken)
-	{
-		while (!stoppingToken.IsCancellationRequested)
-		{
-			// Handles coinjoin finalization and notification.
-			var finishedCoinJoins = trackedCoinJoins.Where(x => x.Value.IsCompleted).Select(x => x.Value).ToImmutableArray();
-			foreach (var finishedCoinJoin in finishedCoinJoins)
-			{
-				await HandleCoinJoinFinalizationAsync(finishedCoinJoin, trackedCoinJoins, trackedAutoStarts, stoppingToken).ConfigureAwait(false);
-			}
-
-			// Updates coinjoin client states.
-			var wallets = await _walletProvider.GetWalletsAsync().ConfigureAwait(false);
-
-			CoinJoinClientStates = GetCoinJoinClientStates(wallets, trackedCoinJoins, trackedAutoStarts);
-			CoinsInCriticalPhase = GetCoinsInCriticalPhase(wallets, trackedCoinJoins);
-
-			await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken).ConfigureAwait(false);
-		}
-	}
-
-	private ImmutableDictionary<WalletId, ImmutableList<SmartCoin>> GetCoinsInCriticalPhase(IEnumerable<IWallet> wallets, ConcurrentDictionary<WalletId, CoinJoinTracker> trackedCoinJoins)
-	{
-		var coinsUsedInCoinjoins = ImmutableDictionary.CreateBuilder<WalletId, ImmutableList<SmartCoin>>();
-
-		foreach (var wallet in wallets)
-		{
-			ImmutableList<SmartCoin> coinsInCoinjoin = ImmutableList<SmartCoin>.Empty;
-
-			if (trackedCoinJoins.TryGetValue(wallet.WalletId, out var coinJoinTracker) && !coinJoinTracker.IsCompleted)
-			{
-				coinsInCoinjoin = coinJoinTracker.CoinsInCriticalPhase;
-			}
-
-			coinsUsedInCoinjoins.Add(wallet.WalletId, coinsInCoinjoin);
-		}
-
-		return coinsUsedInCoinjoins.ToImmutable();
-	}
-
-	private static ImmutableDictionary<WalletId, CoinJoinClientStateHolder> GetCoinJoinClientStates(IEnumerable<IWallet> wallets, ConcurrentDictionary<WalletId, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts)
-	{
-		var coinJoinClientStates = ImmutableDictionary.CreateBuilder<WalletId, CoinJoinClientStateHolder>();
-		foreach (var wallet in wallets)
-		{
-			CoinJoinClientStateHolder state = new(CoinJoinClientState.Idle, StopWhenAllMixed: true, OverridePlebStop: false, OutputWallet: wallet);
-
-			if (trackedCoinJoins.TryGetValue(wallet.WalletId, out var coinJoinTracker) && !coinJoinTracker.IsCompleted)
-			{
-				var trackerState = coinJoinTracker.InCriticalCoinJoinState
-					? CoinJoinClientState.InCriticalPhase
-					: CoinJoinClientState.InProgress;
-
-				state = new(trackerState, coinJoinTracker.StopWhenAllMixed, coinJoinTracker.OverridePlebStop, coinJoinTracker.OutputWallet);
-			}
-			else if (trackedAutoStarts.TryGetValue(wallet, out var autoStartTracker))
-			{
-				state = new(CoinJoinClientState.InSchedule, autoStartTracker.StopWhenAllMixed, autoStartTracker.OverridePlebStop, autoStartTracker.OutputWallet);
-			}
-
-			coinJoinClientStates.Add(wallet.WalletId, state);
-		}
-
-		return coinJoinClientStates.ToImmutable();
-	}
-
-	private async Task HandleCoinJoinFinalizationAsync(CoinJoinTracker finishedCoinJoin, ConcurrentDictionary<WalletId, CoinJoinTracker> trackedCoinJoins, ConcurrentDictionary<IWallet, TrackedAutoStart> trackedAutoStarts, CancellationToken cancellationToken)
-	{
-		var wallet = finishedCoinJoin.Wallet;
-		var destinationProvider = finishedCoinJoin.OutputWallet.OutputProvider.DestinationProvider;
-		var batchedPayments = wallet.BatchedPayments;
-		CoinJoinClientException? cjClientException = null;
-		var forceStop = false;
-		try
-		{
-			var result = await finishedCoinJoin.CoinJoinTask.ConfigureAwait(false);
-			if (result is SuccessfulCoinJoinResult successfulCoinjoin)
-			{
-				_coinRefrigerator.Freeze(successfulCoinjoin.Coins);
-				batchedPayments.MovePaymentsToFinished(successfulCoinjoin.UnsignedCoinJoin.GetHash());
-				MarkDestinationsUsed(destinationProvider, successfulCoinjoin.OutputScripts);
-				Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} finished. Coinjoin transaction was broadcast.", wallet));
-			}
-			else
-			{
-				Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} finished. Coinjoin transaction was not broadcast.", wallet));
-			}
-		}
-		catch (UnknownRoundEndingException ex)
-		{
-			// Assuming that the round might be broadcast but our client was not able to get the ending status.
-			_coinRefrigerator.Freeze(ex.Coins);
-			MarkDestinationsUsed(destinationProvider, ex.OutputScripts);
-			Logger.LogDebug(FormatLog(ex.ToString(), wallet));
-		}
-		catch (CoinJoinClientException clientException)
-		{
-			cjClientException = clientException;
-			if (cjClientException.CoinjoinError is CoinjoinError.CoordinatorLiedAboutInputs)
-			{
-				Logger.LogError(cjClientException);
-				forceStop = true;
-			}
-			else
-			{
-				Logger.LogDebug(cjClientException);
-			}
-		}
-		catch (InvalidOperationException ioe)
-		{
-			Logger.LogWarning(ioe);
-		}
-		catch (OperationCanceledException)
-		{
-			if (finishedCoinJoin.IsStopped)
-			{
-				Logger.LogInfo($"{nameof(CoinJoinClient)} stopped.", wallet);
-			}
-			else
-			{
-				Logger.LogInfo($"{nameof(CoinJoinClient)} was cancelled.", wallet);
-			}
-		}
-		catch (UnexpectedRoundPhaseException e)
-		{
-			// `UnexpectedRoundPhaseException` indicates an error in the protocol however,
-			// temporarily we are shortening the circuit by aborting the rounds if
-			// there are Alices that didn't confirm.
-			// The fix is already done but the clients have to upgrade.
-			Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} failed with exception: '{e}'", wallet));
-		}
-		catch (WabiSabiProtocolException wpe) when (wpe.ErrorCode == WabiSabiProtocolErrorCode.WrongPhase)
-		{
-			// This can happen when the coordinator aborts the round in Signing phase because of detected double spend.
-			Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} failed with: '{wpe.Message}'", wallet));
-		}
-		catch (Exception e)
-		{
-			Logger.LogError(FormatLog($"{nameof(CoinJoinClient)} failed with exception: '{e}'", wallet));
-		}
-		finally
-		{
-			batchedPayments.MovePaymentsToPending();
-		}
-
-		// If any coins were marked for banning, store them to file
-		if (finishedCoinJoin.BannedCoins.Count != 0)
-		{
-			foreach (var info in finishedCoinJoin.BannedCoins)
-			{
-				_coinPrison.Ban(info.Coin, info.BanUntilUtc);
-			}
-		}
-
-		NotifyCoinJoinCompletion(finishedCoinJoin);
-
-		// When to stop mixing:
-		// - If stop was requested by user.
-		// - If cancellation was requested.
-		if (forceStop
-			|| finishedCoinJoin.IsStopped
-			|| cancellationToken.IsCancellationRequested)
-		{
-			NotifyWalletStoppedCoinJoin(wallet);
-		}
-		else if (await wallet.IsWalletPrivateAsync().ConfigureAwait(false))
-		{
-			NotifyCoinJoinStartError(wallet, CoinjoinError.AllCoinsPrivate);
-			if (!finishedCoinJoin.StopWhenAllMixed)
-			{
-				// In auto CJ mode we never stop trying.
-				ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, finishedCoinJoin.OutputWallet, cancellationToken);
-			}
-			else
-			{
-				// We finished with CJ permanently.
-				NotifyWalletStoppedCoinJoin(wallet);
-			}
-		}
-		else if (cjClientException is not null)
-		{
-			// - If there was a CjClient exception, for example PlebStop or no coins to mix,
-			// Keep trying, so CJ starts automatically when the wallet becomes mixable again.
-			ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, finishedCoinJoin.OutputWallet, cancellationToken);
-			NotifyCoinJoinStartError(wallet, cjClientException.CoinjoinError);
-		}
-		else
-		{
-			Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} restart automatically.", wallet));
-
-			ScheduleRestartAutomatically(wallet, trackedAutoStarts, finishedCoinJoin.StopWhenAllMixed, finishedCoinJoin.OverridePlebStop, finishedCoinJoin.OutputWallet, cancellationToken);
-		}
-
-		if (!trackedCoinJoins.TryRemove(wallet.WalletId, out _))
-		{
-			Logger.LogWarning(FormatLog("Was not removed from tracked wallet list. Will retry in a few seconds.", wallet));
-		}
-		else
-		{
-			finishedCoinJoin.WalletCoinJoinProgressChanged -= CoinJoinTracker_WalletCoinJoinProgressChanged;
-			finishedCoinJoin.Dispose();
-		}
-	}
-
 	/// <summary>
 	/// Mark all the outputs we had in any of our wallets used.
 	/// </summary>
@@ -711,95 +917,30 @@ private async Task<CoinSelectionResult> SelectCandidateCoinsAsync(IWallet wallet
 			.Where(x => x.IsMixable)
 			.ToImmutableDictionary(x => x.WalletId, x => x);
 
-	private static async Task WaitAndHandleResultOfTasksAsync(string logPrefix, params Task[] tasks)
-	{
-		foreach (var task in tasks)
-		{
-			try
-			{
-				await task.ConfigureAwait(false);
-				Logger.LogInfo($"Task '{logPrefix}' finished successfully.");
-			}
-			catch (OperationCanceledException)
-			{
-				Logger.LogInfo($"Task '{logPrefix}' finished successfully by cancellation.");
-			}
-			catch (Exception ex)
-			{
-				Logger.LogInfo($"Task '{logPrefix}' finished but with an error: '{ex}'.");
-			}
-		}
-	}
 
 	public void WalletEnteredSendWorkflow(WalletId walletId)
 	{
-		if (CoinJoinClientStates.TryGetValue(walletId, out var stateHolder))
-		{
-			WalletsBlockedByUi.TryAdd(walletId, new UiBlockedStateHolder(NeedRestart: false, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop, stateHolder.OutputWallet));
-		}
+		_mailboxProcessor?.Post(new WalletEnteredSendWorkflowMsg(walletId));
 	}
 
 	public void WalletLeftSendWorkflow(Wallet wallet)
 	{
-		if (!WalletsBlockedByUi.TryRemove(wallet.WalletId, out var stateHolder))
-		{
-			Logger.LogDebug(FormatLog("Wallet was not in send workflow but left it.", wallet));
-			return;
-		}
-
-		if (stateHolder.NeedRestart)
-		{
-			Task.Run(async () => await StartAsync(wallet, stateHolder.OutputWallet, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop, CancellationToken.None).ConfigureAwait(false));
-		}
+		_mailboxProcessor?.Post(new WalletLeftSendWorkflowMsg(wallet));
 	}
 
 	public async Task WalletEnteredSendingAsync(Wallet wallet)
 	{
-		if (!WalletsBlockedByUi.ContainsKey(wallet.WalletId))
-		{
-			Logger.LogDebug(FormatLog("Wallet tried to enter sending but it was not in the send workflow.", wallet));
-			return;
-		}
-
-		if (!CoinJoinClientStates.TryGetValue(wallet.WalletId, out var stateHolder))
-		{
-			Logger.LogDebug(FormatLog("Wallet tried to enter sending but state was missing.", wallet));
-			return;
-		}
-
-		// Evaluate and set if we should restart after the send workflow.
-		if (stateHolder.CoinJoinClientState is not CoinJoinClientState.Idle)
-		{
-			WalletsBlockedByUi[wallet.WalletId] = new UiBlockedStateHolder(NeedRestart: true, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop, stateHolder.OutputWallet);
-		}
-
-		await StopAsync(wallet, CancellationToken.None).ConfigureAwait(false);
+		_mailboxProcessor?.Post(new WalletEnteredSendingMsg(wallet));
 	}
 
 	public async Task SignalToStopCoinjoinsAsync()
 	{
-		foreach (var wallet in await _walletProvider.GetWalletsAsync().ConfigureAwait(false))
-		{
-			if (CoinJoinClientStates.TryGetValue(wallet.WalletId, out var stateHolder) && stateHolder.CoinJoinClientState is not CoinJoinClientState.Idle)
-			{
-				if (!WalletsBlockedByUi.TryAdd(wallet.WalletId, new UiBlockedStateHolder(true, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop, stateHolder.OutputWallet)))
-				{
-					WalletsBlockedByUi[wallet.WalletId] = new UiBlockedStateHolder(true, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop, stateHolder.OutputWallet);
-				}
-				await StopAsync((Wallet)wallet, CancellationToken.None).ConfigureAwait(false);
-			}
-		}
+		_mailboxProcessor?.Post(new SignalStopAllCoinjoins());
 	}
 
 	public async Task RestartAbortedCoinjoinsAsync()
 	{
-		foreach (var wallet in await _walletProvider.GetWalletsAsync().ConfigureAwait(false))
-		{
-			if (WalletsBlockedByUi.TryRemove(wallet.WalletId, out var stateHolder) && stateHolder.NeedRestart)
-			{
-				await StartAsync(wallet, stateHolder.OutputWallet, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop, CancellationToken.None).ConfigureAwait(false);
-			}
-		}
+		_mailboxProcessor?.Post(new RestartAbortedCoinjoins());
 	}
 
 	private void CoinJoinTracker_WalletCoinJoinProgressChanged(object? sender, CoinJoinProgressEventArgs e)
@@ -814,15 +955,38 @@ private async Task<CoinSelectionResult> SelectCandidateCoinsAsync(IWallet wallet
 
 	public override void Dispose()
 	{
+		_mailboxProcessor?.Dispose();
 		_serverTipHeightChangeSubscription.Dispose();
 		base.Dispose();
 	}
 
-	private record CoinJoinCommand(IWallet Wallet);
-	private record StartCoinJoinCommand(IWallet Wallet, IWallet OutputWallet, bool StopWhenAllMixed, bool OverridePlebStop) : CoinJoinCommand(Wallet);
-	private record StopCoinJoinCommand(IWallet Wallet) : CoinJoinCommand(Wallet);
+	// MailboxProcessor state - consolidates all manager state into immutable structure
+	private record ManagerState(
+		ImmutableDictionary<WalletId, IWallet> TrackedWallets,
+		ImmutableDictionary<WalletId, CoinJoinTracker> TrackedCoinJoins,
+		ImmutableDictionary<WalletId, ScheduledRestart> ScheduledRestarts,
+		ImmutableDictionary<WalletId, UiBlockedStateHolder> WalletsBlockedByUi,
+		ImmutableDictionary<WalletId, CoinJoinClientStateHolder> CoinJoinClientStates,
+		ImmutableDictionary<WalletId, ImmutableList<SmartCoin>> CoinsInCriticalPhase)
+	{
+		public static ManagerState Empty => new(
+			ImmutableDictionary<WalletId, IWallet>.Empty,
+			ImmutableDictionary<WalletId, CoinJoinTracker>.Empty,
+			ImmutableDictionary<WalletId, ScheduledRestart>.Empty,
+			ImmutableDictionary<WalletId, UiBlockedStateHolder>.Empty,
+			ImmutableDictionary<WalletId, CoinJoinClientStateHolder>.Empty,
+			ImmutableDictionary<WalletId, ImmutableList<SmartCoin>>.Empty);
+	}
 
-	private record TrackedAutoStart(Task Task, bool StopWhenAllMixed, bool OverridePlebStop, IWallet OutputWallet, CancellationTokenSource CancellationTokenSource);
+	// Represents a scheduled restart in state (replaces TrackedAutoStart)
+	private record ScheduledRestart(
+		IWallet Wallet,
+		IWallet OutputWallet,
+		bool StopWhenAllMixed,
+		bool OverridePlebStop,
+		DateTimeOffset ScheduledFor,
+		Guid ScheduleId);
+
 	private record CoinJoinClientStateHolder(CoinJoinClientState CoinJoinClientState, bool StopWhenAllMixed, bool OverridePlebStop, IWallet OutputWallet);
 	private record UiBlockedStateHolder(bool NeedRestart, bool StopWhenAllMixed, bool OverridePlebStop, IWallet OutputWallet);
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManagerMessages.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManagerMessages.cs
@@ -1,0 +1,38 @@
+using System;
+using WalletWasabi.Services;
+using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.WabiSabi.Client.CoinJoin.Client;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.WabiSabi.Client.CoinJoin.Manager;
+
+// Base message type for all CoinJoinManager messages
+internal abstract record CoinJoinMessage;
+
+// Command messages (user-initiated)
+internal record StartCoinJoin(IWallet Wallet, IWallet OutputWallet, bool StopWhenAllMixed, bool OverridePlebStop) : CoinJoinMessage;
+internal record StopCoinJoin(IWallet Wallet) : CoinJoinMessage;
+
+// Event messages (system-initiated)
+internal record WalletBecameMixable(IWallet Wallet) : CoinJoinMessage;
+internal record WalletBecameUnmixable(IWallet Wallet) : CoinJoinMessage;
+internal record CoinJoinCompleted(WalletId WalletId) : CoinJoinMessage;
+
+// Periodic update messages (timer-driven)
+internal record UpdateWalletStates() : CoinJoinMessage;
+internal record CheckFinalization() : CoinJoinMessage;
+internal record CheckScheduledRestarts() : CoinJoinMessage;
+
+// UI workflow messages
+internal record WalletEnteredSendWorkflowMsg(WalletId WalletId) : CoinJoinMessage;
+internal record WalletLeftSendWorkflowMsg(IWallet Wallet) : CoinJoinMessage;
+internal record WalletEnteredSendingMsg(IWallet Wallet) : CoinJoinMessage;
+internal record SignalStopAllCoinjoins() : CoinJoinMessage;
+internal record RestartAbortedCoinjoins() : CoinJoinMessage;
+
+// Query messages (request-reply pattern)
+internal record GetCoinJoinState(WalletId WalletId, IReplyChannel<CoinJoinClientState> Reply) : CoinJoinMessage;
+
+// Delayed execution messages (auto-restart)
+internal record ScheduleRestart(IWallet Wallet, IWallet OutputWallet, bool StopWhenAllMixed, bool OverridePlebStop, DateTimeOffset ScheduledFor, Guid ScheduleId) : CoinJoinMessage;
+internal record CancelScheduledRestart(IWallet Wallet) : CoinJoinMessage;


### PR DESCRIPTION
Replace Channel-based command processing with MailboxProcessor pattern:
- Single message loop handles all operations via 13 message types
- Immutable state management using ImmutableDictionary
- Three PeriodicTimer tasks post messages (wallet monitor, finalization, restart check)
- Message-based delayed execution replaces Task.Delay background tasks
- Request-reply pattern for synchronous queries (GetCoinjoinClientStateAsync)

Changes:
- CoinJoinManager: Replace while-loop tasks with MailboxProcessor handler
- CoinJoinManagerMessages: Add 13 message record types for all operations
- WasabiJsonRpcService: Update to use async GetCoinjoinClientStateAsync

Removed old code:
- MonitorWalletsAsync, HandleCoinJoinCommandsAsync, MonitorAndHandlingCoinJoinFinalizationAsync
- ScheduleRestartAutomatically (Task.Delay-based)
- Channel-based command processing
- WaitAndHandleResultOfTasksAsync and unused handler methods

Benefits:
- Single serialized message loop (no race conditions)
- Immutable state with structural sharing (thread-safe)
- No detached background tasks or manual CancellationTokenSource management
- Easier to test and debug (pure message handlers)