### PR TITLE
Support event subscriptions

### DIFF
--- a/WalletWasabi.Client/Bootstrap.cs
+++ b/WalletWasabi.Client/Bootstrap.cs
@@ -21,6 +21,8 @@ public class Scheme
 	private bool _initialized = false;
 	private JsonSerializerSettings _defaultJsonSerializerSettings;
 
+	public Action<string>? OnDisplay { get; set; }
+
 	public Scheme(Global global)
 	{
 		var scriptsDir = Path.Combine(global.DataDir, "scripts");
@@ -72,6 +74,10 @@ public class Scheme
 			return w;
 		});
 
+		RegisterNativeFunction<string, Closure>("on",
+			(eventName, func) => SubscribeEvent(global, eventName, func));
+		RegisterNativeAction<object>("display", o => OnDisplay?.Invoke(o?.ToString() ?? ""));
+
 		_defaultJsonSerializerSettings = CreateJsonSerializerSettings(global.Network);
 	}
 
@@ -86,6 +92,16 @@ public class Scheme
 		{
 			var param = ConvertSchemeToNative(args[0]);
 			return ConvertNativeToScheme(fn((T)param), 0);
+		}, 1));
+	}
+
+	private void RegisterNativeAction<T>(string name, Action<T> fn)
+	{
+		_env.Define(name, new Primitive(name, args =>
+		{
+			var param = ConvertSchemeToNative(args[0]);
+			fn((T)param);
+			return Unspecified.Instance;
 		}, 1));
 	}
 
@@ -123,6 +139,7 @@ public class Scheme
 	private object ConvertSchemeToNative(Value e) => ToNativeObject(e);
 
 	private readonly Dictionary<(Type, string), MemberInfo> _accessors = new();
+
 	private object GetterFn(string method, object instance)
 	{
 		var typ = instance.GetType();
@@ -150,6 +167,17 @@ public class Scheme
 			_ => throw new ArgumentOutOfRangeException()
 		};
 		return result!;
+	}
+
+	private object SubscribeEvent(Global global, string eventName, Closure func)
+	{
+		var eventType = Type.GetType($"WalletWasabi.Services.{eventName}, WalletWasabi", throwOnError: false);
+		if (eventType is null)
+		{
+			throw new ArgumentException($"event {eventName} does not exist");
+		}
+		global.EventBus.Subscribe(eventType, arg => Interpreter.Apply(func, [ConvertNativeToScheme(arg, 0)]));
+		return Unspecified.Instance;
 	}
 
 	public async Task<Value> ExecuteAsync(string prg)
@@ -217,13 +245,22 @@ public class Scheme
 			return obj is decimal d && Math.Truncate(d) == d ? (int)d : obj;
 		}
 
-		if (e.All(i => i is IEnumerable<object> ie && ie.Count() == 2 && ie.First() is string))
+		var arr = e.ToArray();
+		var dict = new Dictionary<string, object>(arr.Length);
+
+		foreach (var item in arr)
 		{
-			return e.ToDictionary(x => ((IEnumerable<object>) x).First(),
-				x => ToObject(((IEnumerable<object>) x).ElementAt(1)));
+			if (item is IEnumerable<object> pair && pair.ToArray() is [string key, var value])
+			{
+				dict[key] = ToObject(value);
+			}
+			else
+			{
+				return arr.Select(ToObject).ToArray();
+			}
 		}
 
-		return e.Select(ToObject);
+		return dict;
 	}
 
 	public string ToJson(Value e) =>
@@ -243,6 +280,7 @@ public class Scheme
 			Pair p => SExpr.Iterate(p).Select(ToNativeObject),
 			Nil _ => false,
 			Unspecified _ => "Done",
+			Closure c => c,
 			_ => throw new Exception($"Cannot convert {e.GetType().Name} to native object")
 		};
 }

--- a/WalletWasabi.Fluent/Styles/Themes/Base.axaml
+++ b/WalletWasabi.Fluent/Styles/Themes/Base.axaml
@@ -150,6 +150,7 @@
   <SolidColorBrush x:Key="ConsoleOutputCommandForegroundColor" Color="{StaticResource SystemAccentColor}" />
   <SolidColorBrush x:Key="ConsoleOutputResultForegroundColor">White</SolidColorBrush>
   <SolidColorBrush x:Key="ConsoleOutputErrorForegroundColor" Color="#DD4343" />
+  <SolidColorBrush x:Key="ConsoleInternalOutputResultForegroundColor" Color="SeaGreen" />
   <SolidColorBrush x:Key="ConsoleOutputSeparatorColor" Color="{StaticResource BorderColor}" />
 
 </ResourceDictionary>

--- a/WalletWasabi.Fluent/ViewModels/Scheme/SchemeConsoleViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Scheme/SchemeConsoleViewModel.cs
@@ -31,6 +31,7 @@ public partial class SchemeConsoleViewModel : RoutableViewModel
 	public SchemeConsoleViewModel(UiContext uiContext, Client.Scheme schemeInterpreter) : base(uiContext)
 	{
 		_schemeInterpreter = schemeInterpreter;
+		_schemeInterpreter.OnDisplay = Write;
 		_commandInput = string.Empty;
 		CommandHistory = new();
 		Output = new();
@@ -66,6 +67,8 @@ public partial class SchemeConsoleViewModel : RoutableViewModel
 			IsExecuting = false;
 		}
 	}
+
+	public void Write(string text) => Output.Add(new SchemeInternalOutputResult(text));
 
 	private async Task<string> RunCommandAsync(string command)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Scheme/SchemeOutput.cs
+++ b/WalletWasabi.Fluent/ViewModels/Scheme/SchemeOutput.cs
@@ -5,3 +5,4 @@ public abstract record SchemeOutput(string Text);
 public record SchemeOutputResult(string Text) : SchemeOutput(Text);
 public record SchemeOutputError(string Text) : SchemeOutput(Text);
 public record SchemeOutputCommand(string Text) : SchemeOutput(Text);
+public record SchemeInternalOutputResult(string Text) : SchemeOutput(Text);

--- a/WalletWasabi.Fluent/Views/Scheme/SchemeConsoleView.axaml
+++ b/WalletWasabi.Fluent/Views/Scheme/SchemeConsoleView.axaml
@@ -44,6 +44,11 @@
                     <Run Text="{Binding Text}" />
                   </TextBlock>
                 </DataTemplate>
+                <DataTemplate DataType="{x:Type console:SchemeInternalOutputResult}">
+                  <TextBlock Foreground="{DynamicResource ConsoleInternalOutputResultForegroundColor }" TextAlignment="Right" Margin="0 10 0 0">
+                    <Run Text="{Binding Text}" />
+                  </TextBlock>
+                </DataTemplate>
               </ItemsControl.DataTemplates>
               <Interaction.Behaviors>
                 <behaviors:ScrollToEndOnItemsChangedBehavior ScrollViewer="OutputScrollViewer" />

--- a/WalletWasabi/Services/EventBus.cs
+++ b/WalletWasabi/Services/EventBus.cs
@@ -21,20 +21,23 @@ public class EventBus
 	private readonly SubscriptionRegistry _subscriptions = new();
 	private readonly Lock _syncObj = new();
 
-	public IDisposable Subscribe<TEvent>(Action<TEvent> action) where TEvent : notnull
+	public IDisposable Subscribe(Type eventType, Action<object> action)
 	{
 		lock (_syncObj)
 		{
-			if (!_subscriptions.ContainsKey(typeof(TEvent)))
+			if (!_subscriptions.ContainsKey(eventType))
 			{
-				_subscriptions.Add(typeof(TEvent), []);
+				_subscriptions.Add(eventType, []);
 			}
 
-			var subscription = Subscription.Create(action, this);
-			_subscriptions[typeof(TEvent)].Add(subscription);
+			var subscription = Subscription.Create(eventType, action, this);
+			_subscriptions[eventType].Add(subscription);
 			return subscription;
 		}
 	}
+
+	public IDisposable Subscribe<TEvent>(Action<TEvent> action) where TEvent : notnull
+		=> Subscribe(typeof(TEvent), arg => action((TEvent)arg));
 
 	private void Unsubscribe(Subscription subscription)
 	{
@@ -83,6 +86,9 @@ public class EventBus
 		public Type Type { get; }
 		private readonly Action<object> _action;
 		private readonly EventBus _eventBus;
+
+		public static Subscription Create(Type eventType, Action<object> action, EventBus eventBus) =>
+			new(action, eventType, eventBus);
 
 		public static Subscription Create<TEvent>(Action<TEvent> action, EventBus eventBus) =>
 			new(o => action((TEvent)o), typeof(TEvent), eventBus);


### PR DESCRIPTION
Allow reacting to events in the Scheme scripting engine. For example, the following script allows us to see the hash of the transactions relay to us from the p2p network.

```scheme
(on 'NewTransactionInMempool (lambda (e) (display (transaction-hash (__get 'Transaction e)))))
```