### PR TITLE
Add `<NuGetAudit>true</NuGetAudit>` to make it easier to temporarily …

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
 
 	<!-- Audit both top-level and transitive dependencies for vulnerabilities in NuGet packages. -->
 	<!-- https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages#setting-a-security-audit-mode -->
+	<NuGetAudit>true</NuGetAudit>
 	<NuGetAuditMode>all</NuGetAuditMode>
 	<NuGetAuditLevel>low</NuGetAuditLevel>
  </PropertyGroup>


### PR DESCRIPTION
…disable the audit

Currently, `SQLitePCLRaw.lib.e_sqlite3` (v2.1.11) is flagged as a vulnerable library. The library is referenced by `Microsoft.Data.Sqlite`. So ideally Microsoft should fix it. However, the vulnerability breaks builds because we enabled "TreatWarningsAsErrors".

The library could be bumped to a newer version but there is no https://github.com/ericsink/SQLitePCL.raw/releases v2.x version fixing the issue. Only v3 (not sure if it fixes anything).

I guess adding `<NuGetAudit>` and temporarily changing the value when testing a PR is kind of acceptable for now.

edit: It appears one can actually select SQLite version using https://learn.microsoft.com/en-us/dotnet/standard/data/sqlite/custom-versions?tabs=net-cli#sqlitepclraw-available-providers