### PR TITLE
Introduce observability

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -1,3 +1,7 @@
+using NBitcoin;
+using NBitcoin.Protocol;
+using NBitcoin.RPC;
+using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -8,10 +12,6 @@ using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using NBitcoin;
-using NBitcoin.Protocol;
-using NBitcoin.RPC;
-using Nito.AsyncEx;
 using WalletWasabi.BitcoinP2p;
 using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Blockchain.BlockFilters;
@@ -28,6 +28,7 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Io;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
+using WalletWasabi.Observability;
 using WalletWasabi.Rpc;
 using WalletWasabi.Services;
 using WalletWasabi.Services.NodesManagement;
@@ -89,6 +90,11 @@ public class Global
 
 		ExternalSourcesHttpClientFactory = BuildHttpClientFactory();
 
+		_metricManager = new MetricManager();
+		_metricManager.DisposeUsing(_disposables);
+		_metricDisplayService = new MetricDisplayService(_metricManager);
+		_metricDisplayService.DisposeUsing(_disposables);
+
 		var p2PDataDir = GetBitcoinP2PNetworkDirectory();
 		_blockHeaders = ConfigureBlockHeaderChain(p2PDataDir);
 
@@ -126,6 +132,8 @@ public class Global
 	private readonly CancellationTokenSource _stoppingCts = new();
 
 	private readonly P2pConnectionManager _p2pConnectionManager;
+	private readonly MetricManager _metricManager;
+	private readonly MetricDisplayService _metricDisplayService;
 	private TorManager? _torManager;
 	private readonly IRPCClient? _bitcoinRpcClient;
 	private CoinPrison? _coinPrison;
@@ -574,6 +582,7 @@ public class Global
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _stoppingCts.Token);
 		CancellationToken linkedCtsToken = linkedCts.Token;
 
+		await _metricDisplayService.StartAsync(linkedCtsToken).ConfigureAwait(false);
 		ConfigureBitcoinNetwork(linkedCtsToken);
 		ConfigureWasabiUpdater(linkedCtsToken);
 		ConfigureExchangeRateUpdater(linkedCtsToken);
@@ -847,6 +856,9 @@ public class Global
 
 				_disposables.Dispose();
 				await _asyncDisposables.DisposeAsync().ConfigureAwait(false);
+
+				Logger.LogInfo("Dispose meter listener.");
+				_metricManager.Dispose();
 			}
 			catch (Exception ex)
 			{

--- a/WalletWasabi/BitcoinP2p/CompactFilterBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/CompactFilterBehavior.cs
@@ -25,12 +25,16 @@ public class CompactFilterBehavior(
 	: NodeBehavior
 {
 	private static readonly TimeSpan TickSyncInterval = TimeSpan.FromSeconds(2);
+	private static readonly TimeSpan HeaderAssignmentTimeout = TimeSpan.FromSeconds(25);
+	private static readonly TimeSpan FilterAssignmentTimeout = TimeSpan.FromSeconds(30);
 
 	private readonly Lock _lock = new();
 	private readonly List<CompactFilterPayload> _collectedFilters = [];
 
 	private RangeRequest? _assignedHeaderRange;
+	private DateTime _assignedHeaderRangeAt;
 	private RangeRequest? _assignedFilterRange;
+	private DateTime _assignedFilterRangeAt;
 
 	private volatile bool _invalidReceived;
 
@@ -80,6 +84,13 @@ public class CompactFilterBehavior(
 			}
 
 			lastTickSync = tick.DateTime;
+
+			// Check for stale assignments - disconnect if timed out
+			if (CheckAndHandleStaleAssignment(node, nowUtc))
+			{
+				return;
+			}
+
 			TrySync(node);
 		});
 		RegisterDisposable(tickSubscription);
@@ -345,6 +356,7 @@ public class CompactFilterBehavior(
 		}
 
 		_assignedFilterRange = filterAssignment;
+		_assignedFilterRangeAt = DateTime.UtcNow;
 		Logger.LogDebug(
 			$"Assigned range {filterAssignment} to node {node.Peer.Endpoint}");
 
@@ -368,6 +380,7 @@ public class CompactFilterBehavior(
 		}
 
 		_assignedHeaderRange = headerAssignment;
+		_assignedHeaderRangeAt = DateTime.UtcNow;
 		Logger.LogDebug($"Assigned filter header range {headerAssignment} to node {node.Peer.Endpoint}");
 
 		var payload = new GetCompactFilterHeadersPayload(FilterType.Basic, headerAssignment.StartHeight,
@@ -417,6 +430,45 @@ public class CompactFilterBehavior(
 		_collectedFilters.Clear();
 	}
 
+	private bool CheckAndHandleStaleAssignment(Node node, DateTime nowUtc)
+	{
+		if (!_lock.TryEnter())
+		{
+			return false;
+		}
+
+		try
+		{
+			// Check filter assignment timeout
+			if (_assignedFilterRange is not null)
+			{
+				var elapsed = nowUtc - _assignedFilterRangeAt;
+				if (elapsed > FilterAssignmentTimeout)
+				{
+					HandleInvalidNoLock(node, $"Filter assignment at {_assignedFilterRange.StartHeight} timed out after {elapsed.TotalSeconds:F1}s, disconnecting {node.Peer.Endpoint}");
+					return true;
+				}
+			}
+
+			// Check header assignment timeout
+			if (_assignedHeaderRange is not null)
+			{
+				var elapsed = nowUtc - _assignedHeaderRangeAt;
+				if (elapsed > HeaderAssignmentTimeout)
+				{
+					HandleInvalidNoLock(node, $"Header assignment at {_assignedHeaderRange.StartHeight} timed out after {elapsed.TotalSeconds:F1}s, disconnecting {node.Peer.Endpoint}");
+					return true;
+				}
+			}
+
+			return false;
+		}
+		finally
+		{
+			_lock.Exit();
+		}
+	}
+
 	private bool IsNodeInValidState(Node node)
 	{
 		if (_invalidReceived)
@@ -431,8 +483,8 @@ public class CompactFilterBehavior(
 	{
 		private static readonly TimeSpan HeaderAssignmentTimeout = TimeSpan.FromSeconds(25);
 		private static readonly TimeSpan FilterAssignmentTimeout = TimeSpan.FromSeconds(30);
-		private const int HeadersPerRequest = 1_100;
-		private const int FiltersPerRequest = 400;
+		private const int HeadersPerRequest = 2_000;
+		private const int FiltersPerRequest = 500;
 		private const int MaxLookaheadRanges = 25;
 
 		private readonly Lock _lock = new();

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -18,7 +18,7 @@ namespace WalletWasabi.Extensions;
 
 public static class NBitcoinExtensions
 {
-	public static async Task<Block> DownloadBlockAsync(this Node node, uint256 hash, CancellationToken cancellationToken)
+	public static async Task<Block?> DownloadBlockAsync(this Node node, uint256 hash, CancellationToken cancellationToken)
 	{
 		if (node.State == NodeState.Connected)
 		{
@@ -34,19 +34,27 @@ public static class NBitcoinExtensions
 		// A good way to get any feedback about whether the node knows the block or not is to send a ping request.
 		// If block is not known by the remote node, the pong will be sent immediately, else it will be sent after the block download.
 		ulong pingNonce = RandomUtils.GetUInt64();
-		await node.SendMessageAsync(new PingPayload() { Nonce = pingNonce }).ConfigureAwait(false);
+		await node.SendMessageAsync(new PingPayload { Nonce = pingNonce }).ConfigureAwait(false);
 		while (true)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			var message = listener.ReceiveMessage(cancellationToken);
-			if (message.Message.Payload is NotFoundPayload ||
-				(message.Message.Payload is PongPayload p && p.Nonce == pingNonce))
-			{
-				throw new InvalidOperationException($"Disconnected node, because it does not have the block data.");
-			}
-			else if (message.Message.Payload is BlockPayload b && b.Object?.GetHash() == hash)
+
+			if (message.Message.Payload is BlockPayload b && b.Object?.GetHash() == hash)
 			{
 				return b.Object;
+			}
+
+			if (message.Message.Payload is NotFoundPayload)
+			{
+				return node.SupportsNetwork
+					? throw new InvalidOperationException($"Node {node.RemoteSocketEndpoint} didn't found block {hash} which we assume exists.")
+					: null;
+			}
+
+			if (message.Message.Payload is PongPayload p && p.Nonce == pingNonce)
+			{
+				throw new InvalidOperationException($"Node {node.RemoteSocketEndpoint} send us wrong pong nonce.");
 			}
 		}
 	}
@@ -455,5 +463,14 @@ public static class NBitcoinExtensions
 	{
 		public bool SupportsCompactFilters =>
 			node.PeerVersion?.Services.HasFlag(NodeServices.NODE_COMPACT_FILTERS) == true;
+
+		public bool SupportsNetwork =>
+			node.PeerVersion?.Services.HasFlag(NodeServices.Network) == true;
+
+		public bool SupportsNetworkLimited =>
+			node.PeerVersion?.Services.HasFlag(NodeServices.NODE_NETWORK_LIMITED) == true;
+
+		public bool CanServeBlocks =>
+			node.SupportsNetwork || node.SupportsNetworkLimited;
 	}
 }

--- a/WalletWasabi/Observability/ConsoleTable.cs
+++ b/WalletWasabi/Observability/ConsoleTable.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+
+namespace WalletWasabi.Observability;
+
+public class ConsoleTable
+{
+	private readonly List<string[]> _rows = new();
+	private readonly string[] _headers;
+
+	public ConsoleTable(params string[] headers)
+	{
+		_headers = headers;
+	}
+
+	public void Clear()
+	{
+		_rows.Clear();
+	}
+
+	public void AddRow(params string[] row)
+	{
+		if (row.Length != _headers.Length)
+		{
+			throw new ArgumentException("Row must have the same number of columns as headers.");
+		}
+
+		_rows.Add(row);
+	}
+
+	public void Print()
+	{
+		// Calculate column widths.
+		var columnWidths = new int[_headers.Length];
+
+		for (int i = 0; i < _headers.Length; i++)
+		{
+			columnWidths[i] = _headers[i].Length;
+		}
+
+		foreach (var row in _rows)
+		{
+			for (int i = 0; i < row.Length; i++)
+			{
+				columnWidths[i] = Math.Max(columnWidths[i], row[i]?.Length ?? 0);
+			}
+		}
+
+		// Print top border.
+		PrintLine(columnWidths);
+
+		// Print header.
+		PrintRow(_headers, columnWidths);
+		PrintLine(columnWidths);
+
+		// Print rows.
+		foreach (var row in _rows)
+		{
+			PrintRow(row, columnWidths);
+		}
+
+		// Print bottom border.
+		PrintLine(columnWidths);
+	}
+
+	private void PrintLine(int[] widths)
+	{
+		Console.Write("+");
+		foreach (var width in widths)
+		{
+			Console.Write(new string('-', width + 2) + "+");
+		}
+		Console.WriteLine();
+	}
+
+	private void PrintRow(string[] row, int[] widths)
+	{
+		Console.Write("|");
+		for (int i = 0; i < row.Length; i++)
+		{
+			Console.Write($" {row[i]?.PadRight(widths[i])} |");
+		}
+		Console.WriteLine();
+	}
+}

--- a/WalletWasabi/Observability/MetricDisplayService.cs
+++ b/WalletWasabi/Observability/MetricDisplayService.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Hosting;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WalletWasabi.Observability;
+
+/// <summary>
+/// Service to periodically display a snapshot of tracked metrics.
+/// </summary>
+public class MetricDisplayService(MetricManager metricManager) : BackgroundService
+{
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		if (MetricManager.EnableMetricConsoleSnapshots)
+		{
+			var table = new ConsoleTable("Metric", "Type", "Value");
+
+			while (!stoppingToken.IsCancellationRequested)
+			{
+				await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken).ConfigureAwait(false);
+
+				table.Clear();
+				var snapshot = metricManager.GetMetricsSnapshot();
+
+				foreach ((var name, var value) in snapshot)
+				{
+					var type = name.EndsWith(".histogram", StringComparison.Ordinal) || name.EndsWith(".gauge", StringComparison.Ordinal)
+						? "Last" : "Count";
+					var unit = Metrics.GetUnit(name);
+					var space = unit != "" ? " " : "";
+					var valueStr = string.Create(CultureInfo.InvariantCulture, $"{value}{space}{unit}");
+
+					table.AddRow(name, type, valueStr);
+				}
+
+				Console.WriteLine();
+				table.Print();
+				Console.WriteLine();
+			}
+		}
+	}
+}

--- a/WalletWasabi/Observability/MetricManager.cs
+++ b/WalletWasabi/Observability/MetricManager.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Text;
+using System.Threading;
+using WalletWasabi.Logging;
+
+namespace WalletWasabi.Observability;
+
+public class MetricManager : IDisposable
+{
+	public const bool EnableMetricConsoleLogging = false;
+	public const bool EnableMetricConsoleSnapshots = true;
+
+	public const string P2pMeterName = "WalletWasabi.P2P";
+
+	private readonly MeterListener _listener;
+
+	private readonly Lock _lock = new();
+	private readonly OrderedDictionary<string, decimal> _metrics;
+
+	public MetricManager()
+	{
+		_metrics = new OrderedDictionary<string, decimal>
+		{
+			{ Metrics.P2pConnectedCounter, 0m },
+			{ Metrics.P2pConnectionAttemptsCounter, 0m },
+			{ Metrics.P2pConnectionSuccessCounter, 0m },
+			{ Metrics.P2pConnectionHandshakeDurationHistogram, 0m },
+			{ Metrics.P2pConnectionTotalDurationHistogram, 0m },
+			{ Metrics.P2pMisbehaviorCounter, 0m },
+			{ Metrics.P2pMisbehaviorInvalidDataCounter, 0m },
+			{ Metrics.P2pMisbehaviorTimeoutBlockDownloadCounter, 0m }
+		};
+
+		_listener = new()
+		{
+			InstrumentPublished = (instrument, listener) =>
+			{
+				if (instrument.Meter.Name == P2pMeterName)
+				{
+					listener.EnableMeasurementEvents(instrument);
+				}
+			}
+		};
+
+		// Configure the callbacks to invoke when an Instrument emits a value.
+		_listener.SetMeasurementEventCallback<int>(OnMetric);
+		_listener.SetMeasurementEventCallback<double>(OnMetric);
+		_listener.SetMeasurementEventCallback<decimal>(OnMetric);
+
+		// Start the listener, which invokes OnInstrumentPublished for already-published Instruments.
+		_listener.Start();
+	}
+
+	public OrderedDictionary<string, decimal> GetMetricsSnapshot()
+	{
+		lock (_lock)
+		{
+			return new OrderedDictionary<string, decimal>(_metrics);
+		}
+	}
+
+	private void OnMetric<T>(Instrument instrument, T measurement, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+	{
+		string name = instrument.Name;
+		var exchange = name.EndsWith(".histogram", StringComparison.Ordinal) ||
+			 name.EndsWith(".gauge", StringComparison.Ordinal);
+
+		decimal measurementValue = measurement switch
+		{
+			int i => i,
+			double d => (decimal)d,
+			decimal d => d,
+			_ => throw new NotSupportedException()
+		};
+
+		lock (_lock)
+		{
+			if (_metrics.TryGetValue(name, out var value))
+			{
+				_metrics[name] = exchange
+					? measurementValue
+					: value + measurementValue;
+			}
+		}
+
+#pragma warning disable CS0162 // Unreachable code detected
+		if (EnableMetricConsoleLogging)
+		{
+			var tagsStr = FormatTags(tags);
+			var message = $"{instrument.Name} = {measurement} {tagsStr}";
+			Logger.LogInfo(message);
+		}
+#pragma warning restore CS0162 // Unreachable code detected
+	}
+
+	private static string FormatTags(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+	{
+		if (tags.IsEmpty)
+		{
+			return "";
+		}
+
+		var sb = new StringBuilder();
+		sb.Append('[');
+
+		for (int i = 0; i < tags.Length; i++)
+		{
+			var tag = tags[i];
+			if (i > 0)
+			{
+				sb.Append(", ");
+			}
+
+			sb.Append(tag.Key).Append('=').Append(tag.Value?.ToString() ?? "null");
+		}
+
+		sb.Append(']');
+		return sb.ToString();
+	}
+
+	public void Dispose()
+	{
+		_listener.Dispose();
+	}
+}

--- a/WalletWasabi/Observability/Metrics.cs
+++ b/WalletWasabi/Observability/Metrics.cs
@@ -1,0 +1,33 @@
+namespace WalletWasabi.Observability;
+
+public static class Metrics
+{
+	public const string P2pConnectedCounter = "p2p.connected.gauge";
+	public const string P2pConnectionAttemptsCounter = "p2p.connection.attempt.count";
+	public const string P2pConnectionSuccessCounter = "p2p.connection.success.count";
+	public const string P2pConnectionHandshakeDurationHistogram = "p2p.connection.handshake.duration.histogram";
+	public const string P2pConnectionTotalDurationHistogram = "p2p.connection.total.duration.histogram";
+	public const string P2pMisbehaviorCounter = "p2p.misbehavior.count";
+	public const string P2pMisbehaviorInvalidDataCounter = "p2p.misbehavior.invalid.data.count";
+	public const string P2pMisbehaviorTimeoutBlockDownloadCounter = "p2p.misbehavior.timeout.block.download.count";
+
+	public static string GetDescription(string metricName) => metricName switch
+	{
+		P2pConnectedCounter => "Currently connected nodes",
+		P2pConnectionAttemptsCounter => "Total connection attempts",
+		P2pConnectionSuccessCounter => "Successful connections",
+		P2pConnectionHandshakeDurationHistogram => "Connection handshake duration in milliseconds",
+		P2pConnectionTotalDurationHistogram => "Total connection duration in milliseconds",
+		P2pMisbehaviorCounter => "Total misbehaviors",
+		P2pMisbehaviorInvalidDataCounter => "Misbehaviors due to invalid data",
+		P2pMisbehaviorTimeoutBlockDownloadCounter => "Misbehaviors due to block download timeout",
+		_ => "",
+	};
+
+	public static string GetUnit(string metricName) => metricName switch
+	{
+		P2pConnectionHandshakeDurationHistogram => "ms",
+		P2pConnectionTotalDurationHistogram => "ms",
+		_ => "",
+	};
+}

--- a/WalletWasabi/Services/NodesManagement/P2pConnectionManager.cs
+++ b/WalletWasabi/Services/NodesManagement/P2pConnectionManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -13,6 +14,7 @@ using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
+using WalletWasabi.Observability;
 using static WalletWasabi.Services.Workers;
 
 namespace WalletWasabi.Services.NodesManagement;
@@ -86,6 +88,16 @@ public class P2pConnectionManager : IDisposable
 	private static readonly TimeSpan CrawlerConnectionTimeout = TimeSpan.FromSeconds(10);
 	private static readonly TimeSpan CrawlerHarvestTimeout = TimeSpan.FromSeconds(3);
 
+	private readonly Meter _meter;
+	private readonly Counter<int> _connectionAttemptsCounter;
+	private readonly Counter<int> _connectionSuccessCounter;
+	private readonly Gauge<int> _connectedNodesGauge;
+	private readonly Histogram<double> _connectionHandshakeDuration;
+	private readonly Histogram<double> _connectionTotalDuration;
+	private readonly Counter<int> _misbehaviorsTotal;
+	private readonly Counter<int> _misbehaviorsInvalidData;
+	private readonly Counter<int> _misbehaviorsTimeoutBlockDownload;
+
 	private readonly Network _network;
 	private readonly List<NodeBehavior> _templateBehaviors = [];
 	private readonly EventBus _eventBus;
@@ -124,6 +136,43 @@ public class P2pConnectionManager : IDisposable
 		_connectionTimeout = connectionTimeout;
 		_crawlerCount = crawlerCount;
 		_torSocks5 = torSocks5;
+
+		_meter = new(MetricManager.P2pMeterName, "1.0.0");
+		_disposables.Add(_meter);
+
+		_connectedNodesGauge = _meter.CreateGauge<int>(
+			Metrics.P2pConnectedCounter,
+			description: Metrics.GetDescription(Metrics.P2pConnectedCounter));
+
+		_connectionAttemptsCounter = _meter.CreateCounter<int>(
+			Metrics.P2pConnectionAttemptsCounter,
+			description: Metrics.GetDescription(Metrics.P2pConnectionAttemptsCounter));
+
+		_connectionSuccessCounter = _meter.CreateCounter<int>(
+			Metrics.P2pConnectionSuccessCounter,
+			description: Metrics.GetDescription(Metrics.P2pConnectionSuccessCounter));
+
+		_connectionHandshakeDuration = _meter.CreateHistogram<double>(
+			Metrics.P2pConnectionHandshakeDurationHistogram,
+			unit: Metrics.GetUnit(Metrics.P2pConnectionHandshakeDurationHistogram),
+			description: Metrics.GetDescription(Metrics.P2pConnectionHandshakeDurationHistogram));
+
+		_connectionTotalDuration = _meter.CreateHistogram<double>(
+			Metrics.P2pConnectionTotalDurationHistogram,
+			unit: Metrics.GetUnit(Metrics.P2pConnectionTotalDurationHistogram),
+			description: Metrics.GetDescription(Metrics.P2pConnectionTotalDurationHistogram));
+
+		_misbehaviorsTotal = _meter.CreateCounter<int>(
+			Metrics.P2pMisbehaviorCounter,
+			description: Metrics.GetDescription(Metrics.P2pMisbehaviorCounter));
+
+		_misbehaviorsInvalidData = _meter.CreateCounter<int>(
+			Metrics.P2pMisbehaviorInvalidDataCounter,
+			description: Metrics.GetDescription(Metrics.P2pMisbehaviorInvalidDataCounter));
+
+		_misbehaviorsTimeoutBlockDownload = _meter.CreateCounter<int>(
+			Metrics.P2pMisbehaviorTimeoutBlockDownloadCounter,
+			description: Metrics.GetDescription(Metrics.P2pMisbehaviorTimeoutBlockDownloadCounter));
 	}
 
 	public ImmutableArray<Node> Nodes => _connectedNodes.Values.Select(x => x.Node).Where(x => x.IsConnected).ToImmutableArray();
@@ -389,6 +438,8 @@ public class P2pConnectionManager : IDisposable
 			return;
 		}
 
+		var start = DateTime.UtcNow;
+
 		try
 		{
 			using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -412,6 +463,7 @@ public class P2pConnectionManager : IDisposable
 					networkCredential: null, streamIsolation: true));
 			}
 
+			_connectionAttemptsCounter.Add(1, new KeyValuePair<string, object?>("peer.endpoint", peerInfo.Endpoint.ToString()));
 			var node = await Node.ConnectAsync(_network, peerInfo.Endpoint, connParams)
 				.ConfigureAwait(false);
 			await node.VersionHandshakeAsync(timeoutCts.Token).ConfigureAwait(false);
@@ -422,10 +474,13 @@ public class P2pConnectionManager : IDisposable
 				return;
 			}
 
+			_connectionHandshakeDuration.Record(DateTime.UtcNow.Subtract(start).TotalMilliseconds);
 			node.Disconnected += OnNodeDisconnected;
 
-			if (_connectedNodes.TryAdd(peerInfo.Endpoint, (node, peerInfo, DateTimeOffset.UtcNow)))
+			if (_connectedNodes.TryAdd(peerInfo.Endpoint, (node, peerInfo, start)))
 			{
+				_connectionSuccessCounter.Add(1, new KeyValuePair<string, object?>("peer.endpoint", peerInfo.Endpoint.ToString()));
+				_connectedNodesGauge.Record(_connectedNodes.Count);
 				Logger.LogDebug($"Connected to peer {peerInfo.Endpoint} (score: {peerInfo.Score:F1}, services: {peerInfo.Services.AsCsv()}). Total connected peers: {_connectedNodes.Count}.");
 				_eventBus.Publish(new P2pNodeAdded(peerInfo.Endpoint, node));
 			}
@@ -466,6 +521,9 @@ public class P2pConnectionManager : IDisposable
 	{
 		if (_connectedNodes.TryRemove(node.Peer.Endpoint, out var removed))
 		{
+			_connectionTotalDuration.Record(DateTime.UtcNow.Subtract(removed.ConnectedAt.DateTime).TotalMilliseconds,
+				new KeyValuePair<string, object?>("peer.endpoint", node.Peer.Endpoint.ToString()));
+
 			node.Disconnected -= OnNodeDisconnected;
 			var connectionDuration = DateTimeOffset.UtcNow - removed.ConnectedAt;
 			Logger.LogDebug($"Peer {node.Peer.Endpoint} (score: {removed.PeerInfo.Score:F1}) disconnected after {connectionDuration.TotalSeconds:F1}s. Total connected peers: {_connectedNodes.Count}.");
@@ -564,8 +622,22 @@ public class P2pConnectionManager : IDisposable
 		_disposables.Dispose();
 	}
 
-	private void ReportMisbehavior(EndPoint endpoint, MisbehaviorType misbehavior) =>
+	private void ReportMisbehavior(EndPoint endpoint, MisbehaviorType misbehavior)
+	{
+		var tag = new KeyValuePair<string, object?>("peer.endpoint", endpoint.ToString());
+		_misbehaviorsTotal.Add(1, tag);
+
+		if (misbehavior == MisbehaviorType.ProvidedInvalidData)
+		{
+			_misbehaviorsInvalidData.Add(1, tag);
+		}
+		else if (misbehavior == MisbehaviorType.TimedOutDownloadingBlock)
+		{
+			_misbehaviorsTimeoutBlockDownload.Add(1, tag);
+		}
+
 		_discoveryCoordinator?.Post(new NodeMisbehaveMessage(endpoint, misbehavior));
+	}
 
 	#region Discovery
 

--- a/WalletWasabi/Services/NodesManagement/P2pConnectionManager.cs
+++ b/WalletWasabi/Services/NodesManagement/P2pConnectionManager.cs
@@ -31,6 +31,11 @@ public record P2pNodeClient(
 			using var lts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken);
 			var block = await Node.DownloadBlockAsync(blockHash, lts.Token).ConfigureAwait(false);
 
+			if (block is null)
+			{
+				return null;
+			}
+
 			// Validate block
 			if (!block.Check())
 			{
@@ -42,21 +47,23 @@ public record P2pNodeClient(
 			IncreaseTimeout(-1);
 			return block;
 		}
-		catch (Exception ex)
+		catch (Exception ex) when (ex is OperationCanceledException or TimeoutException)
 		{
-			if (ex is OperationCanceledException or TimeoutException)
-			{
-				IncreaseTimeout(+1);
-				// It could be a slow connection and not a misbehaving node.
-				Error(P2pConnectionManager.MisbehaviorType.TimedOutDownloadingBlock);
-			}
-			else
-			{
-				Logger.LogDebug(ex);
-				Error(P2pConnectionManager.MisbehaviorType.Unknown);
-			}
-			return null;
+			IncreaseTimeout(+1);
+			// It could be a slow connection and not a misbehaving node.
+			Error(P2pConnectionManager.MisbehaviorType.TimedOutDownloadingBlock);
 		}
+		catch (InvalidOperationException ex)
+		{
+			Logger.LogWarning(ex);
+			Error(P2pConnectionManager.MisbehaviorType.ProvidedInvalidData);
+		}
+		catch (Exception)
+		{
+			// ignored
+		}
+
+		return null;
 	}
 }
 
@@ -210,7 +217,7 @@ public class P2pConnectionManager : IDisposable
 	{
 		while (!cancellationToken.IsCancellationRequested)
 		{
-			var nodes = Nodes;
+			var nodes = Nodes.Where(n => n.CanServeBlocks).ToArray();
 
 			if (nodes.Length == 0)
 			{

--- a/WalletWasabi/Services/NodesManagement/P2pConnectionManager.cs
+++ b/WalletWasabi/Services/NodesManagement/P2pConnectionManager.cs
@@ -76,8 +76,8 @@ public class P2pConnectionManager : IDisposable
 	private static readonly TimeSpan QuickDisconnectThreshold = TimeSpan.FromSeconds(30);
 	private static readonly TimeSpan MaintainInterval = TimeSpan.FromSeconds(6);
 	private static readonly TimeSpan RotateInterval = TimeSpan.FromMinutes(3);
-	private static readonly TimeSpan CrawlerConnectionTimeout = TimeSpan.FromSeconds(60);
-	private static readonly TimeSpan CrawlerHarvestTimeout = TimeSpan.FromSeconds(15);
+	private static readonly TimeSpan CrawlerConnectionTimeout = TimeSpan.FromSeconds(10);
+	private static readonly TimeSpan CrawlerHarvestTimeout = TimeSpan.FromSeconds(3);
 
 	private readonly Network _network;
 	private readonly List<NodeBehavior> _templateBehaviors = [];


### PR DESCRIPTION
### Observability of P2P

This PR adds observability code to `P2pConnectionManager` based on https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection (no new dependency is required). It's an independent modification but I wanted to avoid conflicts. To play with this feature, one can:

#### Demo

After Wasabi is started, you should see tables like the following one in your console:

```
+----------------------------------------------+-------+-------------+
| Metric                                       | Type  | Value       |
+----------------------------------------------+-------+-------------+
| p2p.connected.gauge                          | Last  | 12          |    <- Number of currently connected P2P nodes.
| p2p.connection.attempt.count                 | Count | 57          |    <- Number of all attempted P2P connections
| p2p.connection.success.count                 | Count | 52          |    <- Number of all successful P2P connections  
| p2p.connection.handshake.duration.histogram  | Last  | 452.3391 ms |    <- How long it took to connect to a P2P node (the last time!)
| p2p.connection.total.duration.histogram      | Last  | 382.9638 ms |    <- How long was a last disconnected P2P node connected to Wasabi
| p2p.misbehavior.count                        | Count | 18          |    <- Number of all misbehaviors detected
| p2p.misbehavior.invalid.data.count           | Count | 0           |    <- Number of misbehavior events when "invalid data" was provided
| p2p.misbehavior.timeout.block.download.count | Count | 0           |    <- Number of misbehavior events when block downloading timed out
+----------------------------------------------+-------+-------------+
```

It's a quick and simple view of what's happening. Ultimately, it can be removed / improved / simplified, etc. 

### Using `dotnet-counters`

The more common way is to get observability events / metrics and there is a tool called `dotnet-counters` for that which connects to a running process (`WalletWasabi.Fluent.Desktop` in this case) and collects metric updates.

```bash
# Setup step. Install `dotnet-counters` (https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters)
dotnet tool update -g dotnet-counters

# Run Wasabi using `dotnet run --project WalletWasabi.Fluent.Desktop` and then execute one of the following commands:

# ... to watch metrics in real-time.
dotnet-counters monitor --name WalletWasabi.Fluent.Desktop --counters WalletWasabi.P2P

# ... to store metrics in CSV or in JSON
dotnet-counters collect --name WalletWasabi.Fluent.Desktop --counters WalletWasabi.P2P --format csv --output wasabi.metrics.csv
dotnet-counters collect --name WalletWasabi.Fluent.Desktop --counters WalletWasabi.P2P --format json --output wasabi.metrics.json
```

Output of `dotnet-counters monitor --name WalletWasabi.Fluent.Desktop --counters WalletWasabi.P2P` can look like this:

```
Press p to pause, r to resume, q to quit.
    Status: Running

Name                                                                                                                                                                           Current Value
[WalletWasabi.P2P]
    p2p.connected.gauge                                                                                                                                                                6
    p2p.connection.attempt.count (Count)
        peer.endpoint
        -----------------------------
        [::ffff:108.212.196.109]:8333                                                                                                                                                  1
        [::ffff:146.90.189.86]:8333                                                                                                                                                    1
        [::ffff:194.156.188.249]:8333                                                                                                                                                  1
        [::ffff:209.89.17.16]:8333                                                                                                                                                     1
        [::ffff:45.162.104.219]:8333                                                                                                                                                   1
        [::ffff:72.212.56.23]:8333                                                                                                                                                     1
        [::ffff:77.75.203.88]:8333                                                                                                                                                     1
        [::ffff:99.250.38.152]:8333                                                                                                                                                    1
    p2p.connection.handshake.duration.histogram (ms)
        Percentile
        ----------
        50                                                                                                                                                                           515
        95                                                                                                                                                                           515
        99                                                                                                                                                                           515
    p2p.connection.success.count (Count)
        peer.endpoint
        -----------------------------
        [::ffff:108.212.196.109]:8333                                                                                                                                                  1
        [::ffff:146.90.189.86]:8333                                                                                                                                                    1
        [::ffff:194.156.188.249]:8333                                                                                                                                                  1
        [::ffff:45.162.104.219]:8333                                                                                                                                                   1
        [::ffff:72.212.56.23]:8333                                                                                                                                                     1
        [::ffff:77.75.203.88]:8333                                                                                                                                                     1
        [::ffff:99.250.38.152]:8333                                                                                                                                                    1
    p2p.connection.total.duration.histogram (ms)
        peer.endpoint               Percentile
        --------------------------- ----------
        [::ffff:146.90.189.86]:8333 50                                                                                                                                             9.200
        [::ffff:146.90.189.86]:8333 95                                                                                                                                             9.200
        [::ffff:146.90.189.86]:8333 99                                                                                                                                             9.200
```

Output of `dotnet-counters collect --name WalletWasabi.Fluent.Desktop --counters WalletWasabi.P2P --format csv --output wasabi.metrics.csv` can look like this:

```
Timestamp,Provider,Counter Name,Counter Type,Mean/Increment
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:45.162.104.219]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:209.89.17.16]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:99.250.38.152]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:108.212.196.109]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:72.212.56.23]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connected.gauge,Metric,5
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:45.162.104.219]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:35.229.123.111]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:146.90.189.86]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:209.89.17.16]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:99.250.38.152]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:108.212.196.109]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:72.212.56.23]:8333],Rate,1
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.handshake.duration.histogram (ms)[Percentile=50],Metric,608
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.handshake.duration.histogram (ms)[Percentile=95],Metric,657
06/23/2026 06:13:34,WalletWasabi.P2P,p2p.connection.handshake.duration.histogram (ms)[Percentile=99],Metric,657
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:45.162.104.219]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:209.89.17.16]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:99.250.38.152]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:108.212.196.109]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:72.212.56.23]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connected.gauge,Metric,5
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:45.162.104.219]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:35.229.123.111]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:146.90.189.86]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:209.89.17.16]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:99.250.38.152]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:108.212.196.109]:8333],Rate,0
06/23/2026 06:13:35,WalletWasabi.P2P,p2p.connection.attempt.count (Count / 1 sec)[peer.endpoint=[::ffff:72.212.56.23]:8333],Rate,0
06/23/2026 06:13:36,WalletWasabi.P2P,p2p.connection.success.count (Count / 1 sec)[peer.endpoint=[::ffff:45.162.104.219]:8333],Rate,0
```

The goal of this changes is to understand P2P behavior more in depth. To see what really happens there. Logs are helpful but at some point it's useful to see data aggregated. 

**For clarity, the feature is meant for developers or power-users to improve Wasabi. If this PR is to be merged at some point, it does not mean that user data will be shared with anyone.** 

There are questions:

1. Does it make sense to add observability code to Wasabi?
2. Should P2P be tracked like this? 
3. Is it merge worthy, or useful just as temporary code?
