### PR TITLE
Upgrade to NBitcoin 10.0.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <!-- Core libraries. -->
     <PackageVersion Include="WabiSabi" Version="1.0.1.2" />
-    <PackageVersion Include="NBitcoin" Version="10.0.4" />
+    <PackageVersion Include="NBitcoin" Version="10.0.6" />
     <!-- UI. -->
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />

--- a/WalletWasabi.Client/packages.lock.json
+++ b/WalletWasabi.Client/packages.lock.json
@@ -208,7 +208,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[10.0.4, )",
+          "NBitcoin": "[10.0.6, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -278,9 +278,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "xGcG/cUTZ6ucLKH1wuplWQjOhJiL7d123Ij+M2SVmB4Fx7eNG5Z5KSA9mup9WIsxtLhgBegvzP7LiEbZkdiq4Q==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Daemon/packages.lock.json
+++ b/WalletWasabi.Daemon/packages.lock.json
@@ -195,7 +195,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[10.0.4, )",
+          "NBitcoin": "[10.0.6, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -285,9 +285,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "xGcG/cUTZ6ucLKH1wuplWQjOhJiL7d123Ij+M2SVmB4Fx7eNG5Z5KSA9mup9WIsxtLhgBegvzP7LiEbZkdiq4Q==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -562,7 +562,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[10.0.4, )",
+          "NBitcoin": "[10.0.6, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -757,9 +757,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "xGcG/cUTZ6ucLKH1wuplWQjOhJiL7d123Ij+M2SVmB4Fx7eNG5Z5KSA9mup9WIsxtLhgBegvzP7LiEbZkdiq4Q==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -630,7 +630,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[10.0.4, )",
+          "NBitcoin": "[10.0.6, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -720,9 +720,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "xGcG/cUTZ6ucLKH1wuplWQjOhJiL7d123Ij+M2SVmB4Fx7eNG5Z5KSA9mup9WIsxtLhgBegvzP7LiEbZkdiq4Q==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -72,9 +72,9 @@
       },
       "NBitcoin": {
         "type": "Direct",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.6, )",
+        "resolved": "10.0.6",
+        "contentHash": "xGcG/cUTZ6ucLKH1wuplWQjOhJiL7d123Ij+M2SVmB4Fx7eNG5Z5KSA9mup9WIsxtLhgBegvzP7LiEbZkdiq4Q==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/deps.json
+++ b/deps.json
@@ -556,8 +556,8 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "10.0.4",
-    "hash": "sha256-BshBTbLcRE9jca9mIhLzLQ+Mix1R+6i4k0htq7pxSqk="
+    "version": "10.0.6",
+    "hash": "sha256-wnksdV6fMVTJwobgKIvT3NtuP6dIZ0yYn1KrhyO6oqs="
   },
   {
     "pname": "NBitcoin.Secp256k1",


### PR DESCRIPTION
#14651 was an attempt to fix NBitcoin code on Wasabi side. Then I opened https://github.com/MetacoSA/NBitcoin/pull/1304 and it was merged in NBitcoin 10.0.6. 

The motivation for this is the same as before, to decrease the number of unobserved exceptions like this one:

```
2026-06-04 15:54:00.996 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
```

when one starts Wasabi with `--loglevel=trace`. 

edit: The new NBitcoin version contains also @lontivero's: https://github.com/MetacoSA/NBitcoin/pull/1305