### PR TITLE
Update release notes

### DIFF
--- a/WalletWasabi/Announcements/ReleaseHighlights.md
+++ b/WalletWasabi/Announcements/ReleaseHighlights.md
@@ -1,5 +1,5 @@
 ## Release Highlights
-#### ⚙️ Custom indexer replaced with standard Bitcoin RPC
+#### ⚙️ P2P synchronization for compact filters
 #### 🚀 Pay in coinjoin
 #### ↘️ Sub-1 sat/vByte transaction fees
 #### ♻️ Payment batching
@@ -8,12 +8,12 @@
 #### 🔑 Signet test network
 
 ## Release Summary
-Wasabi Wallet v2.8.0 is a massive release with faster onboarding, improved privacy, lower fees, and expanded device support.
+Wasabi Wallet v2.8.0 is a massive release with P2P synchronization, faster onboarding, improved privacy, lower fees, and expanded device support.
 
-### ⚙️ Custom indexer replaced with standard Bitcoin RPC
+### ⚙️ P2P synchronization for compact filters
 Wasabi pioneered the use of compact block filters for private wallet synchronization. This involved implementing a custom indexer to build the filters, and hosting a server to provide them to clients.
 
-Progress continued on block filters, resulting in standardized BIPs and direct support in Bitcoin node software. This release discards the legacy indexer and exclusively uses the node RPC for synchronizing block filters, making Wasabi's architecture simpler and more flexible.
+Progress continued on block filters, resulting in standardized BIPs and direct support in Bitcoin node software. This version of Wasabi uses Bitcoin’s P2P network to download compact filters, eliminating the centralized server.
 
 Onboarding new users to Wasabi is now faster thanks to wallet birthday checkpoints. Newly generated wallets no longer waste time and bandwidth downloading old blockchain history since it would be impossible for a new wallet to have previously received any transactions.
 
@@ -39,4 +39,4 @@ The scripting language is an experimental feature that makes Wasabi programmable
 ### 🔑 Signet test network
 Testnet3 and Testnet4 use proof of work for generating blocks, just like mainnet. Because testnet coins have no value, low mining difficulty allows an attacker with a small amount of hashpower to flood blocks or create long reorgs.
 
-Signet is another test network that allows a set of signers to create blocks. This reduces the unpredictable behavior so developers can work with a stable environment. Wasabi does not ship with a default signet RPC endpoint, so you must specify one in the signet config file or connect it to your signet node.
+Signet is another test network that allows a set of signers to create blocks. This reduces the unpredictable behavior so developers can work with a stable environment.

--- a/WalletWasabi/Announcements/ReleaseHighlights.md
+++ b/WalletWasabi/Announcements/ReleaseHighlights.md
@@ -6,7 +6,7 @@
 #### 📎 Support for arm64 Linux, Tails, and Whonix
 #### 📜 Scheme scripting language
 #### 🔑 Signet test network
-#### 💀 Forward compatability for Tor
+#### 💀 Forward compatibility for Tor
 
 ## Release Summary
 Wasabi Wallet v2.8.0 is a massive release with P2P synchronization, faster onboarding, improved privacy, lower fees, and expanded device support.
@@ -42,5 +42,5 @@ Testnet3 and Testnet4 use proof of work for generating blocks, just like mainnet
 
 Signet is another test network that allows a set of signers to create blocks. This reduces the unpredictable behavior so developers can work with a stable environment.
 
-### 💀 Forward compatability for Tor
+### 💀 Forward compatibility for Tor
 The Tor Project is terminating network support for versions <0.4.9 on September 1, 2026. This release of Wasabi upgrades the bundled Tor dependency to ensure forward compatibility.

--- a/WalletWasabi/Announcements/ReleaseHighlights.md
+++ b/WalletWasabi/Announcements/ReleaseHighlights.md
@@ -6,6 +6,7 @@
 #### 📎 Support for arm64 Linux, Tails, and Whonix
 #### 📜 Scheme scripting language
 #### 🔑 Signet test network
+#### 💀 Forward compatability for Tor
 
 ## Release Summary
 Wasabi Wallet v2.8.0 is a massive release with P2P synchronization, faster onboarding, improved privacy, lower fees, and expanded device support.
@@ -40,3 +41,6 @@ The scripting language is an experimental feature that makes Wasabi programmable
 Testnet3 and Testnet4 use proof of work for generating blocks, just like mainnet. Because testnet coins have no value, low mining difficulty allows an attacker with a small amount of hashpower to flood blocks or create long reorgs.
 
 Signet is another test network that allows a set of signers to create blocks. This reduces the unpredictable behavior so developers can work with a stable environment.
+
+### 💀 Forward compatability for Tor
+The Tor Project is terminating network support for versions <0.4.9 on September 1, 2026. This release of Wasabi upgrades the bundled Tor dependency to ensure forward compatibility.


### PR DESCRIPTION
BIP157 support will be in the release, and Tor is terminating support for legacy versions.