### PR TITLE
Fix unresponsive "Done" button when opened from the Bitcoin RPC error

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/MainViewModel.cs
@@ -190,7 +190,7 @@ public partial class MainViewModel : ViewModelBase
 				onClick: () =>
 				{
 					SettingsPage.SelectedTab = 1; // Bitcoin Tab
-					UiContext.Navigate().To(SettingsPage);
+					_ = SettingsPage.Activate();
 				}));
 
 		Notifications.StartListening();


### PR DESCRIPTION
### Problem
When the Bitcoin RPC is not reachable, a "Could not connect to Bitcoin RPC" notification is shown. Clicking it opens the Settings page, but the Done button does nothing, leaving the user stuck on the page unless they change settings (and restart the wallet).

### Cause
The notification opened Settings with a plain navigation (`UiContext.Navigate().To(SettingsPage)`) instead of the dialog navigation used everywhere else. That bypasses `NavigateDialogAsync`, so nothing awaits the dialog's completion and `Done` (which just calls `Close()`) has no awaiter to trigger the follow-up `Back()`.

### Fix
Open the page via `SettingsPage.Activate()`, exactly like the nav bar and search do. 