### PR TITLE
NodeDiscoveryService: Copy NBitcoin's `VersionHandshake` method with properly awaited methods

### DIFF
--- a/WalletWasabi/Services/NodesManagement/NodeDiscoveryService.cs
+++ b/WalletWasabi/Services/NodesManagement/NodeDiscoveryService.cs
@@ -1,13 +1,14 @@
+using NBitcoin;
+using NBitcoin.Protocol;
+using NBitcoin.Protocol.Behaviors;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using NBitcoin;
-using NBitcoin.Protocol;
-using NBitcoin.Protocol.Behaviors;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using static WalletWasabi.Services.Workers;
@@ -184,7 +185,7 @@ public static class NodeDiscoveryCoordinator
 		try
 		{
 			node = await Node.ConnectAsync(network, endpoint, connParams).ConfigureAwait(false);
-			node.VersionHandshake(timeoutCts.Token);
+			await VersionHandshakeAsync(node, new NodeRequirement(), timeoutCts.Token).ConfigureAwait(false);
 
 			sw.Stop();
 
@@ -210,6 +211,86 @@ public static class NodeDiscoveryCoordinator
 			return null;
 		}
 		return node;
+	}
+
+	/// <summary>
+	/// Method copied from NBitcoin's to fix un-awaited async calls and to add cancellation support.
+	/// </summary>
+	/// <seealso href="https://github.com/MetacoSA/NBitcoin/blob/a5f5f8dd1962001bff4df633016de8e74d00b842/NBitcoin/Protocol/Node.cs#L1075-L1132"/>
+	private static async Task VersionHandshakeAsync(Node node, NodeRequirement requirements, CancellationToken cancellationToken)
+	{
+		if (node.State == NodeState.HandShaked)
+		{
+			throw new InvalidOperationException("Already handshaked");
+		}
+
+		using var listener = node.CreateListener()
+			.Where(p => p.Message.Payload is VersionPayload || p.Message.Payload is VerAckPayload);
+
+		await node.SendMessageAsync(node.MyVersion).ConfigureAwait(false);
+
+		var version = listener.ReceivePayload<VersionPayload>(cancellationToken);
+
+		// node._PeerVersion = version;
+		var peerVersionField = node.GetType().GetField("_PeerVersion", BindingFlags.NonPublic | BindingFlags.Instance);
+		ArgumentNullException.ThrowIfNull(peerVersionField);
+		peerVersionField.SetValue(node, version);
+
+		// node.SetVersion(Math.Min(node.MyVersion.Version, version.Version));
+		var versionToSet = Math.Min(node.MyVersion.Version, version.Version);
+		var setVersionMethod = node.GetType().GetMethod("SetVersion", BindingFlags.NonPublic | BindingFlags.Instance);
+		ArgumentNullException.ThrowIfNull(setVersionMethod);
+		setVersionMethod.Invoke(node, [versionToSet]);
+
+		var receiverAddress = version.AddressReceiver.GetStringAddress();
+		var addressFrom = node.MyVersion.AddressFrom.GetStringAddress();
+
+		if (receiverAddress != addressFrom)
+		{
+			Logger.LogWarning($"Different external address detected by the node {receiverAddress} instead of {addressFrom}");
+		}
+
+		if (node.ProtocolCapabilities.PeerTooOld)
+		{
+			Logger.LogWarning("Outdated version {version} disconnecting", version.Version);
+			node.Disconnect("Outdated version");
+			return;
+		}
+
+		if (!requirements.Check(version, node.ProtocolCapabilities))
+		{
+			node.Disconnect("The peer does not support the required services requirement");
+			return;
+		}
+
+		// As a courtesy we do not send sendaddr to nodes that do not support it.
+		if (node.ProtocolCapabilities.SupportAddrv2)
+		{
+			// Signal ADDRv2 support (BIP155).
+			await node.SendMessageAsync(new SendAddrV2Payload()).ConfigureAwait(false);
+		}
+
+		await node.SendMessageAsync(new VerAckPayload()).ConfigureAwait(false);
+
+		listener.ReceivePayload<VerAckPayload>(cancellationToken);
+
+		// node.State = NodeState.HandShaked;
+		var stateField = node.GetType().GetField("_State", BindingFlags.NonPublic | BindingFlags.Instance);
+		ArgumentNullException.ThrowIfNull(stateField);
+		stateField.SetValue(node, NodeState.HandShaked);
+
+		if (node.Advertize)
+		{
+			if (node.MyVersion.AddressFrom is IPEndPoint iPEndPoint && !iPEndPoint.Address.IsRoutable(true))
+			{
+				return;
+			}
+
+			await node.SendMessageAsync(new AddrPayload(new NetworkAddress(node.MyVersion.AddressFrom)
+			{
+				Time = DateTimeOffset.UtcNow
+			})).ConfigureAwait(false);
+		}
 	}
 
 	private static async Task HarvestAddressesAsync(Node node, TimeSpan harvestTimeout, CancellationToken cancellationToken)


### PR DESCRIPTION
Relevant comments:

* https://github.com/WalletWasabi/WalletWasabi/pull/14616#issuecomment-4544491308
* https://github.com/WalletWasabi/WalletWasabi/pull/14616#issuecomment-4550509254

tl;dr: NBitcoin implements `Node.VersionHandshake` here https://github.com/MetacoSA/NBitcoin/blob/a5f5f8dd1962001bff4df633016de8e74d00b842/NBitcoin/Protocol/Node.cs#L1075-L1132 but some calls are not awaited. Like this [one](https://github.com/MetacoSA/NBitcoin/blob/a5f5f8dd1962001bff4df633016de8e74d00b842/NBitcoin/Protocol/Node.cs#L1115). This ultimately leads to unobserved exceptions. This PR simply copies the `Node.VersionHandshake` to Wasabi code and fixes it (the ugly part is that it requires reflection).

Perhaps @NicolasDorier could share if he plans to do any modifications in this regard, or if he would accept a PR which would fix those few unawaited calls.

edit: Now I'm see more exceptions even with this PR. So I guess there are more unawaited calls somewhere. Sad.

## Test

Run Wasabi using `dotnet run --project WalletWasabi.Fluent.Desktop -- --loglevel=trace`


### Master

```
2026-06-04 15:54:00.754 [ 8] INF | Global.cs:622                  | TorManager is initialized.
2026-06-04 15:54:00.761 [ 8] DBG | WasabiHttpClientFactory.cs:64  | Create HTTP handler long-live-torproject
2026-06-04 15:54:00.766 [ 8] TRC | ProcessExtensions.cs:43        | Wait for the process to exit: '18576'
2026-06-04 15:54:00.871 [19] DBG | NodeDiscoveryService.cs:114    | Peer [::ffff:109.91.172.89]:8333 was punished for FailedToConnect. Score 57.0 -> 47.0.
2026-06-04 15:54:00.996 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.065 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.194 [ 2] DBG | FilterStore.cs:147             | Loaded 5000 lines from the mature index file.
2026-06-04 15:54:01.666 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.668 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.670 [20] INF | MailboxProcessor.cs:292        | Starting Wasabi Index-Based Synchronizer.
2026-06-04 15:54:01.670 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.675 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.677 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.691 [23] INF | MailboxProcessor.cs:292        | Starting WabiSabi Rounds Updater.
2026-06-04 15:54:01.704 [21] INF | HostedServices.cs:61           | Started Sleep Inhibitor.
2026-06-04 15:54:01.704 [ 9] INF | HostedServices.cs:61           | Started CoinJoin Manager.
2026-06-04 15:54:01.718 [ 9] TRC | Global.cs:570                  | Initialization finished.
2026-06-04 15:54:01.766 [10] TRC | NodeConnectionManager.cs:121   | Connecting to 6 peers (current: 0).
2026-06-04 15:54:01.840 [23] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:51.195.63.213]:8333 (score: 27.0, services: Blocks | Limited Network | Witness | P2P v2). Total connected peers: 1.
2026-06-04 15:54:01.841 [10] DBG | WasabiHttpClientFactory.cs:64  | Create HTTP handler MempoolSpace-exchange-rate-provider
2026-06-04 15:54:01.868 [20] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:109.91.172.89]:8333 (score: 51.0, services: Blocks | Compact Filters | Limited Network | Witness | P2P v2). Total connected peers: 2.
2026-06-04 15:54:01.914 [21] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:5.2.222.125]:8333 (score: 37.0, services: Blocks | Limited Network | Witness | P2P v2). Total connected peers: 3.
2026-06-04 15:54:01.914 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.920 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.927 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.931 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:01.932 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.053 [ 6] DBG | WasabiHttpClientFactory.cs:64  | Create HTTP handler MempoolSpace-bitcoin-fee-rate-provider
2026-06-04 15:54:02.054 [18] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:66.26.92.28]:8333 (score: 31.0, services: Blocks | Limited Network | Witness | P2P v2). Total connected peers: 4.
2026-06-04 15:54:02.172 [10] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:189.154.176.85]:8333 (score: 57.0, services: Blocks | Bloom Filters | Compact Filters | Limited Network | Witness | P2P v2). Total connected peers: 5.
2026-06-04 15:54:02.218 [ 9] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:174.85.102.67]:8333 (score: 27.0, services: Blocks | Limited Network | Witness | P2P v2 | 134217728). Total connected peers: 6.
2026-06-04 15:54:02.271 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.280 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.283 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.287 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.292 [ 9] DBG | NodeConnectionManager.cs:287   | Peer candidate [::ffff:173.32.219.110]:8333 (score: 27.0) is not significantly better than our worst peer (score: 27.0). Skipping rotation.
2026-06-04 15:54:02.471 [ 9] DBG | ExchangeRateProvider.cs:78     | {"time":1780602626,"USD":63645,"EUR":54903,"GBP":47513,"CAD":88550,"CHF":50263,"AUD":89243,"JPY":10194917}
2026-06-04 15:54:02.486 [ 9] INF | ExchangeRateProvider.cs:84     | Fetched exchange rate from MempoolSpace: 63645.
2026-06-04 15:54:02.516 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.640 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.700 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.762 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.765 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.818 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.820 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:02.949 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:03.043 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:03.044 [ 6] INF | FeeRateProviders.cs:105        | Fetched fee rate from MempoolSpace: 2.508 sat/vB.
2026-06-04 15:54:03.092 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:03.141 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:03.514 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:03.859 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:03.957 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:04.218 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:04.243 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:04.462 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:04.633 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:04.692 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:05.732 [ 9] INF | NodeConnectionManager.cs:273   | Replacing peer [::ffff:51.195.63.213]:8333 (score: 27.0) with [::ffff:37.191.18.168]:8333 (score: 69.0)
2026-06-04 15:54:05.827 [ 9] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:37.191.18.168]:8333 (score: 69.0, services: Blocks | Bloom Filters | Compact Filters | Limited Network | Witness | P2P v2). Total connected peers: 6.
2026-06-04 15:54:06.574 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:06.575 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:06.577 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:06.579 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:06.582 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:06.585 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:07.724 [ 6] TRC | NodeConnectionManager.cs:121   | Connecting to 3 peers (current: 6).
2026-06-04 15:54:07.791 [ 6] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:95.98.247.110]:8333 (score: 35.0, services: Blocks | Limited Network | Witness | P2P v2). Total connected peers: 7.
2026-06-04 15:54:07.956 [20] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:129.153.163.20]:8333 (score: 25.0, services: Blocks | Limited Network | Witness | P2P v2). Total connected peers: 8.
2026-06-04 15:54:08.042 [ 9] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:173.32.219.110]:8333 (score: 37.0, services: Blocks | Limited Network | Witness | P2P v2). Total connected peers: 9.
2026-06-04 15:54:10.100 [ 9] INF | MailboxProcessor.cs:294        | Stopped Node Endpoints Bootstrap.
2026-06-04 15:54:10.528 [43] DBG | NodeConnectionManager.cs:233   | Peer [::ffff:129.153.163.20]:8333 (score: 25.0) disconnected after 2.6s. Total connected peers: 8.
2026-06-04 15:54:10.722 [ 8] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:54:14.724 [16] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:54:18.726 [ 6] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:54:22.729 [ 8] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:54:26.679 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:26.680 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:26.681 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:26.682 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:54:26.684 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
```


### PR


```
2026-06-04 15:48:32.810 [20] TRC | NodeConnectionManager.cs:121   | Connecting to 1 peers (current: 0).
2026-06-04 15:48:33.015 [ 8] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:5.128.87.126]:8333 (score: 25.0, services: Blocks | Limited Network | Witness | P2P v2). Total connected peers: 1.
2026-06-04 15:48:33.111 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
2026-06-04 15:48:34.814 [18] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:48:34.953 [ 2] DBG | CoinListModel.cs:52            | Refresh signal emitted in Wallet
2026-06-04 15:48:39.804 [ 9] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:48:44.805 [ 9] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:48:49.800 [16] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:48:53.800 [24] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:48:58.802 [ 8] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:01.914 [25] WRN | NodeDiscoveryService.cs:250    | Different external address detected by the node ::ffff:193.142.203.78 instead of ::ffff:0:0
2026-06-04 15:49:02.811 [ 8] DBG | NodeConnectionManager.cs:287   | Peer candidate [::ffff:31.134.121.223]:8333 (score: 25.0) is not significantly better than our worst peer (score: 25.0). Skipping rotation.
2026-06-04 15:49:04.804 [16] TRC | NodeConnectionManager.cs:121   | Connecting to 1 peers (current: 1).
2026-06-04 15:49:04.917 [16] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:31.134.121.223]:8333 (score: 25.0, services: Blocks | Limited Network | Witness | P2P v2 | 134217728). Total connected peers: 2.
2026-06-04 15:49:07.808 [ 8] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:12.803 [18] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:16.808 [16] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:21.800 [16] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:25.807 [16] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:30.804 [18] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:31.917 [18] WRN | NodeDiscoveryService.cs:250    | Different external address detected by the node ::ffff:193.142.203.78 instead of ::ffff:0:0
2026-06-04 15:49:34.809 [31] INF | NodeConnectionManager.cs:273   | Replacing peer [::ffff:5.128.87.126]:8333 (score: 25.0) with [::ffff:46.59.13.35]:8333 (score: 55.0)
2026-06-04 15:49:34.912 [31] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:46.59.13.35]:8333 (score: 55.0, services: Blocks | Compact Filters | Limited Network | Witness | P2P v2). Total connected peers: 2.
2026-06-04 15:49:34.933 [24] WRN | NodeDiscoveryService.cs:250    | Different external address detected by the node ::ffff:193.142.203.78 instead of ::ffff:0:0
2026-06-04 15:49:35.307 [33] DBG | NodeConnectionManager.cs:233   | Peer [::ffff:46.59.13.35]:8333 (score: 55.0) disconnected after 0.4s. Total connected peers: 1.
2026-06-04 15:49:35.311 [33] DBG | NodeDiscoveryService.cs:115    | Peer [::ffff:46.59.13.35]:8333 was punished for DisconnectedQuickly. Score 55.0 -> 45.0.
2026-06-04 15:49:35.808 [18] TRC | NodeConnectionManager.cs:121   | Connecting to 1 peers (current: 1).
2026-06-04 15:49:35.858 [18] DBG | NodeConnectionManager.cs:190   | Connected to peer [::ffff:46.229.238.187]:8333 (score: 55.0, services: Blocks | Bloom Filters | Compact Filters | Limited Network | Witness | P2P v2). Total connected peers: 2.
2026-06-04 15:49:36.128 [40] DBG | NodeConnectionManager.cs:233   | Peer [::ffff:46.229.238.187]:8333 (score: 55.0) disconnected after 0.3s. Total connected peers: 1.
2026-06-04 15:49:36.129 [40] DBG | NodeDiscoveryService.cs:115    | Peer [::ffff:46.229.238.187]:8333 was punished for DisconnectedQuickly. Score 55.0 -> 45.0.
2026-06-04 15:49:39.807 [18] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:44.807 [24] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:49.806 [18] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:54.805 [16] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
2026-06-04 15:49:59.801 [16] TRC | NodeConnectionManager.cs:264   | There is no best peer candidate
```

(i.e. the number of unobserved exceptions is much lower)