### PR TITLE
Wallet: Show transactions even when regtest is on

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -725,9 +725,12 @@ public class Global
 			new NetworkBroadcaster(mempoolService, nodes),
 		};
 
-		var external = ExternalTransactionBroadcaster.GetSortedBroadcasters(Config.ExternalTransactionBroadcaster, Network)
-			.Select(info => new ExternalTransactionBroadcaster(info, ExternalSourcesHttpClientFactory));
-		result.AddRange(external);
+		if (Network != Network.RegTest)
+		{
+			var external = ExternalTransactionBroadcaster.GetSortedBroadcasters(Config.ExternalTransactionBroadcaster, Network)
+				.Select(info => new ExternalTransactionBroadcaster(info, ExternalSourcesHttpClientFactory));
+			result.AddRange(external);
+		}
 
 		return result;
 	}

--- a/WalletWasabi/Wallets/CpfpInfoProvider.cs
+++ b/WalletWasabi/Wallets/CpfpInfoProvider.cs
@@ -45,10 +45,15 @@ public static class CpfpInfoUpdater
 	{
 		return (msg, _, _) =>
 		{
-			// CPFP is not properly supported in RegTest yet.
-			if (msg is CpfpInfoMessage.GetCachedCpfpInfo m)
+			// CPFP is not properly supported in regtest yet.
+			switch (msg)
 			{
-				m.ReplyChannel.Reply([]);
+				case CpfpInfoMessage.GetCachedCpfpInfo m:					
+					m.ReplyChannel.Reply([]);
+					break;
+				case CpfpInfoMessage.GetInfoForTransaction m:
+					m.ReplyChannel.Reply(Result<CpfpInfo, string>.Fail("Not implemented for regtest."));
+					break;
 			}
 
 			return Task.FromResult(Unit.Instance);

--- a/WalletWasabi/Wallets/CpfpInfoProvider.cs
+++ b/WalletWasabi/Wallets/CpfpInfoProvider.cs
@@ -41,8 +41,19 @@ public static class CpfpInfoUpdater
 {
 	private delegate Task<Result<CpfpInfo,string>> CpfpInfoGetter(SmartTransaction stx);
 
-	public static MessageHandler<CpfpInfoMessage, Unit> CreateForRegTest() =>
-		(_, _, _) => Task.FromResult(Unit.Instance);
+	public static MessageHandler<CpfpInfoMessage, Unit> CreateForRegTest()
+	{
+		return (msg, _, _) =>
+		{
+			// CPFP is not properly supported in RegTest yet.
+			if (msg is CpfpInfoMessage.GetCachedCpfpInfo m)
+			{
+				m.ReplyChannel.Reply([]);
+			}
+
+			return Task.FromResult(Unit.Instance);
+		};
+	}
 
 	public static MessageHandler<CpfpInfoMessage, Unit> Create(
 		IHttpClientFactory httpClientFactory, Network network, EventBus eventBus)


### PR DESCRIPTION
I noticed that when one opens Wasabi configured to use the regtest network, then my transaction history is not not shown.

The reason is that `CpfpInfoProvider` is configured specially for regtest like this:

https://github.com/WalletWasabi/WalletWasabi/blob/04957b76cd576b68d869fd69fcc567ab9e1a4ffa/WalletWasabi.Client/Global.cs#L436

https://github.com/WalletWasabi/WalletWasabi/blob/04957b76cd576b68d869fd69fcc567ab9e1a4ffa/WalletWasabi/Wallets/CpfpInfoProvider.cs#L44-L45

However, the non-regtest `CpfpInfoProvider` works differently:

https://github.com/WalletWasabi/WalletWasabi/blob/04957b76cd576b68d869fd69fcc567ab9e1a4ffa/WalletWasabi/Wallets/CpfpInfoProvider.cs#L47-L93

The difference and the reason why no transactions are shown when regtest is on is this line:

https://github.com/WalletWasabi/WalletWasabi/blob/04957b76cd576b68d869fd69fcc567ab9e1a4ffa/WalletWasabi/Wallets/Wallet.cs#L159

which gets stuck (that's what makes it somewhat hard to figure out) with regtest on because 

https://github.com/WalletWasabi/WalletWasabi/blob/04957b76cd576b68d869fd69fcc567ab9e1a4ffa/WalletWasabi/Wallets/CpfpInfoProvider.cs#L44-L45

does not respond to messages. 

So the issue is clear. I need to research the code more to figure out how to properly fix it. Any advice is welcome though.