### PR TITLE
Fix RPC fee estimation falling through when node returns single fee-estimate

### DIFF
--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -118,11 +118,20 @@ public static class RPCClientExtensions
 		}
 
 		// EstimateSmartFeeAsync returns the block number where estimate was found - not always what the requested one.
-		return rpcFeeEstimationTasks
-			.Where(x => x.IsCompletedSuccessfully)
-			.Select(x => (target: x.Result.Blocks, feeRate: x.Result.FeeRate))
-			.DistinctBy(x => x.target)
-			.ToDictionary(x => x.target, x => x.feeRate);
+		var result = rpcFeeEstimationTasks
+		    .Where(x => x.IsCompletedSuccessfully)
+		    .Select(x => (target: x.Result.Blocks, feeRate: x.Result.FeeRate))
+		    .DistinctBy(x => x.target)
+		    .ToDictionary(x => x.target, x => x.feeRate);
+		
+		// If all confirmation targets collapsed to the same block number, the node lacks sufficient
+		// fee history to produce useful estimates. Throw so Composed falls through to the next provider.
+		if (result.Count < 2)
+		{
+		    throw new NoEstimationException(result.Keys.FirstOrDefault());
+		}
+		
+		return result;
 	}
 
 	private static FeeRateByConfirmationTarget GetFeeEstimationsFromMempoolInfo(MemPoolInfo mempoolInfo)

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -130,6 +130,8 @@ public static class RPCClientExtensions
 		{
 			return [];
 		}
+
+		return result;
 	}
 
 	private static FeeRateByConfirmationTarget GetFeeEstimationsFromMempoolInfo(MemPoolInfo mempoolInfo)

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -128,10 +128,8 @@ public static class RPCClientExtensions
 		// fee history to produce useful estimates. Do not return such an estimate to let a next provider do the job.
 		if (result.Count < 2)
 		{
-			return FeeRateEstimations.Empty;
+			return [];
 		}
-		
-		return result;
 	}
 
 	private static FeeRateByConfirmationTarget GetFeeEstimationsFromMempoolInfo(MemPoolInfo mempoolInfo)

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -125,7 +125,7 @@ public static class RPCClientExtensions
 		    .ToDictionary(x => x.target, x => x.feeRate);
 		
 		// If all confirmation targets collapsed to the same block number, the node lacks sufficient
-		// fee history to produce useful estimates. Throw so Composed falls through to the next provider.
+		// fee history to produce useful estimates. Do not return such an estimate to let a next provider do the job.
 		if (result.Count < 2)
 		{
 			return FeeRateEstimations.Empty;

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -128,7 +128,7 @@ public static class RPCClientExtensions
 		// fee history to produce useful estimates. Throw so Composed falls through to the next provider.
 		if (result.Count < 2)
 		{
-		    throw new NoEstimationException(result.Keys.FirstOrDefault());
+			return FeeRateEstimations.Empty;
 		}
 		
 		return result;


### PR DESCRIPTION

When a Bitcoin node has a thin mempool or insufficient fee history, estimatesmartfee returns Blocks=2 for every requested confirmation target. GetFeeEstimationsAsync keys results by the returned block number, so all 9 targets collapse to a single entry {2: X sat/vB} via DistinctBy.

This non-empty result was accepted by Composed as a success, so MempoolSpace and Blockstream fallbacks were never tried, causing the coordinator to always create rounds at the same floor fee rate regardless of actual mempool conditions.

Fix: after deduplication, throw NoEstimationException if fewer than 2 distinct block numbers were returned. This signals Composed to fall through to the next provider, which will supply a proper multi-point fee curve."