### PR TITLE
Add single round coinjoin setting

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
@@ -22,6 +22,7 @@ public partial class WalletSettingsModel : ReactiveObject
 	[AutoNotify] private Money _plebStopThreshold;
 	[AutoNotify] private int _anonScoreTarget;
 	[AutoNotify] private bool _nonPrivateCoinIsolation;
+	[AutoNotify] private bool _singleRoundCoinjoin;
 	[AutoNotify] private WalletId? _outputWalletId;
 	[AutoNotify] private ScriptType _defaultReceiveScriptType;
 	[AutoNotify] private PreferredScriptPubKeyType _changeScriptPubKeyType;
@@ -40,6 +41,7 @@ public partial class WalletSettingsModel : ReactiveObject
 		_plebStopThreshold = _keyManager.PlebStopThreshold ?? KeyManager.DefaultPlebStopThreshold;
 		_anonScoreTarget = _keyManager.AnonScoreTarget;
 		_nonPrivateCoinIsolation = _keyManager.NonPrivateCoinIsolation;
+		_singleRoundCoinjoin = _keyManager.SingleRoundCoinjoin;
 
 		if (!isNewWallet)
 		{
@@ -57,7 +59,8 @@ public partial class WalletSettingsModel : ReactiveObject
 				x => x.PreferPsbtWorkflow,
 				x => x.PlebStopThreshold,
 				x => x.AnonScoreTarget,
-				x => x.NonPrivateCoinIsolation)
+				x => x.NonPrivateCoinIsolation,
+				x => x.SingleRoundCoinjoin)
 			.Skip(1)
 			.Do(_ => SetValues())
 			.Subscribe();
@@ -104,6 +107,7 @@ public partial class WalletSettingsModel : ReactiveObject
 		_keyManager.PlebStopThreshold = PlebStopThreshold;
 		_keyManager.AnonScoreTarget = AnonScoreTarget;
 		_keyManager.NonPrivateCoinIsolation = NonPrivateCoinIsolation;
+		_keyManager.SingleRoundCoinjoin = SingleRoundCoinjoin;
 		_keyManager.DefaultSendWorkflow = DefaultSendWorkflow;
 		_keyManager.DefaultReceiveScriptType = ScriptType.ToScriptPubKeyType(DefaultReceiveScriptType);
 		_keyManager.ChangeScriptPubKeyType = ChangeScriptPubKeyType;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletCoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletCoinJoinSettingsViewModel.cs
@@ -38,6 +38,7 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 	[AutoNotify] private bool _economicalProfileSelected;
 
 	[AutoNotify] private bool _autoCoinJoin;
+	[AutoNotify] private bool _singleRoundCoinjoin;
 	[AutoNotify] private string _plebStopThreshold;
 	[AutoNotify] private bool _isOutputWalletSelectionEnabled = true;
 	[AutoNotify] private IWalletModel _selectedOutputWallet;
@@ -50,9 +51,10 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 		UiContext = uiContext;
 		_wallet = walletModel;
 		_autoCoinJoin = _wallet.Settings.AutoCoinjoin;
+		_singleRoundCoinjoin = _wallet.Settings.SingleRoundCoinjoin;
 		_plebStopThreshold = _wallet.Settings.PlebStopThreshold.ToString();
 		_anonScoreTarget = _wallet.Settings.AnonScoreTarget.ToString();
-		_nonPrivateCoinIsolation = _wallet.Settings.NonPrivateCoinIsolation;
+		_nonPrivateCoinIsolation = _singleRoundCoinjoin ? false : _wallet.Settings.NonPrivateCoinIsolation;
 
 		_selectedOutputWallet = UiContext.WalletRepository.Wallets.Items.First(x => x.Id == _wallet.Settings.OutputWalletId);
 
@@ -72,6 +74,18 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 		{
 			_wallet.Settings.NonPrivateCoinIsolation = NonPrivateCoinIsolation;
 			_wallet.Settings.Save();
+			return Task.CompletedTask;
+		});
+
+		SetSingleRoundCoinjoinCommand = ReactiveCommand.CreateFromTask(() =>
+		{
+			_wallet.Settings.SingleRoundCoinjoin = SingleRoundCoinjoin;
+			_wallet.Settings.Save();
+
+			// Show non-private coin isolation as false when single-round is on,
+			// restore the persisted value when turned off.
+			NonPrivateCoinIsolation = SingleRoundCoinjoin ? false : _wallet.Settings.NonPrivateCoinIsolation;
+
 			return Task.CompletedTask;
 		});
 
@@ -128,6 +142,7 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 
 	public ICommand SetAutoCoinJoin { get; }
 	public ICommand SetNonPrivateCoinIsolationCommand { get; }
+	public ICommand SetSingleRoundCoinjoinCommand { get; }
 	public ICommand SelectMaximizePrivacySettings { get; }
 	public ICommand SelectDefaultSettings { get; }
 	public ICommand SelectEconomicalSettings { get; }

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
@@ -15,7 +15,8 @@
             Spacing="40"
             HorizontalAlignment="Center"
             Orientation="Horizontal"
-            Classes="settingsLayout">
+            Classes="settingsLayout"
+            IsEnabled="{Binding !SingleRoundCoinjoin}">
       <Button Theme="{StaticResource FunctionButton}"
               Height="37"
               Command="{Binding SelectMaximizePrivacySettings}"
@@ -48,12 +49,12 @@
       </Button>
     </StackPanel>
 
-    <DockPanel ToolTip.Tip="Each round can register at most one non-private coin.">
+    <DockPanel ToolTip.Tip="Each round can register at most one non-private coin." IsEnabled="{Binding !SingleRoundCoinjoin}">
       <TextBlock Text="Non-private coin isolation" />
       <ToggleSwitch IsChecked="{Binding NonPrivateCoinIsolation}" Command="{Binding SetNonPrivateCoinIsolationCommand}" />
     </DockPanel>
 
-    <DockPanel>
+    <DockPanel IsEnabled="{Binding !SingleRoundCoinjoin}">
       <TextBlock Text="Anonymity score target" ToolTip.Tip="Minimum anonymity score to consider a coin private." />
       <TextBox Classes="standalone" Name="AnonScoreTargetTextBox" Text="{Binding AnonScoreTarget}" DockPanel.Dock="Right" Watermark="Choose between 2 and 300." MaxLength="3" />
     </DockPanel>
@@ -63,6 +64,11 @@
     <DockPanel>
       <TextBlock Text="Automatically start coinjoin" />
       <ToggleSwitch IsChecked="{Binding AutoCoinJoin}" Command="{Binding SetAutoCoinJoin}" />
+    </DockPanel>
+
+    <DockPanel ToolTip.Tip="Participate in exactly one coinjoin transaction, then stop. Privacy settings are ignored.">
+      <TextBlock Text="Single round coinjoin" />
+      <ToggleSwitch IsChecked="{Binding SingleRoundCoinjoin}" Command="{Binding SetSingleRoundCoinjoinCommand}" />
     </DockPanel>
 
     <DockPanel>

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -32,6 +32,7 @@ public class KeyManager
 {
 	public const bool DefaultAutoCoinjoin = false;
 	public const bool DefaultRedCoinIsolation = false;
+	public const bool DefaultSingleRoundCoinjoin = false;
 
 	public const int AbsoluteMinGapLimit = 21;
 	public const int MaxGapLimit = 10_000;
@@ -197,6 +198,8 @@ public class KeyManager
 	public int AnonScoreTarget { get; set; } = PrivacyProfiles.DefaultProfile.AnonScoreTarget;
 
 	public bool NonPrivateCoinIsolation { get; set; } = PrivacyProfiles.DefaultProfile.NonPrivateCoinIsolation;
+
+	public bool SingleRoundCoinjoin { get; set; } = DefaultSingleRoundCoinjoin;
 
 	public ScriptPubKeyType DefaultReceiveScriptType { get; set; } = ScriptPubKeyType.Segwit;
 
@@ -782,6 +785,7 @@ public class KeyManager
 			("Icon", Encode.Optional(keyManager.Icon, Encode.String)),
 			("AnonScoreTarget", Encode.Int(keyManager.AnonScoreTarget)),
 			("RedCoinIsolation", Encode.Bool(keyManager.NonPrivateCoinIsolation)),
+			("SingleRoundCoinjoin", Encode.Bool(keyManager.SingleRoundCoinjoin)),
 			("DefaultReceiveScriptType", Encode.ScriptPubKeyType(keyManager.DefaultReceiveScriptType)),
 			("ChangeScriptPubKeyType", Encode.PreferredScriptPubKeyType(keyManager.ChangeScriptPubKeyType)),
 			("DefaultSendWorkflow", Encode.SendWorkflow(keyManager.DefaultSendWorkflow)),
@@ -820,6 +824,7 @@ public class KeyManager
 				Icon = get.Optional("Icon", Decode.String),
 				AnonScoreTarget = get.Optional("AnonScoreTarget", Decode.Int, 10),
 				NonPrivateCoinIsolation = get.Optional("RedCoinIsolation", Decode.Bool, false),
+				SingleRoundCoinjoin = get.Optional("SingleRoundCoinjoin", Decode.Bool, false),
 				DefaultReceiveScriptType = get.Optional("DefaultReceiveScriptType", Decode.ScriptPubKeyType, ScriptPubKeyType.Segwit),
 				ChangeScriptPubKeyType = get.Optional("ChangeScriptPubKeyType", Decode.PreferredScriptPubKeyType) ?? PreferredScriptPubKeyType.Unspecified.Instance,
 				DefaultSendWorkflow = get.Optional("DefaultSendWorkflow", Decode.SendWorkflow, SendWorkflow.Automatic),

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
@@ -44,7 +44,7 @@ public class CoinJoinCoinSelector
 		new(
 			wallet.ConsolidationMode,
 			wallet.AnonScoreTarget,
-			wallet.NonPrivateCoinIsolation ? Constants.SemiPrivateThreshold : 0);
+			wallet.SingleRoundCoinjoin ? 0 : (wallet.NonPrivateCoinIsolation ? Constants.SemiPrivateThreshold : 0));
 
 	/// <param name="liquidityClue">Weakly prefer not to select inputs over this.</param>
 	public ImmutableList<SmartCoin> SelectCoinsForRound(IEnumerable<SmartCoin> coins, UtxoSelectionParameters parameters, Money liquidityClue)

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -211,7 +211,8 @@ public class CoinJoinManager : BackgroundService
 				}
 
 				// If there are pending payments, ignore already achieved privacy.
-				if (!walletToStart.BatchedPayments.AreTherePendingPayments)
+				// If single round coinjoin is enabled, skip privacy checks entirely.
+				if (!walletToStart.BatchedPayments.AreTherePendingPayments && !walletToStart.SingleRoundCoinjoin)
 				{
 					// If all coins are already private, then don't mix.
 					if (await walletToStart.IsWalletPrivateAsync().ConfigureAwait(false))
@@ -530,6 +531,7 @@ private async Task<CoinSelectionResult> SelectCandidateCoinsAsync(IWallet wallet
 		var batchedPayments = wallet.BatchedPayments;
 		CoinJoinClientException? cjClientException = null;
 		var forceStop = false;
+		var wasSuccessfulBroadcast = false;
 		try
 		{
 			var result = await finishedCoinJoin.CoinJoinTask.ConfigureAwait(false);
@@ -538,6 +540,7 @@ private async Task<CoinSelectionResult> SelectCandidateCoinsAsync(IWallet wallet
 				_coinRefrigerator.Freeze(successfulCoinjoin.Coins);
 				batchedPayments.MovePaymentsToFinished(successfulCoinjoin.UnsignedCoinJoin.GetHash());
 				MarkDestinationsUsed(destinationProvider, successfulCoinjoin.OutputScripts);
+				wasSuccessfulBroadcast = true;
 				Logger.LogInfo(FormatLog($"{nameof(CoinJoinClient)} finished. Coinjoin transaction was broadcast.", wallet));
 			}
 			else
@@ -620,6 +623,11 @@ private async Task<CoinSelectionResult> SelectCandidateCoinsAsync(IWallet wallet
 			|| finishedCoinJoin.IsStopped
 			|| cancellationToken.IsCancellationRequested)
 		{
+			NotifyWalletStoppedCoinJoin(wallet);
+		}
+		else if (wasSuccessfulBroadcast && wallet.SingleRoundCoinjoin)
+		{
+			Logger.LogInfo(FormatLog("Single round coinjoin completed successfully. Stopping.", wallet));
 			NotifyWalletStoppedCoinJoin(wallet);
 		}
 		else if (await wallet.IsWalletPrivateAsync().ConfigureAwait(false))

--- a/WalletWasabi/Wallets/IWallet.cs
+++ b/WalletWasabi/Wallets/IWallet.cs
@@ -28,6 +28,7 @@ public interface IWallet
 	int AnonScoreTarget { get; }
 	bool ConsolidationMode { get; set; }
 	bool NonPrivateCoinIsolation { get; }
+	bool SingleRoundCoinjoin { get; }
 
 	Task<bool> IsWalletPrivateAsync();
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -81,6 +81,7 @@ public class Wallet : BackgroundService, IWallet
 	public CoinsRegistry Coins { get; }
 
 	public bool NonPrivateCoinIsolation => KeyManager.NonPrivateCoinIsolation;
+	public bool SingleRoundCoinjoin => KeyManager.SingleRoundCoinjoin;
 
 	public Network Network { get; }
 	public TransactionProcessor TransactionProcessor { get; }


### PR DESCRIPTION
Implements #8588

Adds a new wallet setting "Single round coinjoin" that allows users to participate in exactly one coinjoin transaction, then stop.

Currently, even manual mode keeps coinjoining until all coins reach the privacy target. There is no way to do a single coinjoin and stop. This feature enables manual time-staggered coinjoins -- the user triggers one coinjoin, waits, then manually triggers another when ready.

### Behavior

- New toggle in **Wallet Settings > Coinjoin**, off by default
- When enabled, the wallet participates in coinjoin rounds until one transaction is successfully broadcasted, then stops
- If a round fails (blame round, not enough participants, etc.), it keeps retrying until one succeeds
- Privacy profile buttons, anonymity score target, and non-private coin isolation are disabled in the UI (since they are irrelevant for a single round)
- Privacy sanity checks are skipped, allowing coinjoining even when all coins are already considered "private"
- Works with or without auto-start coinjoin enabled