### PR TITLE
fix: only use Tor RPCClient for .onion addresses

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -318,12 +318,10 @@ public class Global
 			return null;
 		}
 
-		// If the RPC URI is not a loopback (i.e., not localhost), then route through Tor
-		var isBitcoinRpcLocal = new Uri(bitcoinRpcUri).IsLoopback;
-		if (!isBitcoinRpcLocal)
+		// Use Tor only if the address ends with .onion
+		if (new Uri(bitcoinRpcUri).DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase))
 		{
 			internalRpcClient.HttpClient = ExternalSourcesHttpClientFactory.CreateClient("long-live-rpc-connection");
-			internalRpcClient.HttpClient.Timeout = TimeSpan.FromMinutes(0.5);
 		}
 
 		return new RpcClientBase(internalRpcClient);

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -318,7 +318,7 @@ public class Global
 			return null;
 		}
 
-		// Use Tor only if the address ends with .onion
+		// Use Tor only if the address ends with .onion. Especially, do not use Tor for loopback (i.e. `localhost`).
 		if (new Uri(bitcoinRpcUri).DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase))
 		{
 			internalRpcClient.HttpClient = ExternalSourcesHttpClientFactory.CreateClient("long-live-rpc-connection");

--- a/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Settings/BitcoinTabSettingsViewModel.cs
@@ -155,7 +155,7 @@ public partial class BitcoinTabSettingsViewModel : RoutableViewModel
 
 			// Create RPC client
 			var rpcClient = new RPCClient(credentials, BitcoinRpcUri, Settings.Network);
-			if (new Uri(BitcoinRpcUri).DnsSafeHost.EndsWith(".onion"))
+			if (new Uri(BitcoinRpcUri).DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase))
 			{
 				if (Settings.UseTor != TorMode.Disabled)
 				{


### PR DESCRIPTION
fixes https://github.com/orgs/WalletWasabi/discussions/14663#discussioncomment-17375220

This restores the logic of registering the RPCClient as it is in 2.7.2 (https://github.com/WalletWasabi/WalletWasabi/blob/v2.7.2/WalletWasabi.Daemon/Global.cs#L203) and aligns it with the connection check in 'BitcoinTabSettingsViewModel.cs'

- Also added StringComparison.OrdinalIgnoreCase 
- Removed the custom timeout (30 seconds on Tor is quite low, 100 seconds is HttpClient default)

The only 'downside' is that clearnet domain names now skip Tor, but it is very uncommon (and discouraged) to expose bitcoind RPC over clearnet anyway, and this is how it worked in current/previous versions.

relevant PRs:

https://github.com/WalletWasabi/WalletWasabi/pull/14443/changes
https://github.com/WalletWasabi/WalletWasabi/pull/14447/changes - fixes https://github.com/WalletWasabi/WalletWasabi/pull/14443 for localhost