### PR TITLE
update log: index based -> P2P network based

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -442,7 +442,7 @@ public class Global
 			await resume().ConfigureAwait(false);
 		}
 
-		Spawn("Synchronizer", Service("Wasabi Index-Based Synchronizer", serviceLoop), cancellationToken)
+		Spawn("Synchronizer", Service("P2P network synchronizer", serviceLoop), cancellationToken)
 			.DisposeUsing(_disposables);
 
 		EventBus.Subscribe<RpcStatusChanged>(e =>


### PR DESCRIPTION
When connecting to RPC fails, it logs:
```
2026-06-09 10:03:19.208 [13] INF | MailboxProcessor.cs:300        | Starting Wasabi Index-Based Synchronizer.
```

which is incorrect now

PR:

```
2026-06-09 10:10:45.830 [45] INF | MailboxProcessor.cs:300        | Starting P2P network synchronizer.
```