### PR TITLE
TransactionBroadcaster: Fallback to other external broadcasters on failure

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -633,10 +633,9 @@ public class Global
 			new NetworkBroadcaster(mempoolService, nodesGroup),
 		};
 
-		foreach (var info in ExternalTransactionBroadcaster.GetSortedBroadcasters(Config.ExternalTransactionBroadcaster, Network))
-		{
-			result.Add(new ExternalTransactionBroadcaster(info, ExternalSourcesHttpClientFactory));
-		}
+		var external = ExternalTransactionBroadcaster.GetSortedBroadcasters(Config.ExternalTransactionBroadcaster, Network)
+			.Select(info => new ExternalTransactionBroadcaster(info, ExternalSourcesHttpClientFactory));
+		result.AddRange(external);
 
 		return result;
 	}

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -625,12 +625,21 @@ public class Global
 		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager.GetWalletsAsync, new RoundStateProvider(roundUpdater), wabiSabiHttpClientFactory, coinJoinConfiguration, _coinPrison, EventBus), "CoinJoin Manager");
 	}
 
-	private List<IBroadcaster> CreateBroadcasters(NodesGroup nodesGroup, MempoolService mempoolService) =>
-		[
+	private List<IBroadcaster> CreateBroadcasters(NodesGroup nodesGroup, MempoolService mempoolService)
+	{
+		var result = new List<IBroadcaster>()
+		{
 			new RpcBroadcaster(_bitcoinRpcClient),
 			new NetworkBroadcaster(mempoolService, nodesGroup),
-			new ExternalTransactionBroadcaster(Config.ExternalTransactionBroadcaster, Network, ExternalSourcesHttpClientFactory),
-		];
+		};
+
+		foreach (var info in ExternalTransactionBroadcaster.GetSortedBroadcasters(Config.ExternalTransactionBroadcaster, Network))
+		{
+			result.Add(new ExternalTransactionBroadcaster(info, ExternalSourcesHttpClientFactory));
+		}
+
+		return result;
+	}
 
 	public async Task DisposeAsync()
 	{

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -107,19 +107,15 @@ public class ExternalTransactionBroadcaster : IBroadcaster
 			_ => throw new NotSupportedException($"Network '{network}' is not supported."),
 		};
 
-		// The main provider will be the first one in the list, so it will be tried first.
-		var sortedProviders = providers
-			.OrderBy(p => p.Name.Equals(mainProviderName, StringComparison.InvariantCultureIgnoreCase) ? 0 : 1)
-			.ToArray();
-
-		// If the main provider is not present, the user wants to use a provider that is not supported.
-		if (sortedProviders.FirstOrDefault() is not ExternalBroadcasterInfo firstProvider
-			|| !firstProvider.Name.Equals(mainProviderName, StringComparison.InvariantCultureIgnoreCase))
+		if (!providers.Any(x => x.Name.Equals(mainProviderName, StringComparison.InvariantCultureIgnoreCase)))
 		{
 			throw new NotSupportedException($"Transaction broadcaster '{mainProviderName}' is not supported");
 		}
 
-		return sortedProviders;
+		// The main provider will be the first one in the list, so it will be tried first.
+		return providers
+			.OrderBy(p => p.Name.Equals(mainProviderName, StringComparison.InvariantCultureIgnoreCase) ? 0 : 1)
+			.ToArray();
 	}
 
 	public ExternalTransactionBroadcaster(ExternalBroadcasterInfo broadcaster, IHttpClientFactory httpClientFactory)

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -96,22 +96,35 @@ public class ExternalTransactionBroadcaster : IBroadcaster
 		new("MempoolSpace", ("https://mempool.space/signet", "http://mempoolhqx4isw62xs7abwphsq7ldayuidyx2v2oethdhhj6mlo2r6ad.onion/signet"), "/api/tx")
 	];
 
-	public ExternalTransactionBroadcaster(string providerName, Network network, IHttpClientFactory httpClientFactory)
+	/// <summary>Gets the sorted list of external transaction broadcasters with the preferred provider first.</summary>
+	public static ExternalBroadcasterInfo[] GetSortedBroadcasters(string mainProviderName, Network network)
 	{
-		if (network == Network.Main)
+		var providers = network switch
 		{
-			Broadcaster = Providers.FirstOrDefault(x => x.Name.Equals(providerName, StringComparison.InvariantCultureIgnoreCase))
-				?? throw new NotSupportedException($"Transaction broadcaster '{providerName}' is not supported");
-		}
-		else if (network == Bitcoin.Instance.Signet)
+			var n when n == Network.Main => Providers,
+			var n when n == Network.TestNet => TestNet4Providers,
+			var n when n == Bitcoin.Instance.Signet => SignetProviders,
+			_ => throw new NotSupportedException($"Network '{network}' is not supported."),
+		};
+
+		// The main provider will be the first one in the list, so it will be tried first.
+		var sortedProviders = providers
+			.OrderBy(p => p.Name.Equals(mainProviderName, StringComparison.InvariantCultureIgnoreCase) ? 0 : 1)
+			.ToArray();
+
+		// If the main provider is not present, the user wants to use a provider that is not supported.
+		if (sortedProviders.FirstOrDefault() is not ExternalBroadcasterInfo firstProvider
+			|| !firstProvider.Name.Equals(mainProviderName, StringComparison.InvariantCultureIgnoreCase))
 		{
-			Broadcaster = SignetProviders.First();
-		}
-		else
-		{
-			Broadcaster = TestNet4Providers.First();
+			throw new NotSupportedException($"Transaction broadcaster '{mainProviderName}' is not supported");
 		}
 
+		return sortedProviders;
+	}
+
+	public ExternalTransactionBroadcaster(ExternalBroadcasterInfo broadcaster, IHttpClientFactory httpClientFactory)
+	{
+		Broadcaster = broadcaster;
 		HttpClientFactory = httpClientFactory;
 		_userAgentGetter = UserAgent.GenerateUserAgentPicker(false);
 	}


### PR DESCRIPTION
Closes #14478
Contributes to #14471

The PR, as is right now, changes the meaning of `Config.ExternalTransactionBroadcaster` from "the external broadcaster to use" to "preferred external broadcaster to use first". It means that other external broadcasters defined in code (two at this point) can be used to send a transaction.

This has potential privacy downside of: _User selected `Config.ExternalTransactionBroadcaster` but other broadcasters can be used too._ That may or may not be what user wants. 

~I tend to think that an interesting alternative would be: Change `Config.ExternalTransactionBroadcasters` to an array and so one can specify all options:~

~1. No external broadcaster (for the greatest privacy)~
~2. Just one~
~3. Some broadcasters~
~4. All broadcasters~