### PR TITLE
UX: Show TXID(s) at the top of transaction details

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
@@ -15,15 +15,6 @@
                  EnableCancel="{Binding EnableCancel}">
     <StackPanel Spacing="15">
 
-      <!-- Date -->
-      <PreviewItem Icon="{StaticResource timer_regular}"
-                     Label="Date"
-                     CopyableContent="{Binding Date}">
-        <TextBlock Text="{Binding Date}" />
-      </PreviewItem>
-
-      <Separator />
-
       <!-- Transaction IDs -->
       <PreviewItem Icon="{StaticResource transaction_id}"
                      Label="Transaction ID"
@@ -31,6 +22,15 @@
         <PrivacyContentControl>
           <TextBlock Text="{Binding TransactionId}" Classes="monoSpaced" />
         </PrivacyContentControl>
+      </PreviewItem>
+
+      <Separator />
+
+      <!-- Date -->
+      <PreviewItem Icon="{StaticResource timer_regular}"
+                     Label="Date"
+                     CopyableContent="{Binding Date}">
+        <TextBlock Text="{Binding Date}" />
       </PreviewItem>
 
       <Separator />
@@ -96,15 +96,14 @@
         </PrivacyContentControl>
       </PreviewItem>
 
-      <Separator />
+      <Separator IsVisible="{Binding IsConfirmationTimeVisible}" />
+      
       <!-- Hex -->
       <PreviewItem Icon="{StaticResource binary_file}"
                    Label="Hex"
                    CopyableContent="{Binding TransactionHex}">
         <TextBlock Text="Copy" />
       </PreviewItem>
-
-      <Separator IsVisible="{Binding IsConfirmationTimeVisible}" />
     </StackPanel>
   </ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
@@ -97,7 +97,7 @@
       </PreviewItem>
 
       <Separator IsVisible="{Binding IsConfirmationTimeVisible}" />
-      
+
       <!-- Hex -->
       <PreviewItem Icon="{StaticResource binary_file}"
                    Label="Hex"

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinsDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinsDetailsView.axaml
@@ -15,10 +15,28 @@
                  EnableCancel="{Binding EnableCancel}">
     <StackPanel Spacing="15">
 
+      <!-- Transaction IDs -->
+      <PreviewItem Icon="{StaticResource transaction_id}"
+                   Label="Transaction IDs">
+        <ItemsControl ItemsSource="{Binding TransactionIds}">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+              <PreviewItem CopyableContent="{Binding }">
+                <PrivacyContentControl>
+                  <TextBlock Text="{Binding }" Classes="monoSpaced" />
+                </PrivacyContentControl>
+              </PreviewItem>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </PreviewItem>
+
+      <Separator />
+
       <!-- Date -->
       <PreviewItem Icon="{StaticResource timer_regular}"
-                     Label="Date"
-                     CopyableContent="{Binding Date}">
+                   Label="Date"
+                   CopyableContent="{Binding Date}">
         <TextBlock Text="{Binding Date}" />
       </PreviewItem>
 
@@ -26,7 +44,7 @@
 
       <!-- Status -->
       <PreviewItem Icon="{StaticResource status_regular}"
-                     Label="Status">
+                   Label="Status">
         <TextBlock Text="{Binding Status}" />
       </PreviewItem>
 
@@ -34,8 +52,8 @@
 
       <!-- TX Count  -->
       <PreviewItem Icon="{StaticResource info_regular}"
-                     Label="Number of transactions"
-                     CopyableContent="{Binding TxCount}">
+                   Label="Number of transactions"
+                   CopyableContent="{Binding TxCount}">
         <TextBlock Text="{Binding TxCount, Mode=OneWay}" />
       </PreviewItem>
 
@@ -55,6 +73,7 @@
           </StackPanel>
         </Grid>
       </DockPanel>
+      
       <Separator />
 
       <!-- CJ fee  -->
@@ -66,34 +85,16 @@
         </PrivacyContentControl>
       </PreviewItem>
 
-      <Separator />
+      <Separator IsVisible="{Binding IsConfirmationTimeVisible}" />
 
       <!-- Confirmation Time -->
       <PreviewItem IsVisible="{Binding IsConfirmationTimeVisible}"
-                     Icon="{StaticResource timer_regular}"
-                     Label="Expected confirmation time"
-                     ToolTip.Tip="This is just an estimation based on some data for transactions and blocks. The confirmation time might change.">
+                   Icon="{StaticResource timer_regular}"
+                   Label="Expected confirmation time"
+                   ToolTip.Tip="This is just an estimation based on some data for transactions and blocks. The confirmation time might change.">
         <PrivacyContentControl>
           <TextBlock Text="{Binding ConfirmationTime, Converter={x:Static conv:TimeSpanConverter.ToEstimatedConfirmationTime}}" Classes="monoSpaced" />
         </PrivacyContentControl>
-      </PreviewItem>
-
-      <Separator IsVisible="{Binding IsConfirmationTimeVisible}" />
-
-      <!-- Transaction IDs -->
-      <PreviewItem Icon="{StaticResource transaction_id}"
-                     Label="Transaction IDs">
-        <ItemsControl ItemsSource="{Binding TransactionIds}">
-          <ItemsControl.ItemTemplate>
-            <DataTemplate>
-              <PreviewItem CopyableContent="{Binding }">
-                <PrivacyContentControl>
-                  <TextBlock Text="{Binding }" Classes="monoSpaced" />
-                </PrivacyContentControl>
-              </PreviewItem>
-            </DataTemplate>
-          </ItemsControl.ItemTemplate>
-        </ItemsControl>
       </PreviewItem>
     </StackPanel>
   </ContentArea>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinsDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinsDetailsView.axaml
@@ -35,8 +35,8 @@
 
       <!-- Date -->
       <PreviewItem Icon="{StaticResource timer_regular}"
-                   Label="Date"
-                   CopyableContent="{Binding Date}">
+                     Label="Date"
+                     CopyableContent="{Binding Date}">
         <TextBlock Text="{Binding Date}" />
       </PreviewItem>
 
@@ -44,7 +44,7 @@
 
       <!-- Status -->
       <PreviewItem Icon="{StaticResource status_regular}"
-                   Label="Status">
+                     Label="Status">
         <TextBlock Text="{Binding Status}" />
       </PreviewItem>
 
@@ -52,8 +52,8 @@
 
       <!-- TX Count  -->
       <PreviewItem Icon="{StaticResource info_regular}"
-                   Label="Number of transactions"
-                   CopyableContent="{Binding TxCount}">
+                     Label="Number of transactions"
+                     CopyableContent="{Binding TxCount}">
         <TextBlock Text="{Binding TxCount, Mode=OneWay}" />
       </PreviewItem>
 
@@ -89,9 +89,9 @@
 
       <!-- Confirmation Time -->
       <PreviewItem IsVisible="{Binding IsConfirmationTimeVisible}"
-                   Icon="{StaticResource timer_regular}"
-                   Label="Expected confirmation time"
-                   ToolTip.Tip="This is just an estimation based on some data for transactions and blocks. The confirmation time might change.">
+                     Icon="{StaticResource timer_regular}"
+                     Label="Expected confirmation time"
+                     ToolTip.Tip="This is just an estimation based on some data for transactions and blocks. The confirmation time might change.">
         <PrivacyContentControl>
           <TextBlock Text="{Binding ConfirmationTime, Converter={x:Static conv:TimeSpanConverter.ToEstimatedConfirmationTime}}" Classes="monoSpaced" />
         </PrivacyContentControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -11,15 +11,26 @@
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Home.History.Details.TransactionDetailsView">
   <ContentArea Title="{Binding Title}"
-                 NextContent="Done" EnableNext="True"
-                 EnableCancel="{Binding EnableCancel}">
+               NextContent="Done" EnableNext="True"
+               EnableCancel="{Binding EnableCancel}">
 
     <StackPanel Spacing="15">
 
+      <!-- Transaction ID -->
+      <PreviewItem Icon="{StaticResource transaction_id}"
+                   Label="Transaction ID"
+                   CopyableContent="{Binding TransactionId}">
+        <PrivacyContentControl>
+          <TextBlock Text="{Binding TransactionId}" Classes="monoSpaced" />
+        </PrivacyContentControl>
+      </PreviewItem>
+
+      <Separator />
+
       <!-- Date -->
       <PreviewItem Icon="{StaticResource timer_regular}"
-                     Label="Date / Time"
-                     CopyableContent="{Binding DateString, Mode=OneWay}">
+                   Label="Date / Time"
+                   CopyableContent="{Binding DateString, Mode=OneWay}">
         <TextBlock Text="{Binding DateString, Mode=OneWay}" Classes="monoSpaced" />
       </PreviewItem>
 
@@ -27,8 +38,8 @@
 
       <!-- Amount -->
       <PreviewItem Icon="{StaticResource btc_logo}"
-                     Label="{Binding AmountText}"
-                     CopyableContent="{Binding Amount.Btc}">
+                   Label="{Binding AmountText}"
+                   CopyableContent="{Binding Amount.Btc}">
         <PrivacyContentControl>
           <AmountControl Amount="{Binding Amount}" />
         </PrivacyContentControl>
@@ -38,13 +49,13 @@
 
       <!-- Destination Address -->
       <PreviewItem Name="DestinationSection" Icon="{StaticResource transceive_regular}" CopyableContent="{Binding SingleAddress}"
-                     Label="Destination addresses" IsVisible="{Binding !!DestinationAddresses.Count}">
+                   Label="Destination addresses" IsVisible="{Binding !!DestinationAddresses.Count}">
         <ItemsControl ItemsSource="{Binding DestinationAddresses}">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
               <PreviewItem CopyableContent="{Binding}"
-                             IsCopyButtonEnabled="{Binding #DestinationSection.CopyableContent, Converter={x:Static ObjectConverters.IsNull}}"
-                             HorizontalAlignment="Stretch">
+                           IsCopyButtonEnabled="{Binding #DestinationSection.CopyableContent, Converter={x:Static ObjectConverters.IsNull}}"
+                           HorizontalAlignment="Stretch">
                 <PrivacyContentControl>
                   <TextBlock Classes="monoSpaced" Text="{Binding}" />
                 </PrivacyContentControl>
@@ -58,9 +69,9 @@
 
       <!-- Fee -->
       <PreviewItem IsVisible="{Binding IsFeeVisible}"
-                     Icon="{StaticResource paper_cash_regular}"
-                     Label="Fee"
-                     CopyableContent="{Binding Fee.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}">
+                   Icon="{StaticResource paper_cash_regular}"
+                   Label="Fee"
+                   CopyableContent="{Binding Fee.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}">
         <PrivacyContentControl>
           <AmountControl Classes="WithUsd" Amount="{Binding Fee}" />
         </PrivacyContentControl>
@@ -70,9 +81,9 @@
 
       <!-- Fee Rate-->
       <PreviewItem IsVisible="{Binding IsFeeRateVisible}"
-                     Icon="{StaticResource paper_cash_regular}"
-                     Label="Fee Rate"
-                     CopyableContent="{Binding FeeRate.SatoshiPerByte}">
+                   Icon="{StaticResource paper_cash_regular}"
+                   Label="Fee Rate"
+                   CopyableContent="{Binding FeeRate.SatoshiPerByte}">
         <PrivacyContentControl>
           <TextBlock Text="{Binding FeeRate.SatoshiPerByte, Converter={x:Static conv:FeeRateConverters.FeeRateConverter}}"/>
         </PrivacyContentControl>
@@ -82,7 +93,7 @@
 
       <!-- Status -->
       <PreviewItem Icon="{StaticResource copy_confirmed}"
-                     Label="Status">
+                   Label="Status">
         <StackPanel Orientation="Horizontal">
           <Panel>
             <TextBlock Text="Confirmed" IsVisible="{Binding IsConfirmed}" />
@@ -96,24 +107,15 @@
 
       <!-- Confirmation Time -->
       <PreviewItem IsVisible="{Binding IsConfirmationTimeVisible}"
-                     Icon="{StaticResource timer_regular}"
-                     Label="Expected confirmation time"
-                     ToolTip.Tip="This is just an estimation based on some data for transactions and blocks. The confirmation time might change.">
+                   Icon="{StaticResource timer_regular}"
+                   Label="Expected confirmation time"
+                   ToolTip.Tip="This is just an estimation based on some data for transactions and blocks. The confirmation time might change.">
         <PrivacyContentControl>
           <TextBlock Text="{Binding ConfirmationTime, Converter={x:Static conv:TimeSpanConverter.ToEstimatedConfirmationTime}}" Classes="monoSpaced" />
         </PrivacyContentControl>
       </PreviewItem>
 
       <Separator IsVisible="{Binding IsConfirmationTimeVisible}" />
-
-      <!-- Transaction ID -->
-      <PreviewItem Icon="{StaticResource transaction_id}"
-                     Label="Transaction ID"
-                     CopyableContent="{Binding TransactionId}">
-        <PrivacyContentControl>
-          <TextBlock Text="{Binding TransactionId}" Classes="monoSpaced" />
-        </PrivacyContentControl>
-      </PreviewItem>
 
       <!-- Inputs/Outputs -->
       <Separator />
@@ -135,18 +137,18 @@
 
       <!-- Block height -->
       <PreviewItem Icon="{StaticResource block_height}"
-                     Label="Block height"
-                     CopyableContent="{Binding BlockHeight}"
-                     IsVisible="{Binding IsConfirmed}">
+                   Label="Block height"
+                   CopyableContent="{Binding BlockHeight}"
+                   IsVisible="{Binding IsConfirmed}">
         <TextBlock Text="{Binding BlockHeight}" />
       </PreviewItem>
 
       <!-- Labels -->
       <Separator IsVisible="{Binding IsLabelsVisible}" />
       <PreviewItem IsVisible="{Binding IsLabelsVisible}"
-                     Icon="{StaticResource entities_regular}"
-                     Label="Labels"
-                     CopyableContent="{Binding Labels}">
+                   Icon="{StaticResource entities_regular}"
+                   Label="Labels"
+                   CopyableContent="{Binding Labels}">
         <PrivacyContentControl VerticalContentAlignment="Center">
           <LabelsItemsPresenter ItemsSource="{Binding Labels}" />
         </PrivacyContentControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -11,8 +11,8 @@
              x:CompileBindings="True"
              x:Class="WalletWasabi.Fluent.Views.Wallets.Home.History.Details.TransactionDetailsView">
   <ContentArea Title="{Binding Title}"
-               NextContent="Done" EnableNext="True"
-               EnableCancel="{Binding EnableCancel}">
+                 NextContent="Done" EnableNext="True"
+                 EnableCancel="{Binding EnableCancel}">
 
     <StackPanel Spacing="15">
 
@@ -29,8 +29,8 @@
 
       <!-- Date -->
       <PreviewItem Icon="{StaticResource timer_regular}"
-                   Label="Date / Time"
-                   CopyableContent="{Binding DateString, Mode=OneWay}">
+                     Label="Date / Time"
+                     CopyableContent="{Binding DateString, Mode=OneWay}">
         <TextBlock Text="{Binding DateString, Mode=OneWay}" Classes="monoSpaced" />
       </PreviewItem>
 
@@ -38,8 +38,8 @@
 
       <!-- Amount -->
       <PreviewItem Icon="{StaticResource btc_logo}"
-                   Label="{Binding AmountText}"
-                   CopyableContent="{Binding Amount.Btc}">
+                     Label="{Binding AmountText}"
+                     CopyableContent="{Binding Amount.Btc}">
         <PrivacyContentControl>
           <AmountControl Amount="{Binding Amount}" />
         </PrivacyContentControl>
@@ -49,13 +49,13 @@
 
       <!-- Destination Address -->
       <PreviewItem Name="DestinationSection" Icon="{StaticResource transceive_regular}" CopyableContent="{Binding SingleAddress}"
-                   Label="Destination addresses" IsVisible="{Binding !!DestinationAddresses.Count}">
+                     Label="Destination addresses" IsVisible="{Binding !!DestinationAddresses.Count}">
         <ItemsControl ItemsSource="{Binding DestinationAddresses}">
           <ItemsControl.ItemTemplate>
             <DataTemplate>
               <PreviewItem CopyableContent="{Binding}"
-                           IsCopyButtonEnabled="{Binding #DestinationSection.CopyableContent, Converter={x:Static ObjectConverters.IsNull}}"
-                           HorizontalAlignment="Stretch">
+                             IsCopyButtonEnabled="{Binding #DestinationSection.CopyableContent, Converter={x:Static ObjectConverters.IsNull}}"
+                             HorizontalAlignment="Stretch">
                 <PrivacyContentControl>
                   <TextBlock Classes="monoSpaced" Text="{Binding}" />
                 </PrivacyContentControl>
@@ -69,9 +69,9 @@
 
       <!-- Fee -->
       <PreviewItem IsVisible="{Binding IsFeeVisible}"
-                   Icon="{StaticResource paper_cash_regular}"
-                   Label="Fee"
-                   CopyableContent="{Binding Fee.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}">
+                     Icon="{StaticResource paper_cash_regular}"
+                     Label="Fee"
+                     CopyableContent="{Binding Fee.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}">
         <PrivacyContentControl>
           <AmountControl Classes="WithUsd" Amount="{Binding Fee}" />
         </PrivacyContentControl>
@@ -81,9 +81,9 @@
 
       <!-- Fee Rate-->
       <PreviewItem IsVisible="{Binding IsFeeRateVisible}"
-                   Icon="{StaticResource paper_cash_regular}"
-                   Label="Fee Rate"
-                   CopyableContent="{Binding FeeRate.SatoshiPerByte}">
+                     Icon="{StaticResource paper_cash_regular}"
+                     Label="Fee Rate"
+                     CopyableContent="{Binding FeeRate.SatoshiPerByte}">
         <PrivacyContentControl>
           <TextBlock Text="{Binding FeeRate.SatoshiPerByte, Converter={x:Static conv:FeeRateConverters.FeeRateConverter}}"/>
         </PrivacyContentControl>
@@ -93,7 +93,7 @@
 
       <!-- Status -->
       <PreviewItem Icon="{StaticResource copy_confirmed}"
-                   Label="Status">
+                     Label="Status">
         <StackPanel Orientation="Horizontal">
           <Panel>
             <TextBlock Text="Confirmed" IsVisible="{Binding IsConfirmed}" />
@@ -107,9 +107,9 @@
 
       <!-- Confirmation Time -->
       <PreviewItem IsVisible="{Binding IsConfirmationTimeVisible}"
-                   Icon="{StaticResource timer_regular}"
-                   Label="Expected confirmation time"
-                   ToolTip.Tip="This is just an estimation based on some data for transactions and blocks. The confirmation time might change.">
+                     Icon="{StaticResource timer_regular}"
+                     Label="Expected confirmation time"
+                     ToolTip.Tip="This is just an estimation based on some data for transactions and blocks. The confirmation time might change.">
         <PrivacyContentControl>
           <TextBlock Text="{Binding ConfirmationTime, Converter={x:Static conv:TimeSpanConverter.ToEstimatedConfirmationTime}}" Classes="monoSpaced" />
         </PrivacyContentControl>
@@ -137,18 +137,18 @@
 
       <!-- Block height -->
       <PreviewItem Icon="{StaticResource block_height}"
-                   Label="Block height"
-                   CopyableContent="{Binding BlockHeight}"
-                   IsVisible="{Binding IsConfirmed}">
+                     Label="Block height"
+                     CopyableContent="{Binding BlockHeight}"
+                     IsVisible="{Binding IsConfirmed}">
         <TextBlock Text="{Binding BlockHeight}" />
       </PreviewItem>
 
       <!-- Labels -->
       <Separator IsVisible="{Binding IsLabelsVisible}" />
       <PreviewItem IsVisible="{Binding IsLabelsVisible}"
-                   Icon="{StaticResource entities_regular}"
-                   Label="Labels"
-                   CopyableContent="{Binding Labels}">
+                     Icon="{StaticResource entities_regular}"
+                     Label="Labels"
+                     CopyableContent="{Binding Labels}">
         <PrivacyContentControl VerticalContentAlignment="Center">
           <LabelsItemsPresenter ItemsSource="{Binding Labels}" />
         </PrivacyContentControl>


### PR DESCRIPTION
This PR makes sure that TXID(s) appear first when one clicks on transaction / coinjoin details button in transaction history. 

I find txid the most important piece of information as it is a unique identifier of each bitcoin transaction.