### PR TITLE
Update release scripts for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           name: packages-zip-dmg
           path: ./packages
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.SIGNING_PGP_KEY }}
           passphrase: ${{ secrets.SIGNING_PGP_PASSPHRASE }}
@@ -148,7 +148,7 @@ jobs:
       - name: Create release note
         run: bash -x ./Contrib/release.sh releasenote > ReleaseNote.md
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: Wasabi Wallet ${{ github.ref_name }}
           files: ./packages/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'  # Triggers on tags that start with 'v'
+  workflow_dispatch:  # Allows manual triggering from GitHub UI
 
 jobs:
   debian-package-and-zips:
@@ -49,11 +50,8 @@ jobs:
         choco install wixtoolset --version=3.14.1 --force
         choco install 7zip.commandline
 
-    - name: Install Windows SDK
-      run: choco install windows-sdk-10.1
-
-    - name: Install Trusted Signing Tools
-      run: choco install trusted-signing-client-tools -y --force --version=1.0.0
+    - name: Install AzureSignTool
+      run: dotnet tool install --global AzureSignTool
 
     - name: Build Windows Installer
       shell: bash
@@ -61,9 +59,9 @@ jobs:
         set -x
         ./Contrib/release.sh wininstaller
       env:
-        AZURE_TENANT_ID: ${{ secrets.AZURE_TS_TENANT_ID }}
-        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_TS_SECRET }}
-        AZURE_CLIENT_ID: ${{ secrets.AZURE_TS_APP_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
 
     - name: Upload windows installer
       uses: actions/upload-artifact@v4

--- a/Contrib/release.sh
+++ b/Contrib/release.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#!nix-shell -i bash -p zip dpkg
 
 #------------------------------------------------------------------------------------#
 #  release.sh                                                                        #
@@ -372,19 +373,17 @@ mkdir -p "$BUILD_INSTALLER_DIR"
 # Remove unwanted file
 rm $PACKAGES_DIR/*.wixpdb
 
-  # Define paths (using your existing variables)
-  SIGNTOOL="C:/Program Files (x86)/Windows Kits/10/bin/10.0.26100.0/x64/signtool.exe"
+# Define paths (using your existing variables)
+SIGNTOOL="azuresigntool"
 
-  METADATA=metadata.json
-  echo '
-  {
-    "Endpoint": "https://eus.codesigning.azure.net",
-    "CodeSigningAccountName": "WasabiWallet",
-    "CertificateProfileName": "WasabiWallet"
-  }' > $METADATA
-
-  DLIB="$APPDATA/../Local/Microsoft/MicrosoftTrustedSigningClientTools/Azure.CodeSigning.Dlib.dll"
-  "$SIGNTOOL" Sign -v -debug -tr 'http://timestamp.digicert.com' -d "Wasabi Wallet" -fd SHA256 -td SHA256 -dlib "$DLIB" -dmdf "$METADATA"  "$PACKAGES_DIR/$PACKAGE_FILE_NAME_PREFIX.msi"
+"$SIGNTOOL" sign \
+    -kvu "https://wasabiwallet.vault.azure.net/" \
+    -kvc "WasabiCodeSignCert" \
+    -kvi "$AZURE_CLIENT_ID" \
+    -kvs "$AZURE_CLIENT_SECRET" \
+    --azure-key-vault-tenant-id "$AZURE_TENANT_ID" \
+    -tr "http://timestamp.digicert.com" \
+    "$PACKAGES_DIR/$PACKAGE_FILE_NAME_PREFIX.msi"
 fi
 
 #------------------------------------------------------------------------------------#


### PR DESCRIPTION
Wasabi was using Azure Trusted Signing feature which currently limits public identity validation for individual developers exclusively to the USA and Canada and for organizations to the US, Canada, EU and UK. For that reason Azure Key Vault paired with a third-party Certificate Authority is used from now.
