### PR TITLE
[codex] Handle empty Nostr update responses

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Services/UpdateManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/UpdateManagerTests.cs
@@ -128,15 +128,35 @@ public class UpdateManagerTests
 
 		await updateTask;
 	}
+
+	[Fact]
+	public async Task EmptyRelayResponseCompletesUpdateCheckAsync()
+	{
+		// Arrange
+		var eventBus = new EventBus();
+		var nostrClientFactory = () => new TesteabletNostrClient([], sendEventsReceived: false);
+		AsyncReleaseDownloader doNothingDownloader = (_, _) => Task.CompletedTask;
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+		var updaterFunc = UpdateManager.CreateUpdater(nostrClientFactory, doNothingDownloader, eventBus);
+
+		// Act
+		var updateTask = updaterFunc(new UpdateManager.UpdateMessage(), Unit.Instance, cts.Token);
+
+		// Assert
+		await updateTask.WaitAsync(TimeSpan.FromSeconds(1));
+	}
 }
 
 public class TesteabletNostrClient : INostrClient
 {
 	private readonly ReleaseInfo[] _releases;
+	private readonly bool _sendEventsReceived;
 
-	public TesteabletNostrClient(ReleaseInfo[] releases)
+	public TesteabletNostrClient(ReleaseInfo[] releases, bool sendEventsReceived = true)
 	{
 		_releases = releases;
+		_sendEventsReceived = sendEventsReceived;
 	}
 
 	public void Dispose()
@@ -164,7 +184,10 @@ public class TesteabletNostrClient : INostrClient
 				Tags = [ new NostrEventTag{ TagIdentifier = "version", Data = [r.Version.ToString()] }]
 			}).ToArray();
 
-		EventsReceived?.Invoke(this, (subscriptionId, nostrEvents));
+		if (_sendEventsReceived)
+		{
+			EventsReceived?.Invoke(this, (subscriptionId, nostrEvents));
+		}
 		EoseReceived?.Invoke(this, subscriptionId);
 		return Task.CompletedTask;
 	}

--- a/WalletWasabi/WebClients/WasabiNostrClient.cs
+++ b/WalletWasabi/WebClients/WasabiNostrClient.cs
@@ -23,6 +23,7 @@ public class WasabiNostrClient : IDisposable
 	{
 		_nostrClient = nostrClient;
 		_nostrClient.EventsReceived += OnNostrEventsReceived;
+		_nostrClient.EoseReceived += OnEoseReceived;
 	}
 
 	public ChannelReader<ReleaseInfo> EventsReader => _updateChannel.Reader;
@@ -76,6 +77,14 @@ public class WasabiNostrClient : IDisposable
 		CheckAllClientsFinished((INostrClient)sender!);
 	}
 
+	private void OnEoseReceived(object? sender, string subscriptionId)
+	{
+		if (subscriptionId == _nostrSubscriptionID)
+		{
+			CheckAllClientsFinished((INostrClient)sender!);
+		}
+	}
+
 	private void CheckAllClientsFinished(INostrClient individualClient)
 	{
 		individualClient.Disconnect();
@@ -96,6 +105,7 @@ public class WasabiNostrClient : IDisposable
 	public void Dispose()
 	{
 		_nostrClient.EventsReceived -= OnNostrEventsReceived;
+		_nostrClient.EoseReceived -= OnEoseReceived;
 	}
 }
 


### PR DESCRIPTION
This PR was prepared by Codex using extra-high reasoning effort. I have not personally reviewed the code changes.

## Summary
- complete the Wasabi Nostr update check when a relay sends `EOSE` without any matching release events
- keep existing event-processing behavior unchanged for relays that do send release events
- add a focused regression test for an EOSE-only relay response

## Root Cause
The updater reads release events through `WasabiNostrClient.EventsReader` until the channel completes. The channel was only completed from `EventsReceived`, so a relay that returned no events and only sent `EOSE` could keep the composite update check open until the 60s timeout. That timeout was then logged as `No new Wasabi release was found`, even if another relay had already returned a valid release event.

## Validation
- `dotnet test WalletWasabi.Tests\WalletWasabi.Tests.csproj --filter FullyQualifiedName~UpdateManagerTests --no-build --no-restore --logger "console;verbosity=normal"`