### PR TITLE
Make RPC non mandatory

### DIFF
--- a/WalletWasabi.Client/Configuration/Config.cs
+++ b/WalletWasabi.Client/Configuration/Config.cs
@@ -266,7 +266,9 @@ public class Config
 
 	private static StringValue GetUriStringValue(string key, string value, string[] cliArgs)
 	{
-		value = value.StartsWith("http") ? value : $"http://{value}";
+		value = string.IsNullOrWhiteSpace(value)
+			? value
+			: value.StartsWith("http") ? value : $"http://{value}";
 		if (GetOverrideValue(key, cliArgs, out string? overrideValue, out ValueSource? valueSource))
 		{
 			overrideValue = overrideValue.StartsWith("http") ? overrideValue : $"http://{overrideValue}";

--- a/WalletWasabi.Client/Configuration/PersistentConfigManager.cs
+++ b/WalletWasabi.Client/Configuration/PersistentConfigManager.cs
@@ -17,7 +17,7 @@ public static class PersistentConfigManager
 		TerminateTorOnExit : false,
 		TorBridges : [],
 		DownloadNewVersion : true,
-		BitcoinRpcCredentialString : "wasabi:wasabi",
+		BitcoinRpcCredentialString : string.Empty,
 		BitcoinRpcUri : Constants.DefaultMainNetBitcoinRpcUri,
 		JsonRpcServerEnabled : false,
 		JsonRpcUser : string.Empty,

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -313,7 +313,7 @@ public class Global
 		{
 			internalRpcClient = new RPCClient(credentials, bitcoinRpcUri, Network);
 		}
-		catch (Exception)
+		catch (ArgumentException)
 		{
 			return null;
 		}
@@ -431,10 +431,14 @@ public class Global
 								+ "\nwait for it to create the filters, what can take some time."
 								+ "\n-----------------------------------------------------------------------------------------");
 			}
-			else
+			else if(!string.IsNullOrWhiteSpace(Config.BitcoinRpcUri))
 			{
 				Logger.LogWarning($"Was not able to connect to the Bitcoin RPC server '{Config.BitcoinRpcUri}' with the credentials provided. " +
 				                  "Please configure valid RPC credentials in settings and restart.");
+			}
+			else
+			{
+				Logger.LogInfo("No Bitcoin Node RPC was configured. Trying P2P synchronization.");
 			}
 
 			await resume().ConfigureAwait(false);

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -127,7 +127,7 @@ public class Global
 
 	private readonly NodeConnectionManager _nodeConnectionManager;
 	private TorManager? _torManager;
-	private readonly IRPCClient _bitcoinRpcClient;
+	private readonly IRPCClient? _bitcoinRpcClient;
 	private CoinPrison? _coinPrison;
 	private readonly ConcurrentChain _blockHeaders;
 	private readonly Timer _ticker;
@@ -161,11 +161,7 @@ public class Global
 		var fileSystemBlockProvider = BlockProviders.FileSystemBlockProvider(fileSystemBlockRepository);
 		var p2PBlockProvider = BlockProviders.P2pBlockProvider(p2PNodesManager, EventBus);
 
-		// Bitcoin RPC of the Wasabi server does not provide blocks.
-		var isWasabiRpcUri = Config.BitcoinRpcUri.StartsWith(Constants.DefaultMainNetBitcoinRpcUri, StringComparison.OrdinalIgnoreCase) ||
-			Config.BitcoinRpcUri.StartsWith(Constants.DefaultMainNetBitcoinRpcOnionUri, StringComparison.OrdinalIgnoreCase);
-
-		BlockProvider[] blockProviders = isWasabiRpcUri
+		BlockProvider[] blockProviders = _bitcoinRpcClient is null
 			? [fileSystemBlockProvider, p2PBlockProvider]
 			: [fileSystemBlockProvider, BlockProviders.RpcBlockProvider(_bitcoinRpcClient), p2PBlockProvider];
 
@@ -291,7 +287,7 @@ public class Global
 		_nodeConnectionManager.Start(cancellationToken);
 	}
 
-	private RpcClientBase ConfigureBitcoinRpcClient()
+	private RpcClientBase? ConfigureBitcoinRpcClient()
 	{
 		var credentialString = Config.BitcoinRpcCredentialString;
 		RPCCredentialString? credentials;
@@ -302,11 +298,12 @@ public class Global
 		}
 		else if (!RPCCredentialString.TryParse(credentialString, out credentials))
 		{
-			// In case the credential string is malformed, we replace it with a valid but extremely improbable one.
-			// That results in the creation of a rpc instance that will fail to connect. In that way the RpcMonitor
-			// can detect the problem an inform to the user.
-			var improbableString = Convert.ToHexString(RandomUtils.GetBytes(32));
-			credentials = RPCCredentialString.Parse($"{improbableString}:{improbableString}");
+			return null;
+		}
+
+		if (string.IsNullOrWhiteSpace(Config.BitcoinRpcUri))
+		{
+			return null;
 		}
 
 		var bitcoinRpcUri = Config.BitcoinRpcUri;
@@ -316,14 +313,9 @@ public class Global
 		{
 			internalRpcClient = new RPCClient(credentials, bitcoinRpcUri, Network);
 		}
-		catch (ArgumentException)
+		catch (Exception)
 		{
-			// The network has no default cookie file path registered (e.g. testnet4).
-			// Create a non-functional RPC client so the app can start and the user can
-			// configure credentials through the UI. RpcMonitor will report the problem.
-			var improbableString = Convert.ToHexString(RandomUtils.GetBytes(32));
-			credentials = RPCCredentialString.Parse($"{improbableString}:{improbableString}");
-			internalRpcClient = new RPCClient(credentials, bitcoinRpcUri, Network);
+			return null;
 		}
 
 		// If the RPC URI is not a loopback (i.e., not localhost), then route through Tor
@@ -356,8 +348,9 @@ public class Global
 			var providerName => throw new ArgumentException( $"Not supported fee rate estimations provider '{providerName}'. Default: '{Constants.DefaultFeeRateEstimationProvider}'")
 		};
 
-		var rpcFeeProvider = FeeRateProviders.RpcAsync(_bitcoinRpcClient);
-		feeRateProvider = FeeRateProviders.Composed([rpcFeeProvider, feeRateProvider]);
+		feeRateProvider = _bitcoinRpcClient is not null
+			? FeeRateProviders.Composed([FeeRateProviders.RpcAsync(_bitcoinRpcClient), feeRateProvider])
+			: feeRateProvider;
 		var feeRateUpdater = Spawn("FeeRateUpdater",
 			Service("Mining Fee Rate Updater",
 				Periodically(
@@ -371,6 +364,10 @@ public class Global
 
 	private void ConfigureRpcMonitor(CancellationToken cancellationToken)
 	{
+		if (_bitcoinRpcClient is null)
+		{
+			return;
+		}
 		var rpcMonitor = Spawn(RpcMonitor.ServiceName,
 			Service("Bitcoin Rpc Interface Monitoring",
 				Periodically(
@@ -384,9 +381,13 @@ public class Global
 
 	private async Task ConfigureSynchronizerAsync(CancellationToken cancellationToken)
 	{
-		var supportsBlockFiltersResult = await _bitcoinRpcClient.SupportsBlockFiltersAsync(cancellationToken).ConfigureAwait(false);
+		var supportsBlockFiltersResult = await (_bitcoinRpcClient is { } rpcClient
+				? rpcClient.SupportsBlockFiltersAsync(cancellationToken)
+				: Task.FromResult(Result<bool>.Fail(false)))
+			.ConfigureAwait(false);
+
 		var filtersProvider = supportsBlockFiltersResult
-			.Map(_ => FilterProviders.CreateBitcoinRpcFilterProvider(_bitcoinRpcClient, _blockHeaders))
+			.Map(_ => FilterProviders.CreateBitcoinRpcFilterProvider(_bitcoinRpcClient!, _blockHeaders))
 			.Match(
 				rpcProvider => rpcProvider,
 				_ =>
@@ -719,11 +720,15 @@ public class Global
 
 	private List<IBroadcaster> CreateBroadcasters(INodesRegistry nodes, MempoolService mempoolService)
 	{
-		var result = new List<IBroadcaster>()
+		List<IBroadcaster> result =
+		[
+			new NetworkBroadcaster(mempoolService, nodes)
+		];
+
+		if (_bitcoinRpcClient is not null)
 		{
-			new RpcBroadcaster(_bitcoinRpcClient),
-			new NetworkBroadcaster(mempoolService, nodes),
-		};
+			result.Insert(0, new RpcBroadcaster(_bitcoinRpcClient));
+		}
 
 		if (Network != Network.RegTest)
 		{

--- a/WalletWasabi.Client/WasabiApplication.cs
+++ b/WalletWasabi.Client/WasabiApplication.cs
@@ -264,7 +264,7 @@ public class WasabiApplication
 		return new PersistentConfig(
 			Network: oldConfig.Network,
 			AbsoluteMinInputCount: oldConfig.AbsoluteMinInputCount,
-			BitcoinRpcCredentialString: mustMigrateMain ? "wasabi:wasabi" : oldConfig.BitcoinRpcCredentialString,
+			BitcoinRpcCredentialString: mustMigrateMain ? string.Empty : oldConfig.BitcoinRpcCredentialString,
 			BitcoinRpcUri: mustMigrateMain ? Constants.DefaultMainNetBitcoinRpcUri : oldConfig.BitcoinRpcUri,
 			ConfigVersion: 4,
 			CoordinatorUri: oldConfig.CoordinatorUri,
@@ -302,7 +302,7 @@ public class WasabiApplication
 		var mainConfig = new PersistentConfig(
 			Network: Network.Main,
 			AbsoluteMinInputCount : oldConfig.AbsoluteMinInputCount,
-			BitcoinRpcCredentialString : mustMigrateMain ? "wasabi:wasabi" : oldConfig.BitcoinRpcCredentialString,
+			BitcoinRpcCredentialString : mustMigrateMain ? string.Empty : oldConfig.BitcoinRpcCredentialString,
 			BitcoinRpcUri : mustMigrateMain ? Constants.DefaultMainNetBitcoinRpcUri : oldConfig.BitcoinRpcUri,
 			ConfigVersion : 4,
 			CoordinatorUri : oldConfig.CoordinatorUri,
@@ -328,8 +328,8 @@ public class WasabiApplication
 		oldConfig = configs260.TestNet;
 		var testConfig = new PersistentConfig(
 			Network: Network.TestNet,
-			BitcoinRpcCredentialString : MustMigrate(configs260.TestNet) ? "wasabi:wasabi" : oldConfig.BitcoinRpcCredentialString,
-			BitcoinRpcUri : MustMigrate(configs260.TestNet) ? "https://rpc.wasabiwallet.co" : oldConfig.BitcoinRpcUri,
+			BitcoinRpcCredentialString : MustMigrate(configs260.TestNet) ? string.Empty : oldConfig.BitcoinRpcCredentialString,
+			BitcoinRpcUri : MustMigrate(configs260.TestNet) ? string.Empty : oldConfig.BitcoinRpcUri,
 			ExperimentalFeatures : new ValueList<string>(["scripting"]),
 			AbsoluteMinInputCount : oldConfig.AbsoluteMinInputCount,
 			ConfigVersion : 4,
@@ -355,8 +355,8 @@ public class WasabiApplication
 		oldConfig = configs260.TestNet;
 		var regtestConfig = new PersistentConfig(
 			Network: Network.RegTest,
-			BitcoinRpcCredentialString: MustMigrate(configs260.RegTest) ? "wasabi:wasabi" : oldConfig.BitcoinRpcCredentialString,
-			BitcoinRpcUri: MustMigrate(configs260.RegTest) ? Constants.DefaultRegTestBitcoinRpcUri : oldConfig.BitcoinRpcUri,
+			BitcoinRpcCredentialString: MustMigrate(configs260.RegTest) ? string.Empty : oldConfig.BitcoinRpcCredentialString,
+			BitcoinRpcUri: MustMigrate(configs260.RegTest) ? string.Empty : oldConfig.BitcoinRpcUri,
 			ExperimentalFeatures: new ValueList<string>(["scripting"]),
 			AbsoluteMinInputCount : oldConfig.AbsoluteMinInputCount,
 			ConfigVersion : 4,

--- a/WalletWasabi.Fluent/Converters/StatusConverters.cs
+++ b/WalletWasabi.Fluent/Converters/StatusConverters.cs
@@ -19,7 +19,7 @@ public static class StatusConverters
 	public static readonly IValueConverter FeeRateToString =
 		new FuncValueConverter<decimal, string>(x => x == 0 ? "No data" : $"{x:0.##} sat/vB");
 
-	public static readonly IValueConverter BlockchainTipToString =
+	public static readonly IValueConverter HeightToString =
 		new FuncValueConverter<uint, string>(x => x == 0 ? "No data" : $"{x:N0}");
 
 	public static readonly IValueConverter RpcStatusStringConverter =

--- a/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
+++ b/WalletWasabi.Fluent/Models/UI/ApplicationSettings.cs
@@ -300,9 +300,13 @@ public partial class ApplicationSettings : ReactiveObject
 		result = result with { EnableGpu = EnableGpu };
 
 		// Bitcoin
-		if (Uri.TryCreate(BitcoinRpcUri, UriKind.Absolute, out var uri))
+		if (string.IsNullOrWhiteSpace(BitcoinRpcUri))
 		{
-			result = result with { BitcoinRpcUri = uri.ToString(), BitcoinRpcCredentialString = BitcoinRpcCredentialString};
+			result = result with { BitcoinRpcUri = "", BitcoinRpcCredentialString = BitcoinRpcCredentialString };
+		}
+		else if (Uri.TryCreate(BitcoinRpcUri, UriKind.Absolute, out var uri))
+		{
+			result = result with { BitcoinRpcUri = uri.ToString(), BitcoinRpcCredentialString = BitcoinRpcCredentialString };
 		}
 
 		result = result with { CoordinatorUri = CoordinatorUri };

--- a/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
@@ -1,4 +1,3 @@
-using ReactiveUI;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Disposables;
@@ -6,9 +5,8 @@ using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Fluent.Extensions;
-using WalletWasabi.Fluent.Models.UI;
 using WalletWasabi.Helpers;
-using WalletWasabi.Models;
+using WalletWasabi.Logging;
 using WalletWasabi.Services;
 using WalletWasabi.Tor.StatusChecker;
 
@@ -20,6 +18,7 @@ public partial class HealthMonitor : ReactiveObject
 
 	[AutoNotify] private decimal _priorityFee;
 	[AutoNotify] private uint _blockchainTip;
+	[AutoNotify] private uint _clientTip;
 	[AutoNotify] private TorStatus _torStatus;
 	[AutoNotify] private Result<ConnectedRpcStatus, string> _bitcoinRpcStatus;
 	[AutoNotify] private int _peers;
@@ -35,7 +34,7 @@ public partial class HealthMonitor : ReactiveObject
 		// Do not make it dynamic, because if you change this config settings only next time will it activate.
 		UseTor = services.GetUseTor();
 		TorStatus = UseTor == TorMode.Disabled ? TorStatus.TurnedOff : TorStatus.NotRunning;
-		_bitcoinRpcStatus = Result<ConnectedRpcStatus, string>.Fail("");
+		_bitcoinRpcStatus = Result<ConnectedRpcStatus, string>.Fail("No detected/configured");
 
 		// Priority Fee
 		services.EventBus.AsObservable<MiningFeeRatesChanged>()
@@ -50,6 +49,13 @@ public partial class HealthMonitor : ReactiveObject
 			.WhereNotNull()
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Subscribe(blockchainTip => BlockchainTip = blockchainTip);
+
+		// Local Tip
+		services.EventBus.AsObservable<ClientTipHeightChanged>()
+			.Select(value => value.Height)
+			.WhereNotNull()
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Subscribe(clientTip => ClientTip = clientTip);
 
 		// Tor Status
 		services.EventBus.AsObservable<TorConnectionStateChanged>()
@@ -125,6 +131,8 @@ public partial class HealthMonitor : ReactiveObject
 		this.WhenAnyValue(
 				x => x.TorStatus,
 				x => x.Peers,
+				x => x.BlockchainTip,
+				x => x.ClientTip,
 				x => x.BitcoinRpcStatus,
 				x => x.UpdateAvailable,
 				x => x.CheckForUpdates)
@@ -155,13 +163,23 @@ public partial class HealthMonitor : ReactiveObject
 
 		var torConnected = UseTor == TorMode.Disabled || TorStatus == TorStatus.Running;
 
+		if (torConnected && BlockchainTip == ClientTip)
+		{
+			return HealthMonitorState.Ready;
+		}
+		if (torConnected && BlockchainTip > ClientTip && Peers > 0)
+		{
+			return HealthMonitorState.Loading;
+		}
+
 		return _bitcoinRpcStatus.Match(
 			r => torConnected
 				? r.Synchronized
 					? HealthMonitorState.Ready
 					: HealthMonitorState.BitcoinRpcSynchronizing
 				: HealthMonitorState.Loading,
-			_ =>
-				HealthMonitorState.BitcoinRpcIssueDetected);
+			e => e == "No detected/configured"
+				? HealthMonitorState.Ready
+				: HealthMonitorState.BitcoinRpcIssueDetected);
 	}
 }

--- a/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
@@ -28,7 +28,7 @@ public partial class HealthMonitor : ReactiveObject
 	[AutoNotify] private bool _isReadyToInstall;
 	[AutoNotify] private bool _checkForUpdates = true;
 	[AutoNotify] private Version? _clientVersion;
-	private const string NoBitcoinRpcDetectedConfigured = "No detected/configured";
+	private const string NoBitcoinRpcDetectedConfigured = "Not detected/configured";
 
 	public HealthMonitor(IServices services, TorStatusCheckerModel torStatusChecker)
 	{

--- a/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/HealthMonitor.cs
@@ -28,13 +28,14 @@ public partial class HealthMonitor : ReactiveObject
 	[AutoNotify] private bool _isReadyToInstall;
 	[AutoNotify] private bool _checkForUpdates = true;
 	[AutoNotify] private Version? _clientVersion;
+	private const string NoBitcoinRpcDetectedConfigured = "No detected/configured";
 
 	public HealthMonitor(IServices services, TorStatusCheckerModel torStatusChecker)
 	{
 		// Do not make it dynamic, because if you change this config settings only next time will it activate.
 		UseTor = services.GetUseTor();
 		TorStatus = UseTor == TorMode.Disabled ? TorStatus.TurnedOff : TorStatus.NotRunning;
-		_bitcoinRpcStatus = Result<ConnectedRpcStatus, string>.Fail("No detected/configured");
+		_bitcoinRpcStatus = Result<ConnectedRpcStatus, string>.Fail(NoBitcoinRpcDetectedConfigured);
 
 		// Priority Fee
 		services.EventBus.AsObservable<MiningFeeRatesChanged>()
@@ -163,7 +164,7 @@ public partial class HealthMonitor : ReactiveObject
 
 		var torConnected = UseTor == TorMode.Disabled || TorStatus == TorStatus.Running;
 
-		if (torConnected && BlockchainTip == ClientTip)
+		if (torConnected && BlockchainTip > 0 && BlockchainTip == ClientTip)
 		{
 			return HealthMonitorState.Ready;
 		}
@@ -178,7 +179,7 @@ public partial class HealthMonitor : ReactiveObject
 					? HealthMonitorState.Ready
 					: HealthMonitorState.BitcoinRpcSynchronizing
 				: HealthMonitorState.Loading,
-			e => e == "No detected/configured"
+			e => e == NoBitcoinRpcDetectedConfigured
 				? HealthMonitorState.Ready
 				: HealthMonitorState.BitcoinRpcIssueDetected);
 	}

--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -88,6 +88,10 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 				Settings.BitcoinRpcUri = BitcoinRpcUri;
 			}
 		}
+		else
+		{
+			Settings.BitcoinRpcUri = "";
+		}
 	}
 
 	private void ValidateBitcoinRpcCredentialString(IValidationErrors errors)

--- a/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/CoordinatorTabSettingsViewModel.cs
@@ -62,8 +62,9 @@ public partial class CoordinatorTabSettingsViewModel : RoutableViewModel
 	{
 		var coordinatorUri = CoordinatorUri;
 
-		if (string.IsNullOrEmpty(coordinatorUri))
+		if (string.IsNullOrWhiteSpace(coordinatorUri))
 		{
+			Settings.CoordinatorUri = "";
 			return;
 		}
 

--- a/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
+++ b/WalletWasabi.Fluent/Views/StatusIcon/StatusIcon.axaml
@@ -19,7 +19,7 @@
 
     <Style Selector="PathIcon.rotate">
       <Style.Animations>
-        <Animation Duration="0:0:2" IterationCount="5">
+        <Animation Duration="0:0:2" IterationCount="Infinite">
           <KeyFrame Cue="0%">
             <Setter Property="(RotateTransform.Angle)" Value="0" />
           </KeyFrame>
@@ -79,14 +79,19 @@
           <!-- Status -->
           <StackPanel Spacing="16">
 
-
             <StatusItem Title="Priority Fee" StatusText="{Binding HealthMonitor.PriorityFee, Converter={x:Static converters:StatusConverters.FeeRateToString}}">
               <StatusItem.Icon>
                 <PathIcon Data="{StaticResource rocket_regular}" />
               </StatusItem.Icon>
             </StatusItem>
 
-            <StatusItem Title="Chain Tip" StatusText="{Binding HealthMonitor.BlockchainTip, Converter={x:Static converters:StatusConverters.BlockchainTipToString}}">
+            <StatusItem Title="Network Tip" StatusText="{Binding HealthMonitor.BlockchainTip, Converter={x:Static converters:StatusConverters.HeightToString}}">
+              <StatusItem.Icon>
+                <PathIcon Data="{StaticResource block_height}" />
+              </StatusItem.Icon>
+            </StatusItem>
+
+            <StatusItem Title="Client Tip" StatusText="{Binding HealthMonitor.ClientTip, Converter={x:Static converters:StatusConverters.HeightToString}}">
               <StatusItem.Icon>
                 <PathIcon Data="{StaticResource block_height}" />
               </StatusItem.Icon>
@@ -113,6 +118,7 @@
                 <PathIcon Data="{StaticResource entities_regular}" />
               </StatusItem.Icon>
             </StatusItem>
+
             <StatusItem
               Title="Bitcoin RPC"
               StatusText="{Binding HealthMonitor.BitcoinRpcStatus, Converter={x:Static converters:StatusConverters.RpcStatusStringConverter}}">

--- a/WalletWasabi.Tests/UnitTests/Client/Configuration/PersistentConfigManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Client/Configuration/PersistentConfigManagerTests.cs
@@ -53,8 +53,8 @@ public class PersistentConfigManagerTests
 			  "TerminateTorOnExit": false,
 			  "TorBridges": [],
 			  "DownloadNewVersion": true,
-			  "BitcoinRpcCredentialString": "wasabi:wasabi",
-			  "BitcoinRpcEndPoint": "https://rpc.wasabiwallet.io",
+			  "BitcoinRpcCredentialString": "",
+			  "BitcoinRpcEndPoint": "",
 			  "JsonRpcServerEnabled": false,
 			  "JsonRpcUser": "",
 			  "JsonRpcPassword": "",
@@ -168,7 +168,7 @@ public class PersistentConfigManagerTests
 		var migratedConfig = WasabiApplication.UpdateFrom260To280(v2_6_0Config);
 
 		// When UseBitcoinRpc=false and URI is invalid, should migrate to Wasabi RPC
-		Assert.Equal("wasabi:wasabi", migratedConfig.BitcoinRpcCredentialString);
+		Assert.Equal("", migratedConfig.BitcoinRpcCredentialString);
 		Assert.Equal(Constants.DefaultMainNetBitcoinRpcUri, migratedConfig.BitcoinRpcUri);
 		Assert.Equal(4, migratedConfig.ConfigVersion);
 	}
@@ -189,7 +189,7 @@ public class PersistentConfigManagerTests
 		var migratedConfig = WasabiApplication.UpdateFrom260To280(v2_6_0Config);
 
 		// When URI is valid, it should be preserved even if UseBitcoinRpc=false
-		Assert.Equal("wasabi:wasabi", migratedConfig.BitcoinRpcCredentialString);
+		Assert.Equal("", migratedConfig.BitcoinRpcCredentialString);
 		Assert.Equal(Constants.DefaultMainNetBitcoinRpcUri, migratedConfig.BitcoinRpcUri);
 		Assert.Equal(4, migratedConfig.ConfigVersion);
 	}
@@ -294,7 +294,7 @@ public class PersistentConfigManagerTests
 		var migratedConfig = WasabiApplication.UpdateFrom260To280(v2_6_0Config);
 
 		// Should migrate to Wasabi RPC service because UseBitcoinRpc=false and URI is not well-formed
-		Assert.Equal("wasabi:wasabi", migratedConfig.BitcoinRpcCredentialString);
+		Assert.Equal("", migratedConfig.BitcoinRpcCredentialString);
 		Assert.Equal(Constants.DefaultMainNetBitcoinRpcUri, migratedConfig.BitcoinRpcUri);
 	}
 

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -123,7 +123,7 @@ public static class RPCClientExtensions
 		    .Select(x => (target: x.Result.Blocks, feeRate: x.Result.FeeRate))
 		    .DistinctBy(x => x.target)
 		    .ToDictionary(x => x.target, x => x.feeRate);
-		
+
 		// If all confirmation targets collapsed to the same block number, the node lacks sufficient
 		// fee history to produce useful estimates. Do not return such an estimate to let a next provider do the job.
 		if (result.Count < 2)
@@ -205,22 +205,22 @@ public static class RPCClientExtensions
 	}
 
 
-	public static async Task<Result<Unit,bool>> SupportsBlockFiltersAsync(this IRPCClient rpc, CancellationToken cancellationToken)
+	public static async Task<Result<bool>> SupportsBlockFiltersAsync(this IRPCClient rpc, CancellationToken cancellationToken)
 	{
 		try
 		{
 			var blockHash = await rpc.GetBestBlockHashAsync(cancellationToken).ConfigureAwait(false);
 			await rpc.GetBlockFilterAsync(blockHash, cancellationToken).ConfigureAwait(false);
-			return Result<Unit,bool>.Ok(Unit.Instance);
+			return Result<bool>.Ok();
 		}
 		catch (RPCException e) when (e.RPCCode == RPCErrorCode.RPC_MISC_ERROR && e.Message.Contains("Index is not enabled"))
 		{
-			return Result<Unit,bool>.Fail(true);
+			return Result<bool>.Fail(true);
 		}
 		catch (Exception e)
 		{
 			Logger.LogWarning(e);
-			return Result<Unit,bool>.Fail(false);
+			return Result<bool>.Fail(false);
 		}
 	}
 }

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -79,7 +79,7 @@ public static class Constants
 
 	public const string AppName = "Wasabi Wallet";
 
-	public static readonly string DefaultMainNetBitcoinRpcUri = "https://rpc.wasabiwallet.io";
+	public static readonly string DefaultMainNetBitcoinRpcUri = "";
 	public static readonly string DefaultTestNetBitcoinRpcUri = $"http://localhost:{DefaultTestNetBitcoinRpcPort}";
 	public static readonly string DefaultSignetBitcoinRpcUri = $"http://localhost:{DefaultSignetBitcoinRpcPort}";
 	public static readonly string DefaultRegTestBitcoinRpcUri = $"http://localhost:{DefaultRegTestBitcoinCorePort}";

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -80,7 +80,6 @@ public static class Constants
 	public const string AppName = "Wasabi Wallet";
 
 	public static readonly string DefaultMainNetBitcoinRpcUri = "https://rpc.wasabiwallet.io";
-	public static readonly string DefaultMainNetBitcoinRpcOnionUri = "http://wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion/rpc";
 	public static readonly string DefaultTestNetBitcoinRpcUri = $"http://localhost:{DefaultTestNetBitcoinRpcPort}";
 	public static readonly string DefaultSignetBitcoinRpcUri = $"http://localhost:{DefaultSignetBitcoinRpcPort}";
 	public static readonly string DefaultRegTestBitcoinRpcUri = $"http://localhost:{DefaultRegTestBitcoinCorePort}";

--- a/WalletWasabi/WabiSabi/Coordinator/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Coordinator/WabiSabiConfig.cs
@@ -24,7 +24,7 @@ public class WabiSabiConfig : ConfigBase
 
 	public Network Network { get; init; } = Network.Main;
 
-	public string MainNetBitcoinRpcUri { get; init; } = Constants.DefaultMainNetBitcoinRpcUri;
+	public string MainNetBitcoinRpcUri { get; init; } = $"http://localhost:{Constants.DefaultTestNetBitcoinRpcPort}";
 
 	public string TestNetBitcoinRpcUri { get; init; } = Constants.DefaultTestNetBitcoinRpcUri;
 

--- a/WalletWasabi/WabiSabi/Coordinator/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Coordinator/WabiSabiConfig.cs
@@ -24,7 +24,7 @@ public class WabiSabiConfig : ConfigBase
 
 	public Network Network { get; init; } = Network.Main;
 
-	public string MainNetBitcoinRpcUri { get; init; } = $"http://localhost:{Constants.DefaultTestNetBitcoinRpcPort}";
+	public string MainNetBitcoinRpcUri { get; init; } = $"http://localhost:{Constants.DefaultMainNetBitcoinRpcPort}";
 
 	public string TestNetBitcoinRpcUri { get; init; } = Constants.DefaultTestNetBitcoinRpcUri;
 


### PR DESCRIPTION
This PR allows user to do not configure a Bitcoin Node RPC. This means that in case the user has an empty value for the `BitcoinRpcEndpoint` setting, Wasabi assumes it doesn't have access to anyone and then tries synchronizing with the p2p network. 

The logic for the status icon is changed (and it needs to change again) to do not display a yellow exclamation mark warning when p2p synchronization is the mechanism used and it only displays the green "ready" icon when the wallet is synchronized (client tip height equals network tip height).

It is a Draft PR but it worth to test and provide feedback. There are many scenarios but the most relevant are:

* Missing Bitcoin RPC endpoint: it should not display error in the logs, it should rotate the green arrows until fully synchronized
* Bitcoin RPC with problems (not found, invalid credentials). Log with errors, pop up windows saying that something is wrong, fallback to p2p
* Bitcoin RPC without any problem. No error logs, synchronization is done via rpc.