### PR TITLE
[experiment] Do not synchronize blockheaders from height 0 but from 480000

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -186,7 +186,12 @@ public class Global
 					[] => new ConcurrentChain(Network),
 					_ => new ConcurrentChain(bytes, Network)
 				},
-				_ => new ConcurrentChain(Network));
+				_ =>
+				{
+					var chain = new ConcurrentChain();
+					bool result = chain.SetTip(FilterCheckpoints.GetWasabiGenesisHeader(Network));
+					return chain;
+				});
 
 		return blockHeaders;
 	}

--- a/WalletWasabi/Blockchain/BlockFilters/FilterCheckpoints.cs
+++ b/WalletWasabi/Blockchain/BlockFilters/FilterCheckpoints.cs
@@ -1,5 +1,4 @@
 using NBitcoin;
-using System;
 using System.Linq;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Blockchain.Blocks;
@@ -230,4 +229,11 @@ public static class FilterCheckpoints
 
 	public static FilterModel GetMostRecentCheckpoint(Network network) =>
 		GetCheckpointsByNetwork(network).Last();
+
+	public static BlockHeader GetWasabiGenesisHeader(Network network)
+	{
+		var hex = "02000020801b81629334be8e7af5ebfb9df09c18e1f833b5f0efcb00000000000000000040d1ca077fefe7fb797711baa0c063eca9b8ed9469ae0128982b44ad0c25386491329e59e93c011822ff5422";
+		var blockHeader = new BlockHeader(hex, network);
+		return blockHeader;
+	}
 }


### PR DESCRIPTION
Regarding https://github.com/orgs/WalletWasabi/discussions/14663 

> Do not synchronize blockheaders from height 0 but from 480000 (this should improve the initial download time)

I tried what the simplest way to achieve this might be and the idea was to set a tip of `ConcurrentChain` to `481824`. `ConcurrentChain` does not seem to allow it though. 

So I guess this does not seem worth working on given https://github.com/WalletWasabi/WalletWasabi/pull/14674#issuecomment-4709269368.