### PR TITLE
JSON-RPC: Explicit null values

### DIFF
--- a/WalletWasabi.Tests/UnitTests/RpcTests.cs
+++ b/WalletWasabi.Tests/UnitTests/RpcTests.cs
@@ -162,7 +162,7 @@ public class RpcTests
 	{
 		var options = new JsonSerializerOptions()
 		{
-			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+			DefaultIgnoreCondition = JsonIgnoreCondition.Never,
 			Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
 		};
 

--- a/WalletWasabi.Tests/UnitTests/RpcTests.cs
+++ b/WalletWasabi.Tests/UnitTests/RpcTests.cs
@@ -1,10 +1,6 @@
-using NBitcoin;
-using System.Diagnostics;
-using System.Text.Encodings.Web;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using NBitcoin;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Client.Rpc;
 using WalletWasabi.Rpc;
@@ -14,72 +10,72 @@ namespace WalletWasabi.Tests.UnitTests;
 
 public class RpcTests
 {
-	public static TheoryData<string, string, string> RequestResponse
+	public static TheoryData<string, string> RequestResponse
 	{
 		get
 		{
-			var result = new TheoryData<string, string, string>
+			var result = new TheoryData<string, string>
 			{
 				{
-					"Invalid (broken) request", 
-					Request("1", "substract").Replace("\"id\":", "\"id\","),
-					Error(null!, -32700, "Parse error")
+					// Invalid (broken) request
+					"""{"jsonrpc":"2.0","method":"substract","params":[],"id","1"}""",
+					"""{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}"""
 				},
 				{
-					"Invalid (missing jsonrpc) request", 
-					Request("1", "substract", 42, 23).Replace("\"jsonrpc\":\"2.0\",", ""),
-					Ok("1", 19)
+					// Invalid request (missing jsonrpc)
+					"""{"method":"substract","params":[42,23],"id":"1"}""",
+					"""{"jsonrpc":"2.0","result":19,"id":"1"}"""
 				},
 				{
-					"Invalid (missing method) request", 
-					Request("1", "", "[42, 23]").Replace("\"method\":\"\",", ""),
-					Error(null!, -32700, "Parse error")
+					// Invalid request (missing method)
+					"""{"jsonrpc":"2.0","params":["[42, 23]"],"id":"1"}""",
+					"""{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}"""
 				},
 				{
-					"Invalid (wrong number of arguments) request", 
-					Request("3", "substract", new { subtrahend = 23 }),
-					Error("3", -32602, "A value for the 'minuend' is missing.")
+					// Invalid request (wrong number of arguments)
+					"""{"jsonrpc":"2.0","method":"substract","params":{"subtrahend":23},"id":"3"}""",
+					"""{"jsonrpc":"2.0","error":{"code":-32602,"message":"A value for the 'minuend' is missing."},"id":"3"}"""
 				},
 				{
-					"Invalid (wrong number of arguments) request", 
-					Request("3", "substract", 23),
-					Error("3", -32602, "2 parameters were expected but 1 were received.")
+					// Invalid request (wrong number of arguments)
+					"""{"jsonrpc":"2.0","method":"substract","params":[23],"id":"3"}""",
+					"""{"jsonrpc":"2.0","error":{"code":-32602,"message":"2 parameters were expected but 1 were received."},"id":"3"}"""
 				},
 				{
-					"Valid request with params by order", 
-					Request("1", "substract", 42, 23),
-					Ok("1", 19)
+					// Valid request with params by order
+					"""{"jsonrpc":"2.0","method":"substract","params":[42,23],"id":"1"}""",
+					"""{"jsonrpc":"2.0","result":19,"id":"1"}"""
 				},
 				{
-					"Valid request with params by name", 
-					Request("2", "substract", new { minuend = 42, subtrahend = 23 }),
-					Ok("2", 19)
+					// Valid request with params by name
+					"""{"jsonrpc":"2.0","method":"substract","params":{"minuend":42,"subtrahend":23},"id":"2"}""",
+					"""{"jsonrpc":"2.0","result":19,"id":"2"}"""
 				},
 				{
-					"Valid request (Notification)", 
-					Request(null!, "substract", 42, 23),
+					// Valid request (Notification)
+					"""{"jsonrpc":"2.0","method":"substract","params":[42,23],"id":null}""",
 					""
 				},
 				{
-					"Valid request for void procedure", 
-					Request("log-id-01", "writelog", "blah blah blah"),
-					Ok("log-id-01", null!)
+					// Valid request for void procedure
+					"""{"jsonrpc":"2.0","method":"writelog","params":["blah blah blah"],"id":"log-id-01"}""",
+					"""{"jsonrpc":"2.0","result":null,"id":"log-id-01"}"""
 				},
 				{
-					"Valid request for async procedure with cancellation token", 
-					Request("1", "format", "c:"),
-					Ok("1", null!)
+					// Valid request for async procedure with cancellation token
+					"""{"jsonrpc":"2.0","method":"format","params":["c:"],"id":"1"}""",
+					"""{"jsonrpc":"2.0","result":null,"id":"1"}"""
 				},
 				{
-					"Valid request but internal server error", 
-					Request("1", "fail", "c:"),
-					Error("1", -32603, "the error")
+					// Valid request but internal server error
+					"""{"jsonrpc":"2.0","method":"fail","params":["c:"],"id":"1"}""",
+					"""{"jsonrpc":"2.0","error":{"code":-32603,"message":"the error"},"id":"1"}"""
 				},
 				{
-					"Valid request to async method", 
-					Request("7", "substractasync", new { minuend = 42, subtrahend = 23 }),
-					Ok("7", 19)
-				}
+					// Valid request to async method
+					"""{"jsonrpc":"2.0","method":"substractasync","params":{"minuend":42,"subtrahend":23},"id":"7"}""",
+					"""{"jsonrpc":"2.0","result":19,"id":"7"}"""
+				},
 			};
 
 			return result;
@@ -88,21 +84,9 @@ public class RpcTests
 
 	[Theory]
 	[MemberData(nameof(RequestResponse))]
-	public async Task ParsingRequestTestsAsync(
-		string testName,
-		string request,
-		string expectedResponse)
+	public async Task ParsingRequestTestsAsync(string request, string expectedResponse)
 	{
 		var handler = new JsonRpcRequestHandler<TestableRpcService>(new TestableRpcService(), Network.Main);
-
-		Debug.WriteLine($$""""
-{
-	// {{testName}}
-	"""{{request}}""",
-	"""{{expectedResponse}}""",
-},
-
-"""");
 
 		var response = await handler.HandleAsync("", request, CancellationToken.None);
 		Assert.Equal(expectedResponse, response);
@@ -138,47 +122,5 @@ public class RpcTests
 		Assert.Throws<ArgumentException>(() => BuildTransaction(feeRate: 20, feeTarget: 8));
 		Assert.Throws<InvalidOperationException>(() => BuildTransaction(feeRate: 20));
 		Assert.Throws<InvalidOperationException>(() => BuildTransaction(feeTarget: 1008));
-	}
-
-	private static string Request(string id, string methodName, params object[] parameters)
-	{
-		return ToJson(new
-		{
-			jsonrpc = "2.0",
-			method = methodName,
-			@params = parameters.Length == 1 && (parameters[0].GetType().IsClass && parameters[0] is not string) ? parameters[0] : parameters,
-			id
-		});
-	}
-
-	private static string Ok(string id, object content)
-	{
-		return ToJson(new
-		{
-			jsonrpc = "2.0",
-			result = content,
-			id
-		});
-	}
-
-	private static string Error(string id, int code, string message)
-	{
-		return ToJson(new
-		{
-			jsonrpc = "2.0",
-			error = new { code, message },
-			id
-		});
-	}
-
-	private static string ToJson(object o)
-	{
-		var options = new JsonSerializerOptions()
-		{
-			DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-			Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-		};
-
-		return JsonSerializer.Serialize(o, options);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/RpcTests.cs
+++ b/WalletWasabi.Tests/UnitTests/RpcTests.cs
@@ -1,9 +1,10 @@
+using NBitcoin;
+using System.Diagnostics;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using NBitcoin;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Client.Rpc;
 using WalletWasabi.Rpc;
@@ -13,69 +14,69 @@ namespace WalletWasabi.Tests.UnitTests;
 
 public class RpcTests
 {
-	public static TheoryData<string, string> RequestResponse
+	public static TheoryData<string, string, string> RequestResponse
 	{
 		get
 		{
-			var result = new TheoryData<string, string>
+			var result = new TheoryData<string, string, string>
 			{
 				{
-					// Invalid (broken) request
+					"Invalid (broken) request", 
 					Request("1", "substract").Replace("\"id\":", "\"id\","),
 					Error(null!, -32700, "Parse error")
 				},
 				{
-					// Invalid (missing jsonrpc) request
+					"Invalid (missing jsonrpc) request", 
 					Request("1", "substract", 42, 23).Replace("\"jsonrpc\":\"2.0\",", ""),
 					Ok("1", 19)
 				},
 				{
-					// Invalid (missing method) request
+					"Invalid (missing method) request", 
 					Request("1", "", "[42, 23]").Replace("\"method\":\"\",", ""),
 					Error(null!, -32700, "Parse error")
 				},
 				{
-					// Invalid (wrong number of arguments) request
+					"Invalid (wrong number of arguments) request", 
 					Request("3", "substract", new { subtrahend = 23 }),
 					Error("3", -32602, "A value for the 'minuend' is missing.")
 				},
 				{
-					// Invalid (wrong number of arguments) request
+					"Invalid (wrong number of arguments) request", 
 					Request("3", "substract", 23),
 					Error("3", -32602, "2 parameters were expected but 1 were received.")
 				},
 				{
-					// Valid request with params by order
+					"Valid request with params by order", 
 					Request("1", "substract", 42, 23),
 					Ok("1", 19)
 				},
 				{
-					// Valid request with params by name
+					"Valid request with params by name", 
 					Request("2", "substract", new { minuend = 42, subtrahend = 23 }),
 					Ok("2", 19)
 				},
 				{
-					// Valid request (Notification)
+					"Valid request (Notification)", 
 					Request(null!, "substract", 42, 23),
 					""
 				},
 				{
-					// Valid request for void procedure
+					"Valid request for void procedure", 
 					Request("log-id-01", "writelog", "blah blah blah"),
 					Ok("log-id-01", null!)
 				},
 				{
-					// Valid request for async procedure with cancellation token
+					"Valid request for async procedure with cancellation token", 
 					Request("1", "format", "c:"),
 					Ok("1", null!)
 				},
 				{
-					// Valid request but internal server error
+					"Valid request but internal server error", 
 					Request("1", "fail", "c:"),
 					Error("1", -32603, "the error")
 				},
 				{
-					// Valid request to async method
+					"Valid request to async method", 
 					Request("7", "substractasync", new { minuend = 42, subtrahend = 23 }),
 					Ok("7", 19)
 				}
@@ -87,9 +88,21 @@ public class RpcTests
 
 	[Theory]
 	[MemberData(nameof(RequestResponse))]
-	public async Task ParsingRequestTestsAsync(string request, string expectedResponse)
+	public async Task ParsingRequestTestsAsync(
+		string testName,
+		string request,
+		string expectedResponse)
 	{
 		var handler = new JsonRpcRequestHandler<TestableRpcService>(new TestableRpcService(), Network.Main);
+
+		Debug.WriteLine($$""""
+{
+	// {{testName}}
+	"""{{request}}""",
+	"""{{expectedResponse}}""",
+},
+
+"""");
 
 		var response = await handler.HandleAsync("", request, CancellationToken.None);
 		Assert.Equal(expectedResponse, response);

--- a/WalletWasabi/Rpc/JsonRpcRequestHandler.cs
+++ b/WalletWasabi/Rpc/JsonRpcRequestHandler.cs
@@ -29,7 +29,7 @@ public class JsonRpcRequestHandler<TService>
 		_metadataProvider = new JsonRpcServiceMetadataProvider(service.GetType());
 		_defaultSettings = new()
     	{
-    		NullValueHandling = NullValueHandling.Ignore,
+    		NullValueHandling = NullValueHandling.Include,
     		ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
 
     		Converters = new List<JsonConverter>

--- a/WalletWasabi/Rpc/JsonRpcResponse.cs
+++ b/WalletWasabi/Rpc/JsonRpcResponse.cs
@@ -15,7 +15,7 @@ public abstract record JsonRpcResponse
 		[JsonRpcErrorCodes.InternalError] = "Internal error",
 	};
 
-	protected JsonRpcResponse(string id)
+	protected JsonRpcResponse(string? id)
 	{
 		Id = id;
 	}
@@ -24,12 +24,12 @@ public abstract record JsonRpcResponse
 	public string JsonRpc => "2.0";
 
 	[JsonProperty("id", Order = 3)]
-	public string Id { get; }
+	public string? Id { get; }
 
 	public static JsonRpcSuccessResponse CreateResultResponse(string id, object? result = null) =>
 		new(id, result);
 
-	public static JsonRpcErrorResponse CreateErrorResponse(string id, JsonRpcErrorCodes code, string? customMessage = null) =>
+	public static JsonRpcErrorResponse CreateErrorResponse(string? id, JsonRpcErrorCodes code, string? customMessage = null) =>
 		new(id, code, customMessage ?? GetDefaultMessageFor(code));
 
 	public string ToJson(JsonSerializerSettings serializerSettings) =>
@@ -55,7 +55,7 @@ public record JsonRpcSuccessResponse : JsonRpcResponse
 
 public record JsonRpcErrorResponse : JsonRpcResponse
 {
-	public JsonRpcErrorResponse(string id, JsonRpcErrorCodes code, string message)
+	public JsonRpcErrorResponse(string? id, JsonRpcErrorCodes code, string message)
 		: base(id)
 	{
 		Error = new ErrorObject(code, message);


### PR DESCRIPTION
5 -> 4 warnings

This PR also makes it so that JSON-RPC explicitly writes `"id": null` in JSON-RPC responses when a parsing error occurs. So it follows the [spec](https://www.jsonrpc.org/specification).