### PR TITLE
TransactionBroadcaster: Use `EventBus` to announce a new transaction.

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -106,7 +106,7 @@ public class Global
 		WalletManager = new WalletManager(Config.Network, walletDirectories, walletFactory);
 
 		var broadcasters = CreateBroadcasters(NodesGroup, mempoolService);
-		TransactionBroadcaster = new TransactionBroadcaster(broadcasters.ToArray(), mempoolService, WalletManager);
+		TransactionBroadcaster = new TransactionBroadcaster(EventBus, broadcasters.ToArray(), mempoolService);
 
 		Scheme = new Scheme(this);
 	}
@@ -132,7 +132,7 @@ public class Global
 	public Config Config { get; }
 	public WalletManager WalletManager { get; }
 	public NodesGroup NodesGroup { get; }
-	public TransactionBroadcaster TransactionBroadcaster { get; set; }
+	public TransactionBroadcaster TransactionBroadcaster { get; }
 	public HostedServices HostedServices { get; }
 	public Network Network => Config.Network;
 	public JsonRpcServer? RpcServer { get; private set; }

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -106,7 +106,7 @@ public class Global
 		WalletManager = new WalletManager(Config.Network, walletDirectories, walletFactory);
 
 		var broadcasters = CreateBroadcasters(NodesGroup, mempoolService);
-		TransactionBroadcaster = new TransactionBroadcaster(EventBus, broadcasters.ToArray(), mempoolService);
+		TransactionBroadcaster = new TransactionBroadcaster(broadcasters.ToArray(), mempoolService);
 
 		Scheme = new Scheme(this);
 	}

--- a/WalletWasabi/Blockchain/Mempool/MempoolService.cs
+++ b/WalletWasabi/Blockchain/Mempool/MempoolService.cs
@@ -23,6 +23,9 @@ public class MempoolService(EventBus eventBus)
 	/// <summary>Guards <see cref="_broadcastStore"/>.</summary>
 	private readonly Lock _broadcastStoreLock = new();
 
+	public void ReportSuccessfullyBroadcastedTransaction(SmartTransaction transaction) =>
+		eventBus.Publish(new NewTransactionInMempool(transaction));
+
 	public bool TryAddToBroadcastStore(SmartTransaction transaction)
 	{
 		lock (_broadcastStoreLock)
@@ -47,7 +50,7 @@ public class MempoolService(EventBus eventBus)
 		}
 	}
 
-	public LabelsArray TryGetLabel(uint256 txid)
+	private LabelsArray TryGetLabel(uint256 txid)
 	{
 		var label = LabelsArray.Empty;
 		if (TryGetFromBroadcastStore(txid, out var entry))

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -14,14 +14,12 @@ using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
-using WalletWasabi.Wallets;
 using WalletWasabi.WebClients.Wasabi;
 using System.Collections.Immutable;
 using System.Text;
 using WalletWasabi.BitcoinP2p;
 using WalletWasabi.WebClients;
 using System.Net.Mime;
-using WalletWasabi.Services;
 
 namespace WalletWasabi.Blockchain.TransactionBroadcasting;
 
@@ -265,7 +263,7 @@ public class NetworkBroadcaster(MempoolService mempoolService, NodesGroup nodes)
 	}
 }
 
-public class TransactionBroadcaster(EventBus eventBus, IBroadcaster[] broadcasters, MempoolService mempoolService)
+public class TransactionBroadcaster(IBroadcaster[] broadcasters, MempoolService mempoolService)
 {
 	public async Task SendTransactionAsync(SmartTransaction tx, CancellationToken cancellationToken = default)
 	{
@@ -345,7 +343,7 @@ public class TransactionBroadcaster(EventBus eventBus, IBroadcaster[] broadcaste
 		}
 
 		mempoolService.TryAddToBroadcastStore(transaction);
-		eventBus.Publish(new NewTransactionInMempool(transaction));
+		mempoolService.ReportSuccessfullyBroadcastedTransaction(transaction);
 	}
 }
 

--- a/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
+++ b/WalletWasabi/Blockchain/TransactionBroadcasting/TransactionBroadcaster.cs
@@ -21,6 +21,7 @@ using System.Text;
 using WalletWasabi.BitcoinP2p;
 using WalletWasabi.WebClients;
 using System.Net.Mime;
+using WalletWasabi.Services;
 
 namespace WalletWasabi.Blockchain.TransactionBroadcasting;
 
@@ -264,7 +265,7 @@ public class NetworkBroadcaster(MempoolService mempoolService, NodesGroup nodes)
 	}
 }
 
-public class TransactionBroadcaster(IBroadcaster[] broadcasters, MempoolService mempoolService, WalletManager walletManager)
+public class TransactionBroadcaster(EventBus eventBus, IBroadcaster[] broadcasters, MempoolService mempoolService)
 {
 	public async Task SendTransactionAsync(SmartTransaction tx, CancellationToken cancellationToken = default)
 	{
@@ -344,8 +345,7 @@ public class TransactionBroadcaster(IBroadcaster[] broadcasters, MempoolService 
 		}
 
 		mempoolService.TryAddToBroadcastStore(transaction);
-
-		walletManager.Process(transaction);
+		eventBus.Publish(new NewTransactionInMempool(transaction));
 	}
 }
 

--- a/WalletWasabi/Wallets/WalletManager.cs
+++ b/WalletWasabi/Wallets/WalletManager.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
@@ -285,17 +284,6 @@ public class WalletManager
 		}
 
 		_cancelAllTasks.Dispose();
-	}
-
-	public void Process(SmartTransaction transaction)
-	{
-		lock (_lock)
-		{
-			foreach (var wallet in _wallets.Where(x => x.Loaded))
-			{
-				wallet.TransactionProcessor.Process(transaction);
-			}
-		}
 	}
 
 	public void SetMaxBestHeight(uint bestHeight)


### PR DESCRIPTION
The goal is to remove `WalletManager` from `TransactionBroadcaster`. In my opinion, the two components should be less coupled. It appears that this PR would be a small step for #14568 to move forward.