### PR TITLE
Add k_max limit check for silent payments specified in BIP 352

### DIFF
--- a/WalletWasabi/Wallets/SilentPayment/SilentPayment.cs
+++ b/WalletWasabi/Wallets/SilentPayment/SilentPayment.cs
@@ -16,6 +16,8 @@ public static class SilentPayment
 	private static readonly byte[] NUMS =
 		Encoders.Hex.DecodeData("50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0");
 
+	private const uint K_MAX = 2323;
+
 	public static ECPubKey ComputeSharedSecretReceiver(OutPoint[] prevOuts, GE[] pubKeys, ECPrivKey b) =>
 		ComputeSharedSecret(prevOuts, A: SumPublicKeys(pubKeys), b);
 
@@ -28,6 +30,11 @@ public static class SilentPayment
 	public static Dictionary<SilentPaymentAddress, ECXOnlyPubKey[]> GetPubKeys(IEnumerable<SilentPaymentAddress> recipients, Utxo[] utxos) =>
 		recipients
 			.GroupBy(x => x.ScanKey, (scanKey, addresses) => {
+				var addressCount = addresses.Count();
+				if (addressCount > K_MAX)
+				{
+					throw new ArgumentException($"Too many outputs for single scan key. Maximum is {K_MAX}, got {addressCount}", nameof(recipients));
+				}
 				var sharedSecret = ComputeSharedSecretSender(utxos, scanKey);
 				return addresses.Select((addr, k) => (
 					Address: addr,


### PR DESCRIPTION
## What is the goal of this PR?
With the recent changes in [BIP 352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki), a new parameter for a sanity check was introduced, the `k_max`. 
>If any of the groups exceed the limit of Kmax (=2323) silent payment addresses, fail.[[18](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki#cite_note-why_limit_k_18)]

Its objective is to limit the number of outputs generated by a single scan key (which corresponds to the number of grouped recipient addresses) a silent payments transaction can have in order to limit the computational cost on the scanning side and it does that by checking if the number of addresses for a single scan key does not exceed 2323.

### What did I change?
I added a `K_MAX` variable at the top of `SilentPayment.cs` that is set to 2323, and then added an `if` check to verify if the number of addresses is bigger than `K_MAX`, if so, it throws an error.