### PR TITLE
Upgrade to NBitcoin 10.0.7 to fix uncaught exceptions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <!-- Core libraries. -->
     <PackageVersion Include="WabiSabi" Version="1.0.1.2" />
-    <PackageVersion Include="NBitcoin" Version="10.0.4" />
+    <PackageVersion Include="NBitcoin" Version="10.0.7" />
     <!-- UI. -->
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />

--- a/WalletWasabi.Client/packages.lock.json
+++ b/WalletWasabi.Client/packages.lock.json
@@ -208,7 +208,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[10.0.4, )",
+          "NBitcoin": "[10.0.7, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -278,9 +278,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "vdC7GYGspnM8rKovshvc6p40p66HsvrVAY8/3r718jDxYFHOxLWU2bUJXiogOJiCSRHfzbaiGK4lFDV0qKd05g==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Daemon/packages.lock.json
+++ b/WalletWasabi.Daemon/packages.lock.json
@@ -195,7 +195,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[10.0.4, )",
+          "NBitcoin": "[10.0.7, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -285,9 +285,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "vdC7GYGspnM8rKovshvc6p40p66HsvrVAY8/3r718jDxYFHOxLWU2bUJXiogOJiCSRHfzbaiGK4lFDV0qKd05g==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -562,7 +562,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[10.0.4, )",
+          "NBitcoin": "[10.0.7, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -757,9 +757,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "vdC7GYGspnM8rKovshvc6p40p66HsvrVAY8/3r718jDxYFHOxLWU2bUJXiogOJiCSRHfzbaiGK4lFDV0qKd05g==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -630,7 +630,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[10.0.4, )",
+          "NBitcoin": "[10.0.7, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -720,9 +720,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "vdC7GYGspnM8rKovshvc6p40p66HsvrVAY8/3r718jDxYFHOxLWU2bUJXiogOJiCSRHfzbaiGK4lFDV0qKd05g==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/P2pBasedTests.cs
@@ -13,7 +13,6 @@ using WalletWasabi.Services;
 using WalletWasabi.Stores;
 using WalletWasabi.Tests.BitcoinCore;
 using WalletWasabi.Tests.Helpers;
-using WalletWasabi.Wallets;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.BitcoinCore;
@@ -50,7 +49,7 @@ public class P2pBasedTests
 			await rpc.GenerateAsync(blockCount: 101);
 
 			node.Behaviors.Add(new P2pBehavior(mempoolService));
-			node.VersionHandshake();
+			await node.VersionHandshakeAsync();
 
 			using Key k = new();
 			var address = k.PubKey.GetAddress(ScriptPubKeyType.Segwit, network);

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -22,7 +22,7 @@ public static class NBitcoinExtensions
 	{
 		if (node.State == NodeState.Connected)
 		{
-			node.VersionHandshake(cancellationToken);
+			await node.VersionHandshakeAsync(cancellationToken).ConfigureAwait(false);
 		}
 
 		using var listener = node.CreateListener();

--- a/WalletWasabi/Services/NodesManagement/NodeConnectionManager.cs
+++ b/WalletWasabi/Services/NodesManagement/NodeConnectionManager.cs
@@ -252,7 +252,7 @@ public class NodeConnectionManager : INodesRegistry, IDisposable
 
 			var node = await Node.ConnectAsync(_network, peerInfo.Endpoint, connParams)
 				.ConfigureAwait(false);
-			node.VersionHandshake(timeoutCts.Token);
+			await node.VersionHandshakeAsync(timeoutCts.Token).ConfigureAwait(false);
 
 			if (node.State != NodeState.HandShaked)
 			{
@@ -570,7 +570,7 @@ public class NodeConnectionManager : INodesRegistry, IDisposable
 		try
 		{
 			node = await Node.ConnectAsync(_network, endpoint, connParams).ConfigureAwait(false);
-			node.VersionHandshake(timeoutCts.Token);
+			await node.VersionHandshakeAsync(timeoutCts.Token).ConfigureAwait(false);
 
 			sw.Stop();
 

--- a/WalletWasabi/Services/NodesManagement/NodeDiscoveryService.cs
+++ b/WalletWasabi/Services/NodesManagement/NodeDiscoveryService.cs
@@ -185,7 +185,7 @@ public static class NodeDiscoveryCoordinator
 		try
 		{
 			node = await Node.ConnectAsync(network, endpoint, connParams).ConfigureAwait(false);
-			node.VersionHandshake(timeoutCts.Token);
+			await node.VersionHandshakeAsync(timeoutCts.Token).ConfigureAwait(false);
 
 			sw.Stop();
 

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -72,9 +72,9 @@
       },
       "NBitcoin": {
         "type": "Direct",
-        "requested": "[10.0.4, )",
-        "resolved": "10.0.4",
-        "contentHash": "QZ1wwcyv3hGnzdE6Ba0+/qivhMmsZ/xeJl1SuxHPbmxdccuDQiZJjD2LZnoFr/XfTsEDvbuwpenw7kL5ecOy7w==",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "vdC7GYGspnM8rKovshvc6p40p66HsvrVAY8/3r718jDxYFHOxLWU2bUJXiogOJiCSRHfzbaiGK4lFDV0qKd05g==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/deps.json
+++ b/deps.json
@@ -556,8 +556,8 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "10.0.4",
-    "hash": "sha256-BshBTbLcRE9jca9mIhLzLQ+Mix1R+6i4k0htq7pxSqk="
+    "version": "10.0.7",
+    "hash": "sha256-4arn8+u0dy2iOmwMH/tjcTXR+/4viRf9dlUeMCRqXvI="
   },
   {
     "pname": "NBitcoin.Secp256k1",


### PR DESCRIPTION
This PR upgrades NBitcoin to 10.0.7 and it fixes the long-standing issue (https://github.com/WalletWasabi/WalletWasabi/issues/1264#issuecomment-477969364):

<img width="1850" height="876" alt="image" src="https://github.com/user-attachments/assets/92cc6d41-13db-4a59-8421-f477ce670439" />


where NBitcoin throws a lot of uncaught exceptions like this one:

```
2026-06-04 15:54:00.996 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
```

## Testing

Run

```
dotnet run --project WalletWasabi.Fluent.Desktop -- --loglevel=trace
```

On master, you should see `AggregateException` exceptions in console. With this PR, you should not.


## Upgrade

NBitcoin now has a few new perf optimizations:

* https://github.com/MetacoSA/NBitcoin/pull/1316
* https://github.com/MetacoSA/NBitcoin/pull/1317