### PR TITLE
Wallet: Fix cancellation that breaks clean CTRL+C experience

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -347,7 +347,7 @@ public class Wallet : BackgroundService
 			lastHashesLeft = FilterHeaderChain.HashesLeft;
 		}
 
-		await WalletFilterProcessor.InitialSynchronizationFinished.ConfigureAwait(false);
+		await WalletFilterProcessor.InitialSynchronizationFinished.WaitAsync(cancel).ConfigureAwait(false);
 	}
 
 	private void LoadDummyMempool()


### PR DESCRIPTION
Fixes #14635

I believe this fixes the issue. I tested it twice. However, it's certainly hard to say it with utmost certainty. Anyway, in my opinion, the change makes sense anyway.

## Testing

1. Start Wasabi with a new wallet
    ```
    dotnet run --project WalletWasabi.Fluent.Desktop -- --datadir="~/EmptyWallet"
    ``
2. Wait until filters are downloaded. 
3. Press CTRL+C when blocks are being downloaded.

It takes some time to reproduce because it takes time to find a peer providing compact filters but otherwise the repro worked well for me.