### PR TITLE
Logger: Refactor to create logger once and configuration is allowed only before actual logging

### DIFF
--- a/WalletWasabi.Client/Configuration/Config.cs
+++ b/WalletWasabi.Client/Configuration/Config.cs
@@ -17,18 +17,16 @@ public class Config
 {
 	public static readonly IDictionary EnvironmentVariables = Environment.GetEnvironmentVariables();
 
+#if RELEASE
+	private static readonly LogMode[] DefaultLogModes = [LogMode.Console, LogMode.File];
+#else
+	private static readonly LogMode[] DefaultLogModes = [LogMode.Debug, LogMode.Console, LogMode.File];
+#endif
+
 	public Config(PersistentConfig persistentConfig, string[] cliArgs)
 	{
 		PersistentConfig = persistentConfig;
 		CliArgs = cliArgs;
-
-		LogMode[] defaultLogModes;
-
-#if RELEASE
-		defaultLogModes = [LogMode.Console, LogMode.File];
-#else
-		defaultLogModes = [LogMode.Debug, LogMode.Console, LogMode.File];
-#endif
 
 		Data = new() {
 			[nameof(Network)] = GetNetworkValue("Network", PersistentConfig.Network.ToString(), []),
@@ -50,7 +48,7 @@ public class Config
 			[nameof(DustThreshold)] = GetMoneyValue("DustThreshold", PersistentConfig.DustThreshold, cliArgs),
 			[nameof(BlockOnlyMode)] = GetBoolValue("BlockOnly", value: false, cliArgs),
 			[nameof(LogLevel)] = GetStringValue("LogLevel", value: "", cliArgs),
-			[nameof(LogModes)] = GetLogModeArrayValue("LogModes", arrayValues: defaultLogModes, cliArgs),
+			[nameof(LogModes)] = GetLogModeArrayValue("LogModes", arrayValues: DefaultLogModes, cliArgs),
 			[nameof(EnableGpu)] = GetBoolValue("EnableGpu", PersistentConfig.EnableGpu, cliArgs),
 			[nameof(CoordinatorIdentifier)] = GetStringValue("CoordinatorIdentifier", PersistentConfig.CoordinatorIdentifier, cliArgs),
 			[nameof(MaxCoinjoinMiningFeeRate)] = GetDecimalValue("MaxCoinjoinMiningFeeRate", PersistentConfig.MaxCoinJoinMiningFeeRate, cliArgs),
@@ -65,8 +63,8 @@ public class Config
 		// Check if any config value is overridden (either by an environment value, or by a CLI argument).
 		foreach (string optionName in Data.Keys)
 		{
-			// It is allowed to override the log level.
-			if (!string.Equals(optionName, nameof(LogLevel)) && !string.Equals(optionName, nameof(Network)) )
+			// It is allowed to override the network.
+			if (!string.Equals(optionName, nameof(Network)))
 			{
 				IValue optionValue = Data[optionName];
 
@@ -136,8 +134,6 @@ public class Config
 	public bool RpcOnionEnabled => GetEffectiveValue<bool>(nameof(RpcOnionEnabled));
 	public Money DustThreshold => GetEffectiveValue<Money>(nameof(DustThreshold));
 	public bool BlockOnlyMode => GetEffectiveValue<bool>(nameof(BlockOnlyMode));
-	public string LogLevel => GetEffectiveValue<string>(nameof(LogLevel));
-	public LogMode[] LogModes => GetEffectiveValue<LogMode[]>(nameof(LogModes));
 	public string ExchangeRateProvider => GetEffectiveValue<string>(nameof(ExchangeRateProvider));
 	public string FeeRateEstimationProvider => GetEffectiveValue<string>(nameof(FeeRateEstimationProvider));
 	public string ExternalTransactionBroadcaster => GetEffectiveValue<string>(nameof(ExternalTransactionBroadcaster));
@@ -158,6 +154,9 @@ public class Config
 		"datadir",
 		EnvironmentHelpers.GetDataDir(Path.Combine("WalletWasabi", "Client")),
 		Environment.GetCommandLineArgs()).EffectiveValue;
+
+	public static string LogLevel { get; } = GetStringValue("loglevel", "", Environment.GetCommandLineArgs()).EffectiveValue;
+	public static LogMode[] LogModes { get; } = GetLogModeArrayValue("LogModes", arrayValues: DefaultLogModes, Environment.GetCommandLineArgs()).EffectiveValue;
 
 	/// <summary>Whether a config option was overridden by a command line argument or an environment variable.</summary>
 	/// <remarks>

--- a/WalletWasabi.Client/WasabiApplication.cs
+++ b/WalletWasabi.Client/WasabiApplication.cs
@@ -27,8 +27,8 @@ public class WasabiApplication
 
 		CheckVersionAndHelp();
 		Directory.CreateDirectory(Config.DataDir);
-		Config = new Config(LoadOrCreateConfigs(), wasabiAppBuilder.Arguments);
 		SetupLogger();
+		Config = new Config(LoadOrCreateConfigs(), wasabiAppBuilder.Arguments);
 		Logger.LogDebug($"Wasabi was started with these argument(s): {string.Join(" ", AppConfig.Arguments.DefaultIfEmpty("none"))}.");
 
 		Global = new Global(Config.DataDir, Config);

--- a/WalletWasabi/Helpers/EnvironmentHelpers.cs
+++ b/WalletWasabi/Helpers/EnvironmentHelpers.cs
@@ -34,7 +34,6 @@ public static class EnvironmentHelpers
 			if (!string.IsNullOrEmpty(home))
 			{
 				directory = Path.Combine(home, "." + appName.ToLowerInvariant());
-				Logger.LogInfo($"Using HOME environment variable for initializing application data at `{directory}`.");
 			}
 			else
 			{
@@ -47,7 +46,6 @@ public static class EnvironmentHelpers
 			if (!string.IsNullOrEmpty(localAppData))
 			{
 				directory = Path.Combine(localAppData, appName);
-				Logger.LogInfo($"Using APPDATA environment variable for initializing application data at `{directory}`.");
 			}
 			else
 			{
@@ -61,7 +59,6 @@ public static class EnvironmentHelpers
 			return directory;
 		}
 
-		Logger.LogInfo($"Creating data directory at `{directory}`.");
 		Directory.CreateDirectory(directory);
 
 		DataDirDict.TryAdd(appName, directory);

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -1,10 +1,5 @@
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
-using WalletWasabi.Helpers;
 using WalletWasabi.WabiSabi.Client.CoinJoin.Client;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.Wallets;
@@ -14,197 +9,83 @@ namespace WalletWasabi.Logging;
 
 public static class Logger
 {
-	private static readonly Lock Lock = new();
-	private static LogLevel MinimumLevel { get; set; } = LogLevel.Critical;
-	private static HashSet<LogMode> Modes { get; } = new();
-	public static string FilePath { get; private set; } = "Log.txt";
-	public static string EntrySeparator { get; } = Environment.NewLine;
-	private static long MaximumLogFileSizeBytes { get; set; } = 10_000_000;
-	private static long LogFileSizeBytes { get; set; }
+	private static readonly Lock ConfigLock = new();
 
-	public static void Configure(string filePath, LogLevel? logLevel = null, LogMode[]? logModes = null)
+	private static LogLevel LogLevel = LogLevel.Info;
+	private static LogMode[] LogModes = [LogMode.Console, LogMode.File];
+
+	public static string FilePath
 	{
-		FilePath = filePath;
-		IoHelpers.EnsureContainingDirectoryExists(FilePath);
-
-		lock (Lock)
+		get
 		{
-			if (File.Exists(FilePath))
+			lock (ConfigLock)
 			{
-				LogFileSizeBytes = new FileInfo(FilePath).Length;
-			}
-
-#if RELEASE
-			logLevel ??= LogLevel.Info;
-			logModes ??= [LogMode.Console, LogMode.File];
-#else
-			logLevel ??= LogLevel.Debug;
-			logModes ??= [LogMode.Debug, LogMode.Console, LogMode.File];
-#endif
-
-			MinimumLevel = logLevel.Value;
-
-			Modes.Clear();
-			Modes.UnionWith(logModes);
-
-			if (MinimumLevel == LogLevel.Trace)
-			{
-				MaximumLogFileSizeBytes = 0;
+				return field;
 			}
 		}
-	}
-
-	private static string GetShortNameLevel(LogLevel level) =>
-		level switch
+		private set
 		{
-			LogLevel.Trace => "TRC",
-			LogLevel.Debug => "DBG",
-			LogLevel.Info => "INF",
-			LogLevel.Warning => "WRN",
-			LogLevel.Error => "ERR",
-			LogLevel.Critical => "CRT",
-			_ => throw new ArgumentOutOfRangeException(nameof(level), level, null)
-		};
+			lock (ConfigLock)
+			{
+				field = value;
+			}
+		}
+	} = "Logs.txt";
 
-	private static ConsoleColor GetConsoleColor(LogLevel level) =>
-		level switch
-		{
-			LogLevel.Warning => ConsoleColor.Yellow,
-			LogLevel.Error or LogLevel.Critical => ConsoleColor.Red,
-			_ => Console.ForegroundColor
-		};
+	private static Lazy<LoggerCore> Core { get; } = new(() => new LoggerCore(FilePath, LogLevel, LogModes), isThreadSafe: true);
 
-	private static string FormatCategory(string callerFilePath, int callerLineNumber)
+	/// <summary>
+	/// Configure the logger. Must be called before any logging occurs.
+	/// </summary>
+	public static void Configure(string? filePath = null, LogLevel? logLevel = null, LogMode[]? logModes = null)
 	{
-		if (string.IsNullOrWhiteSpace(callerFilePath))
+		lock (ConfigLock)
 		{
-			return "";
-		}
-
-		var filePath = Path.GetFileName(callerFilePath);
-		var category = $"{filePath}:{callerLineNumber}";
-		return category.Length > 30 ? $"..{category[^28..]}" : category;
-	}
-
-	private static void AppendMessageContent(StringBuilder builder, string message, string category)
-	{
-		if (message.Length == 0 && category.Length == 0)
-		{
-			return;
-		}
-
-		if (category.Length == 0)
-		{
-			builder.Append(message);
-		}
-		else if (message.Length == 0)
-		{
-			builder.Append(category);
-		}
-		else
-		{
-			builder.Append($"{category,-30} | {message}");
-		}
-	}
-
-	private static string ContextToString(object? ctx) =>
-		ctx switch
-		{
-			not null => ctx.ToString()!,
-			_ => ""
-		};
-
-	public static void Log(LogLevel level, string message, object? ctx = null, string callerFilePath = "",
-		int callerLineNumber = -1)
-	{
-		if (Modes.Count == 0)
-		{
-			return;
-		}
-
-		if (level < MinimumLevel)
-		{
-			return;
-		}
-
-		var category = FormatCategory(callerFilePath, callerLineNumber);
-
-		var messageBuilder = new StringBuilder();
-		messageBuilder.Append(
-			$"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff} [{Environment.CurrentManagedThreadId,2}] {GetShortNameLevel(level)} | ");
-
-		AppendMessageContent(messageBuilder, message, category);
-		messageBuilder.Append(EntrySeparator);
-
-		if (ctx is not null)
-		{
-			messageBuilder.AppendLine(ContextToString(ctx));
-		}
-
-		var finalMessage = messageBuilder.ToString();
-
-		var finalFileMessage = messageBuilder.ToString();
-		lock (Lock)
-		{
-			if (Modes.Contains(LogMode.Console))
+			if (Core.IsValueCreated)
 			{
-				lock (Console.Out)
-				{
-					Console.ForegroundColor = GetConsoleColor(level);
-					Console.Write(finalMessage);
-					Console.ResetColor();
-				}
+				throw new InvalidOperationException("Logger has already been initialized and cannot be reconfigured.");
 			}
 
-			if (Modes.Contains(LogMode.Debug))
+			if (logLevel.HasValue)
 			{
-				Debug.Write(finalMessage);
+				LogLevel = logLevel.Value;
 			}
 
-			if (!Modes.Contains(LogMode.File))
+			if (filePath is not null)
 			{
-				return;
+				FilePath = filePath;
 			}
 
-			if (MaximumLogFileSizeBytes > 0)
+			if (logModes is not null)
 			{
-				// Simplification here is that: 1 character ~ 1 byte.
-				LogFileSizeBytes += finalFileMessage.Length;
-
-				if (LogFileSizeBytes > MaximumLogFileSizeBytes)
-				{
-					LogFileSizeBytes = 0;
-					File.Delete(FilePath);
-				}
+				LogModes = logModes;
 			}
-
-			File.AppendAllText(FilePath, finalFileMessage);
 		}
 	}
 
 	public static void LogTrace(string message, object? ctx = null, [CallerFilePath] string callerFilePath = "",
 		[CallerLineNumber] int callerLineNumber = -1) =>
-		Log(LogLevel.Trace, message, ctx, callerFilePath, callerLineNumber);
+		Core.Value.Log(LogLevel.Trace, message, ctx, callerFilePath, callerLineNumber);
 
 	public static void LogDebug(string message, object? ctx = null, [CallerFilePath] string callerFilePath = "",
 		[CallerLineNumber] int callerLineNumber = -1) =>
-		Log(LogLevel.Debug, message, ctx, callerFilePath, callerLineNumber);
+		Core.Value.Log(LogLevel.Debug, message, ctx, callerFilePath, callerLineNumber);
 
 	public static void LogInfo(string message, object? ctx = null, [CallerFilePath] string callerFilePath = "",
 		[CallerLineNumber] int callerLineNumber = -1) =>
-		Log(LogLevel.Info, message, ctx, callerFilePath, callerLineNumber);
+		Core.Value.Log(LogLevel.Info, message, ctx, callerFilePath, callerLineNumber);
 
 	public static void LogWarning(string message, object? ctx = null, [CallerFilePath] string callerFilePath = "",
 		[CallerLineNumber] int callerLineNumber = -1) =>
-		Log(LogLevel.Warning, message, ctx, callerFilePath, callerLineNumber);
+		Core.Value.Log(LogLevel.Warning, message, ctx, callerFilePath, callerLineNumber);
 
 	public static void LogError(string message, object? ctx = null, [CallerFilePath] string callerFilePath = "",
 		[CallerLineNumber] int callerLineNumber = -1) =>
-		Log(LogLevel.Error, message, ctx, callerFilePath, callerLineNumber);
+		Core.Value.Log(LogLevel.Error, message, ctx, callerFilePath, callerLineNumber);
 
 	public static void LogCritical(string message, object? ctx = null, [CallerFilePath] string callerFilePath = "",
 		[CallerLineNumber] int callerLineNumber = -1) =>
-		Log(LogLevel.Critical, message, ctx, callerFilePath, callerLineNumber);
+		Core.Value.Log(LogLevel.Critical, message, ctx, callerFilePath, callerLineNumber);
 
 	public static void LogTrace(Exception exception, [CallerFilePath] string callerFilePath = "",
 		[CallerLineNumber] int callerLineNumber = -1) =>

--- a/WalletWasabi/Logging/LoggerCore.cs
+++ b/WalletWasabi/Logging/LoggerCore.cs
@@ -1,0 +1,164 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using WalletWasabi.Helpers;
+
+namespace WalletWasabi.Logging;
+
+public class LoggerCore
+{
+	private LogLevel MinimumLevel { get; }
+	private ImmutableHashSet<LogMode> Modes { get; }
+	public string FilePath { get; }
+	public string EntrySeparator { get; } = Environment.NewLine;
+
+	/// <summary>Maximum file size of the log file in bytes. 0 means there is no limit.</summary>
+	private long MaximumLogFileSizeBytes { get; }
+
+	/// <summary>Lock for console output, debug info output, file output to prevent concurrent attempts.</summary>
+	private readonly Lock _lock = new();
+
+	/// <summary>Current file size in bytes.</summary>
+	/// <remarks>Guarded by <see cref="_lock"/>.</remarks>
+	private long LogFileSizeBytes { get; set; }
+
+	public LoggerCore(string filePath, LogLevel logLevel, LogMode[] logModes)
+	{
+		FilePath = filePath;
+		MinimumLevel = logLevel;
+		Modes = [.. logModes];
+		MaximumLogFileSizeBytes = MinimumLevel == LogLevel.Trace ? 0 : 10_000_000;
+		LogFileSizeBytes = File.Exists(FilePath) ? new FileInfo(FilePath).Length : 0;
+
+		IoHelpers.EnsureContainingDirectoryExists(FilePath);
+	}
+
+	private string GetShortNameLevel(LogLevel level) =>
+		level switch
+		{
+			LogLevel.Trace => "TRC",
+			LogLevel.Debug => "DBG",
+			LogLevel.Info => "INF",
+			LogLevel.Warning => "WRN",
+			LogLevel.Error => "ERR",
+			LogLevel.Critical => "CRT",
+			_ => throw new ArgumentOutOfRangeException(nameof(level), level, null)
+		};
+
+	private ConsoleColor GetConsoleColor(LogLevel level) =>
+		level switch
+		{
+			LogLevel.Warning => ConsoleColor.Yellow,
+			LogLevel.Error or LogLevel.Critical => ConsoleColor.Red,
+			_ => Console.ForegroundColor
+		};
+
+	private string FormatCategory(string callerFilePath, int callerLineNumber)
+	{
+		if (string.IsNullOrWhiteSpace(callerFilePath))
+		{
+			return "";
+		}
+
+		var filePath = Path.GetFileName(callerFilePath);
+		var category = $"{filePath}:{callerLineNumber}";
+		return category.Length > 30 ? $"..{category[^28..]}" : category;
+	}
+
+	private void AppendMessageContent(StringBuilder builder, string message, string category)
+	{
+		if (message.Length == 0 && category.Length == 0)
+		{
+			return;
+		}
+
+		if (category.Length == 0)
+		{
+			builder.Append(message);
+		}
+		else if (message.Length == 0)
+		{
+			builder.Append(category);
+		}
+		else
+		{
+			builder.Append($"{category,-30} | {message}");
+		}
+	}
+
+	private string ContextToString(object? ctx) =>
+		ctx switch
+		{
+			not null => ctx.ToString()!,
+			_ => ""
+		};
+
+	public void Log(LogLevel level, string message, object? ctx = null, string callerFilePath = "", int callerLineNumber = -1)
+	{
+		if (Modes.Count == 0)
+		{
+			return;
+		}
+
+		if (level < MinimumLevel)
+		{
+			return;
+		}
+
+		var category = FormatCategory(callerFilePath, callerLineNumber);
+
+		var messageBuilder = new StringBuilder();
+		messageBuilder.Append(
+			$"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff} [{Environment.CurrentManagedThreadId,2}] {GetShortNameLevel(level)} | ");
+
+		AppendMessageContent(messageBuilder, message, category);
+		messageBuilder.Append(EntrySeparator);
+
+		if (ctx is not null)
+		{
+			messageBuilder.AppendLine(ContextToString(ctx));
+		}
+
+		var finalMessage = messageBuilder.ToString();
+
+		var finalFileMessage = messageBuilder.ToString();
+		lock (_lock)
+		{
+			if (Modes.Contains(LogMode.Console))
+			{
+				lock (Console.Out)
+				{
+					Console.ForegroundColor = GetConsoleColor(level);
+					Console.Write(finalMessage);
+					Console.ResetColor();
+				}
+			}
+
+			if (Modes.Contains(LogMode.Debug))
+			{
+				Debug.Write(finalMessage);
+			}
+
+			if (!Modes.Contains(LogMode.File))
+			{
+				return;
+			}
+
+			if (MaximumLogFileSizeBytes > 0)
+			{
+				// Simplification here is that: 1 character ~ 1 byte.
+				LogFileSizeBytes += finalFileMessage.Length;
+
+				if (LogFileSizeBytes > MaximumLogFileSizeBytes)
+				{
+					LogFileSizeBytes = 0;
+					File.Delete(FilePath);
+				}
+			}
+
+			File.AppendAllText(FilePath, finalFileMessage);
+		}
+	}
+}

--- a/WalletWasabi/Logging/LoggerCore.cs
+++ b/WalletWasabi/Logging/LoggerCore.cs
@@ -110,8 +110,7 @@ public class LoggerCore
 		var category = FormatCategory(callerFilePath, callerLineNumber);
 
 		var messageBuilder = new StringBuilder();
-		messageBuilder.Append(
-			$"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff} [{Environment.CurrentManagedThreadId,2}] {GetShortNameLevel(level)} | ");
+		messageBuilder.Append($"{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss.fff} [{Environment.CurrentManagedThreadId,2}] {GetShortNameLevel(level)} | ");
 
 		AppendMessageContent(messageBuilder, message, category);
 		messageBuilder.Append(EntrySeparator);

--- a/WalletWasabi/Logging/LoggerCore.cs
+++ b/WalletWasabi/Logging/LoggerCore.cs
@@ -110,7 +110,8 @@ public class LoggerCore
 		var category = FormatCategory(callerFilePath, callerLineNumber);
 
 		var messageBuilder = new StringBuilder();
-		messageBuilder.Append($"{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss.fff} [{Environment.CurrentManagedThreadId,2}] {GetShortNameLevel(level)} | ");
+		messageBuilder.Append(
+			$"{DateTime.UtcNow.ToLocalTime():yyyy-MM-dd HH:mm:ss.fff} [{Environment.CurrentManagedThreadId,2}] {GetShortNameLevel(level)} | ");
 
 		AppendMessageContent(messageBuilder, message, category);
 		messageBuilder.Append(EntrySeparator);


### PR DESCRIPTION
### This PR

This PR is inspired by this comment https://github.com/WalletWasabi/WalletWasabi/pull/14546#issuecomment-4498455815

> When testing the P2P use logs in debug level instead of trace level because it will flush an lot of entries that will make the process a bit slower.

The idea is to clean up the `Logger` implementation a bit first. The idea is: 

* *Configure your logger however you want but once you start actual logging, no additional configuration is allowed.*
* This PR makes sure that the logger for tests is initialized once which brings some elementary order to it.
* Config-related changes were introduced so that "logger settings are read, logger is set up and config settings (with logs) are processed)". Again this makes the process more orderly.

### Second step (not this PR)

The second step is to avoid this call:

https://github.com/WalletWasabi/WalletWasabi/blob/9a7ac4993a95ffa366814eff1562372d8632662e/WalletWasabi/Logging/Logger.cs#L195

I believe the logger should work differently to be less resource intensive. At this point, basically each log line equals one file write. Typically, files are written to using `StreamWriter` or by handing over messages to a thread that just writes to the file to avoid log callers to bear the cost of writing to the log. 

To avoid

https://github.com/WalletWasabi/WalletWasabi/blob/9a7ac4993a95ffa366814eff1562372d8632662e/WalletWasabi/Logging/Logger.cs#L195

one can keep writing to the file (but not flushing each time) and when the app is about to stop, one would call `Logger.Flush()`. This, of course, requires thinking about the logger's lifecycle but I guess that's a good thing too.

Do you agree? Concept ACK / NACK?