### PR TITLE
Lower sanity fee floor from 2 to 0.5 sat/vB

### DIFF
--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -299,7 +299,7 @@ public static class NBitcoinExtensions
 		// Make sure to be prepared for mempool spikes.
 		var spikeSanity = mempoolMinFee * 1.5m;
 
-		var sanityFee = FeeRate.Max(new FeeRate(Money.Coins(spikeSanity)), new FeeRate(2m));
+		var sanityFee = FeeRate.Max(new FeeRate(Money.Coins(spikeSanity)), new FeeRate(0.5m));
 		return sanityFee;
 	}
 


### PR DESCRIPTION
This fixes the coordinator floor fee stuck at 2 sat/vB, my suggestion is to set to 0.5 sat/vB instead as a sanity fee floor.
Alternatively or more relay-safe would be 1 sat/vB floor, not all Bitcoin clients will relay sub 1 sat/vB by default although 0.1 sat/vB is configurable in Bitcoin Core v31.0.
Related to #14621, as now the Bitcoin RPC fee is correct but Wasabi rounds it to 2 sat/vB with this 2m sanityFee variable `new FeeRate(2m)`.