### PR TITLE
Change end of feed detection

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Services/UpdateManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/UpdateManagerTests.cs
@@ -128,17 +128,29 @@ public class UpdateManagerTests
 
 		await updateTask;
 	}
+
+	[Fact]
+	public async Task EmptyRelayResponseCompletesUpdateCheckAsync()
+	{
+		// Arrange
+		var eventBus = new EventBus();
+		// this nostr client doesn't return any event
+		var nostrClientFactory = () => new TesteabletNostrClient([], sendEventsReceived: false);
+		AsyncReleaseDownloader doNothingDownloader = (_, _) => Task.CompletedTask;
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+		var updaterFunc = UpdateManager.CreateUpdater(nostrClientFactory, doNothingDownloader, eventBus);
+
+		// Act
+		var updateTask = updaterFunc(new UpdateManager.UpdateMessage(), Unit.Instance, cts.Token);
+
+		// Assert - should complete quickly without timing out
+		await updateTask.WaitAsync(TimeSpan.FromSeconds(1));
+	}
 }
 
-public class TesteabletNostrClient : INostrClient
+public class TesteabletNostrClient(ReleaseInfo[] releases, bool sendEventsReceived = true) : INostrClient
 {
-	private readonly ReleaseInfo[] _releases;
-
-	public TesteabletNostrClient(ReleaseInfo[] releases)
-	{
-		_releases = releases;
-	}
-
 	public void Dispose()
 	{
 	}
@@ -157,14 +169,17 @@ public class TesteabletNostrClient : INostrClient
 
 	public Task CreateSubscription(string subscriptionId, NostrSubscriptionFilter[] filters, CancellationToken token)
 	{
-		var nostrEvents = _releases
+		var nostrEvents = releases
 			.Select((r, i) => new NostrEvent
 			{
 				Id = i.ToString(),
 				Tags = [ new NostrEventTag{ TagIdentifier = "version", Data = [r.Version.ToString()] }]
 			}).ToArray();
 
-		EventsReceived?.Invoke(this, (subscriptionId, nostrEvents));
+		if (sendEventsReceived)
+		{
+			EventsReceived?.Invoke(this, (subscriptionId, nostrEvents));
+		}
 		EoseReceived?.Invoke(this, subscriptionId);
 		return Task.CompletedTask;
 	}

--- a/WalletWasabi/Discoverability/NostrExtensions.cs
+++ b/WalletWasabi/Discoverability/NostrExtensions.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Net;
 using System.Net.WebSockets;
 using System.Threading;
@@ -26,7 +25,7 @@ public static class NostrClientFactory
 		return relays.Length switch
 		{
 			0 => throw new ArgumentException("At least one relay is required.", nameof(relays)),
-			1 => new NostrClient(relays.First(), ConfigureSocket),
+			1 => new NostrClient(relays[0], ConfigureSocket),
 			_ => new WalletWasabi.WebClients.CompositeNostrClient(relays, ConfigureSocket)
 		};
 

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -38,7 +38,7 @@ public static class UpdateManager
 		try
 		{
 			// Connect to Nostr relays and check for release version updates
-			await wasabiNostrClient.ConnectAnsSubscribeAsync(cancellationToken).ConfigureAwait(false);
+			await wasabiNostrClient.ConnectAndSubscribeAsync(cancellationToken).ConfigureAwait(false);
 			await ProcessReleaseEventsAsync(wasabiNostrClient, releaseDownloader, eventBus, cancellationToken)
 				.ConfigureAwait(false);
 		}

--- a/WalletWasabi/WebClients/WasabiNostrClient.cs
+++ b/WalletWasabi/WebClients/WasabiNostrClient.cs
@@ -16,27 +16,34 @@ public class WasabiNostrClient : IDisposable
 {
 	private readonly Channel<ReleaseInfo> _updateChannel = Channel.CreateUnbounded<ReleaseInfo>();
 	private readonly Dictionary<string, NostrEvent> _events = new();
+	private readonly HashSet<object> _eoseReceivedFrom = new();
 	private readonly INostrClient _nostrClient;
-	private readonly string _nostrSubscriptionID = Guid.NewGuid().ToString();
+	private readonly string _nostrSubscriptionId = Guid.NewGuid().ToString();
+	private int _connectedClientsCount;
 
 	public WasabiNostrClient(INostrClient nostrClient)
 	{
 		_nostrClient = nostrClient;
 		_nostrClient.EventsReceived += OnNostrEventsReceived;
+		_nostrClient.EoseReceived += OnEoseReceived;
 	}
 
 	public ChannelReader<ReleaseInfo> EventsReader => _updateChannel.Reader;
 
-	public async Task ConnectAnsSubscribeAsync(CancellationToken cancel)
+	public async Task ConnectAndSubscribeAsync(CancellationToken cancel)
 	{
 		await _nostrClient.ConnectAndWaitUntilConnected(cancel).ConfigureAwait(false);
+
+		_connectedClientsCount = _nostrClient is CompositeNostrClient composite
+			? composite.States.Count(s => s.Value is WebSocketState.Open)
+			: 1;
 
 		var nostrSubscriptionFilter = new NostrSubscriptionFilter {
 			Kinds = [1],
 			Authors = [NIP19.FromNIP19Npub(Constants.WasabiTeamNostrPubKey).ToHex()],
 			Limit = 1};
 
-		await _nostrClient.CreateSubscription(_nostrSubscriptionID, [nostrSubscriptionFilter], cancel).ConfigureAwait(false);
+		await _nostrClient.CreateSubscription(_nostrSubscriptionId, [nostrSubscriptionFilter], cancel).ConfigureAwait(false);
 	}
 
 	public async Task DisconnectAsync(CancellationToken cancellationToken)
@@ -46,7 +53,7 @@ public class WasabiNostrClient : IDisposable
 
 	private void OnNostrEventsReceived(object? sender, (string subscriptionId, NostrEvent[] events) args)
 	{
-		if (args.subscriptionId != _nostrSubscriptionID)
+		if (args.subscriptionId != _nostrSubscriptionId)
 		{
 			return;
 		}
@@ -72,30 +79,30 @@ public class WasabiNostrClient : IDisposable
 				Logger.LogError($"Invalid Nostr Event received. ID: {nostrEvent.Id}");
 			}
 		}
-
-		CheckAllClientsFinished((INostrClient)sender!);
 	}
 
-	private void CheckAllClientsFinished(INostrClient individualClient)
+	private void OnEoseReceived(object? sender, string subscriptionId)
 	{
-		individualClient.Disconnect();
-
-		if (_nostrClient is CompositeNostrClient multiClient)
+		if (subscriptionId != _nostrSubscriptionId || sender is null)
 		{
-			if (multiClient.States.All(s => s.Value is WebSocketState.Closed or WebSocketState.Aborted))
+			return;
+		}
+
+		lock (_eoseReceivedFrom)
+		{
+			_eoseReceivedFrom.Add(sender);
+
+			if (_eoseReceivedFrom.Count >= _connectedClientsCount)
 			{
 				_updateChannel.Writer.TryComplete();
 			}
-		}
-		else
-		{
-			_updateChannel.Writer.TryComplete();
 		}
 	}
 
 	public void Dispose()
 	{
 		_nostrClient.EventsReceived -= OnNostrEventsReceived;
+		_nostrClient.EoseReceived -= OnEoseReceived;
 	}
 }
 


### PR DESCRIPTION
Fix a problem existing since v2.6.0 that doesn't detect properly when all nostr clients finished sending the feed and for that reason the `UpdateManager` times out in most of the cases and displaying "No new version found".