### PR TITLE
`CoinJoinManager`: Convert `async` methods to sync [8/n]

### DIFF
--- a/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
@@ -509,7 +509,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 
 		AssertWalletIsLoaded();
 
-		coinJoinManager.RequestCoinJoinStopAsync(activeWallet).ConfigureAwait(false);
+		coinJoinManager.RequestCoinJoinStop(activeWallet);
 	}
 
 	[JsonRpcMethod("getfeerates", initializable: false)]

--- a/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
@@ -468,7 +468,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 
 		AssertWalletIsLoaded();
 		AssertWalletIsLoggedIn(activeWallet, password ?? "");
-		coinJoinManager.RequestCoinJoinStartAsync(activeWallet, activeWallet, stopWhenAllMixed, overridePlebStop).ConfigureAwait(false);
+		coinJoinManager.RequestCoinJoinStart(activeWallet, activeWallet, stopWhenAllMixed, overridePlebStop);
 	}
 
 	[JsonRpcMethod("startcoinjoinsweep")]
@@ -498,7 +498,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 			await Global.WalletManager.StartWalletAsync(outputWallet).ConfigureAwait(false);
 		}
 
-		await coinJoinManager.RequestCoinJoinStartAsync(activeWallet, outputWallet, stopWhenAllMixed: false, overridePlebStop: true).ConfigureAwait(false);
+		coinJoinManager.RequestCoinJoinStart(activeWallet, outputWallet, stopWhenAllMixed: false, overridePlebStop: true);
 	}
 
 	[JsonRpcMethod("stopcoinjoin")]

--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
@@ -95,6 +95,6 @@ public partial class WalletCoinjoinModel : ReactiveObject
 
 	public async Task StopAsync()
 	{
-		await _coinJoinManager.RequestCoinJoinStopAsync(_wallet);
+		_coinJoinManager.RequestCoinJoinStop(_wallet);
 	}
 }

--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
@@ -90,7 +90,7 @@ public partial class WalletCoinjoinModel : ReactiveObject
 	{
 		Wallet outputWallet = _services.GetWallets().First(x => x.WalletId == _settings.OutputWalletId);
 
-		await _coinJoinManager.RequestCoinJoinStartAsync(_wallet, outputWallet, stopWhenAllMixed, overridePlebStop);
+		_coinJoinManager.RequestCoinJoinStart(_wallet, outputWallet, stopWhenAllMixed, overridePlebStop);
 	}
 
 	public async Task StopAsync()

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -74,7 +74,8 @@ public class CoinJoinManager : BackgroundService
 
 	public async Task RequestCoinJoinStartAsync(Wallet wallet, Wallet outputWallet, bool stopWhenAllMixed, bool overridePlebStop)
 	{
-		var coinCandidates = (GetCoinSelection(wallet)).CandidateCoins;
+		var coinSelectionResult = GetCoinSelection(wallet);
+		var coinCandidates = coinSelectionResult.CandidateCoins;
 
 		if (overridePlebStop && !IsUnderPlebStop(coinCandidates, wallet.PlebStopThreshold))
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -281,7 +281,7 @@ public class CoinJoinManager : BackgroundService
 
 	private async Task<CoinSelectionResult> GetCoinSelectionAsync(Wallet wallet)
 	{
-		var coinCandidates = new CoinsView(await wallet.GetCoinjoinCoinCandidatesAsync().ConfigureAwait(false))
+		var coinCandidates = new CoinsView(wallet.GetCoinjoinCoinCandidates())
 			.Available()
 			.Where(x => !_coinRefrigerator.IsFrozen(x))
 			.ToArray();

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -88,7 +88,7 @@ public class CoinJoinManager : BackgroundService
 		_mailboxProcessor.Post(command);
 	}
 
-	public async Task RequestCoinJoinStopAsync(Wallet wallet)
+	public void RequestCoinJoinStop(Wallet wallet)
 	{
 		_mailboxProcessor.Post(new StopCoinJoinCommand(wallet));
 	}
@@ -738,7 +738,7 @@ public class CoinJoinManager : BackgroundService
 			_state.WalletsBlockedByUi[wallet.WalletId] = new UiBlockedStateHolder(NeedRestart: true, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop, stateHolder.OutputWallet);
 		}
 
-		await RequestCoinJoinStopAsync(wallet).ConfigureAwait(false);
+		RequestCoinJoinStop(wallet);
 	}
 
 	public async Task SignalToStopCoinjoinsAsync()
@@ -751,7 +751,7 @@ public class CoinJoinManager : BackgroundService
 				{
 					_state.WalletsBlockedByUi[wallet.WalletId] = new UiBlockedStateHolder(true, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop, stateHolder.OutputWallet);
 				}
-				await RequestCoinJoinStopAsync(wallet).ConfigureAwait(false);
+				RequestCoinJoinStop(wallet);
 			}
 		}
 	}

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -72,7 +72,7 @@ public class CoinJoinManager : BackgroundService
 
 	#region Public API (Start | Stop | TryGetWalletStatus)
 
-	public async Task RequestCoinJoinStartAsync(Wallet wallet, Wallet outputWallet, bool stopWhenAllMixed, bool overridePlebStop)
+	public void RequestCoinJoinStart(Wallet wallet, Wallet outputWallet, bool stopWhenAllMixed, bool overridePlebStop)
 	{
 		var coinSelectionResult = GetCoinSelection(wallet);
 		var coinCandidates = coinSelectionResult.CandidateCoins;
@@ -410,7 +410,7 @@ public class CoinJoinManager : BackgroundService
 
 				if (trackedAutoStarts.TryRemove(walletToStart.WalletId, out _))
 				{
-					await RequestCoinJoinStartAsync(walletToStart, outputWallet, stopWhenAllMixed, overridePlebStop).ConfigureAwait(false);
+					RequestCoinJoinStart(walletToStart, outputWallet, stopWhenAllMixed, overridePlebStop);
 				}
 				else
 				{
@@ -714,7 +714,7 @@ public class CoinJoinManager : BackgroundService
 
 		if (stateHolder.NeedRestart)
 		{
-			Task.Run(async () => await RequestCoinJoinStartAsync(wallet, stateHolder.OutputWallet, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop).ConfigureAwait(false));
+			Task.Run(async () => RequestCoinJoinStart(wallet, stateHolder.OutputWallet, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop));
 		}
 	}
 
@@ -762,7 +762,7 @@ public class CoinJoinManager : BackgroundService
 		{
 			if (_state.WalletsBlockedByUi.TryRemove(wallet.WalletId, out var stateHolder) && stateHolder.NeedRestart)
 			{
-				await RequestCoinJoinStartAsync(wallet, stateHolder.OutputWallet, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop).ConfigureAwait(false);
+				RequestCoinJoinStart(wallet, stateHolder.OutputWallet, stateHolder.StopWhenAllMixed, stateHolder.OverridePlebStop);
 			}
 		}
 	}

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -74,7 +74,7 @@ public class CoinJoinManager : BackgroundService
 
 	public async Task RequestCoinJoinStartAsync(Wallet wallet, Wallet outputWallet, bool stopWhenAllMixed, bool overridePlebStop)
 	{
-		var coinCandidates = (await GetCoinSelectionAsync(wallet).ConfigureAwait(false)).CandidateCoins;
+		var coinCandidates = (GetCoinSelection(wallet)).CandidateCoins;
 
 		if (overridePlebStop && !IsUnderPlebStop(coinCandidates, wallet.PlebStopThreshold))
 		{
@@ -279,7 +279,7 @@ public class CoinJoinManager : BackgroundService
 		public CoinSelectionResult() : this([], [], [], [], []) { }
 	}
 
-	private async Task<CoinSelectionResult> GetCoinSelectionAsync(Wallet wallet)
+	private CoinSelectionResult GetCoinSelection(Wallet wallet)
 	{
 		var coinCandidates = new CoinsView(wallet.GetCoinjoinCoinCandidates())
 			.Available()
@@ -315,7 +315,7 @@ public class CoinJoinManager : BackgroundService
 
 	private async Task<CoinSelectionResult> SelectCandidateCoinsAsync(Wallet wallet)
 	{
-		var result = await GetCoinSelectionAsync(wallet).ConfigureAwait(false);
+		var result = GetCoinSelection(wallet);
 
 		if (result.CandidateCoins.Length > 0)
 		{

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/LiquidityClueProvider.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/LiquidityClueProvider.cs
@@ -36,7 +36,7 @@ public class LiquidityClueProvider
 
 	public async Task InitLiquidityClueAsync(Wallet wallet)
 	{
-		var transactions = await wallet.GetTransactionsAsync().ConfigureAwait(false);
+		var transactions = wallet.GetTransactions();
 		if (transactions.LastOrDefault(x => x.IsOwnCoinjoin()) is { } lastCoinJoin)
 		{
 			InitLiquidityClue(lastCoinJoin.Transaction, lastCoinJoin.WalletOutputs.Select(x => x.TxOut));

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -124,8 +124,6 @@ public class Wallet : BackgroundService
 
 	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync() => Task.FromResult(GetTransactions());
 
-	public Task<IEnumerable<SmartCoin>> GetCoinjoinCoinCandidatesAsync() => Task.FromResult(GetCoinjoinCoinCandidates());
-
 	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates() => Coins;
 
 	/// <summary>

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -122,8 +122,6 @@ public class Wallet : BackgroundService
 
 	public bool IsWalletPrivate() => GetPrivacyPercentage() >= 100;
 
-	public Task<IEnumerable<SmartTransaction>> GetTransactionsAsync() => Task.FromResult(GetTransactions());
-
 	public IEnumerable<SmartCoin> GetCoinjoinCoinCandidates() => Coins;
 
 	/// <summary>


### PR DESCRIPTION
Fixes #14111 (see https://github.com/WalletWasabi/WalletWasabi/pull/14709#pullrequestreview-4583460985)

Easy to review by checking individual commits.

This PR is a refactoring that comes from me trying to figure out why #14111 happens and converting `async` methods to synchronous versions to simplify code. I can only speculate why it appears to fix #14111.

I ran `regtest-coinjoin-test.sh` for this PR and it succeeded.