### PR TITLE
Make coordinator use the native WabiSabi

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,8 +20,9 @@
 		<!-- Transitive audit suppress: Microsoft.Data.Sqlite → SQLitePCLRaw.lib.e_sqlite3 2.1.11. -->
 		<!-- https://github.com/dotnet/efcore/issues/38257 claims that the issue should be fixed on Aug 11th 2026. -->
 		<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+		<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
 		<AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <!-- Core libraries. -->
-    <PackageVersion Include="WabiSabi" Version="1.0.1.2" />
+    <PackageVersion Include="WabiSabi" Version="1.1.4" />
     <PackageVersion Include="NBitcoin" Version="10.0.7" />
     <!-- UI. -->
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/WalletWasabi.Client/packages.lock.json
+++ b/WalletWasabi.Client/packages.lock.json
@@ -243,7 +243,7 @@
           "NBitcoin": "[10.0.7, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
-          "WabiSabi": "[1.0.1.2, )"
+          "WabiSabi": "[1.1.4, )"
         }
       },
       "Microsoft.AspNetCore.WebUtilities": {
@@ -343,9 +343,9 @@
       },
       "WabiSabi": {
         "type": "CentralTransitive",
-        "requested": "[1.0.1.2, )",
-        "resolved": "1.0.1.2",
-        "contentHash": "e+pMZGVEfWQvkpZHAydGv6grY71urfO47lodjXC9eWtfSFvNtPWjrgqck9O24yIbXhP4K3QrJKzJQFGpAp8rqg==",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
         "dependencies": {
           "NBitcoin.Secp256k1": "3.1.0"
         }

--- a/WalletWasabi.Coordinator/WabiSabi/Arena.Partial.cs
+++ b/WalletWasabi.Coordinator/WabiSabi/Arena.Partial.cs
@@ -317,12 +317,12 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.DeltaNotZero, $"Round ({round.Id}): Vsize credentials delta must be zero.");
 		}
 
-		if (request.RealAmountCredentialRequests.Requested.Count() != ProtocolConstants.CredentialNumber)
+		if (request.RealAmountCredentialRequests.Requested.Count != ProtocolConstants.CredentialNumber)
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongNumberOfCreds, $"Round ({round.Id}): Incorrect requested number of amount credentials.");
 		}
 
-		if (request.RealVsizeCredentialRequests.Requested.Count() != ProtocolConstants.CredentialNumber)
+		if (request.RealVsizeCredentialRequests.Requested.Count != ProtocolConstants.CredentialNumber)
 		{
 			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongNumberOfCreds, $"Round ({round.Id}): Incorrect requested number of weight credentials.");
 		}

--- a/WalletWasabi.Daemon/packages.lock.json
+++ b/WalletWasabi.Daemon/packages.lock.json
@@ -224,7 +224,7 @@
           "NBitcoin": "[10.0.7, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
-          "WabiSabi": "[1.0.1.2, )"
+          "WabiSabi": "[1.1.4, )"
         }
       },
       "walletwasabi.client": {
@@ -351,9 +351,9 @@
       },
       "WabiSabi": {
         "type": "CentralTransitive",
-        "requested": "[1.0.1.2, )",
-        "resolved": "1.0.1.2",
-        "contentHash": "e+pMZGVEfWQvkpZHAydGv6grY71urfO47lodjXC9eWtfSFvNtPWjrgqck9O24yIbXhP4K3QrJKzJQFGpAp8rqg==",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
         "dependencies": {
           "NBitcoin.Secp256k1": "3.1.0"
         }
@@ -375,6 +375,15 @@
         "requested": "[10.0.2, )",
         "resolved": "10.0.2",
         "contentHash": "1G4BdeFwc8E95MpwtR7pO4rEh2YCG/o5gqcOszdQRGrWX1ayHTZtho3xPuYZTbBxKb/3kQHjL3b4nQeNGvbM9g=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     },
     "net10.0/linux-x64": {
@@ -393,6 +402,15 @@
         "requested": "[10.0.2, )",
         "resolved": "10.0.2",
         "contentHash": "1G4BdeFwc8E95MpwtR7pO4rEh2YCG/o5gqcOszdQRGrWX1ayHTZtho3xPuYZTbBxKb/3kQHjL3b4nQeNGvbM9g=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     },
     "net10.0/osx-arm64": {
@@ -411,6 +429,15 @@
         "requested": "[10.0.2, )",
         "resolved": "10.0.2",
         "contentHash": "1G4BdeFwc8E95MpwtR7pO4rEh2YCG/o5gqcOszdQRGrWX1ayHTZtho3xPuYZTbBxKb/3kQHjL3b4nQeNGvbM9g=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     },
     "net10.0/osx-x64": {
@@ -429,6 +456,15 @@
         "requested": "[10.0.2, )",
         "resolved": "10.0.2",
         "contentHash": "1G4BdeFwc8E95MpwtR7pO4rEh2YCG/o5gqcOszdQRGrWX1ayHTZtho3xPuYZTbBxKb/3kQHjL3b4nQeNGvbM9g=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     },
     "net10.0/win-x64": {
@@ -447,6 +483,15 @@
         "requested": "[10.0.2, )",
         "resolved": "10.0.2",
         "contentHash": "1G4BdeFwc8E95MpwtR7pO4rEh2YCG/o5gqcOszdQRGrWX1ayHTZtho3xPuYZTbBxKb/3kQHjL3b4nQeNGvbM9g=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     }
   }

--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -749,7 +749,7 @@
           "NBitcoin": "[10.0.7, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
-          "WabiSabi": "[1.0.1.2, )"
+          "WabiSabi": "[1.1.4, )"
         }
       },
       "walletwasabi.client": {
@@ -1013,9 +1013,9 @@
       },
       "WabiSabi": {
         "type": "CentralTransitive",
-        "requested": "[1.0.1.2, )",
-        "resolved": "1.0.1.2",
-        "contentHash": "e+pMZGVEfWQvkpZHAydGv6grY71urfO47lodjXC9eWtfSFvNtPWjrgqck9O24yIbXhP4K3QrJKzJQFGpAp8rqg==",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
         "dependencies": {
           "NBitcoin.Secp256k1": "3.1.0"
         }
@@ -1298,6 +1298,15 @@
         "requested": "[3.119.2, )",
         "resolved": "3.119.2",
         "contentHash": "9WzxSyG/s9Id506j0Ht+Bi5ucOpWKPzd1XXr9TD4fuCafHHy2swRSlbZtC3IDQAsvCH63OerkDJajj43uSv5og=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     },
     "net10.0/linux-x64": {
@@ -1561,6 +1570,15 @@
         "requested": "[3.119.2, )",
         "resolved": "3.119.2",
         "contentHash": "9WzxSyG/s9Id506j0Ht+Bi5ucOpWKPzd1XXr9TD4fuCafHHy2swRSlbZtC3IDQAsvCH63OerkDJajj43uSv5og=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     },
     "net10.0/osx-arm64": {
@@ -1824,6 +1842,15 @@
         "requested": "[3.119.2, )",
         "resolved": "3.119.2",
         "contentHash": "9WzxSyG/s9Id506j0Ht+Bi5ucOpWKPzd1XXr9TD4fuCafHHy2swRSlbZtC3IDQAsvCH63OerkDJajj43uSv5og=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     },
     "net10.0/osx-x64": {
@@ -2087,6 +2114,15 @@
         "requested": "[3.119.2, )",
         "resolved": "3.119.2",
         "contentHash": "9WzxSyG/s9Id506j0Ht+Bi5ucOpWKPzd1XXr9TD4fuCafHHy2swRSlbZtC3IDQAsvCH63OerkDJajj43uSv5og=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     },
     "net10.0/win-x64": {
@@ -2329,6 +2365,15 @@
         "requested": "[3.119.2, )",
         "resolved": "3.119.2",
         "contentHash": "9WzxSyG/s9Id506j0Ht+Bi5ucOpWKPzd1XXr9TD4fuCafHHy2swRSlbZtC3IDQAsvCH63OerkDJajj43uSv5og=="
+      },
+      "WabiSabi": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
+        "dependencies": {
+          "NBitcoin.Secp256k1": "3.1.0"
+        }
       }
     }
   }

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -815,7 +815,7 @@
           "NBitcoin": "[10.0.7, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
-          "WabiSabi": "[1.0.1.2, )"
+          "WabiSabi": "[1.1.4, )"
         }
       },
       "walletwasabi.client": {
@@ -942,9 +942,9 @@
       },
       "WabiSabi": {
         "type": "CentralTransitive",
-        "requested": "[1.0.1.2, )",
-        "resolved": "1.0.1.2",
-        "contentHash": "e+pMZGVEfWQvkpZHAydGv6grY71urfO47lodjXC9eWtfSFvNtPWjrgqck9O24yIbXhP4K3QrJKzJQFGpAp8rqg==",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
         "dependencies": {
           "NBitcoin.Secp256k1": "3.1.0"
         }

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -27,6 +27,7 @@ using WalletWasabi.WabiSabi.Coordinator.Models;
 using WalletWasabi.WabiSabi.Coordinator.PostRequests;
 using WalletWasabi.WabiSabi.Coordinator.Rounds;
 using WalletWasabi.Coordinator.WabiSabi;
+using CredentialIssuer = WabiSabi.Native.CredentialIssuer;
 
 namespace WalletWasabi.Tests.Helpers;
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/ConfirmConnectionTests.cs
@@ -10,6 +10,7 @@ using WalletWasabi.WabiSabi.Coordinator.Models;
 using WalletWasabi.WabiSabi.Coordinator.Rounds;
 using WalletWasabi.WabiSabi.Models;
 using Xunit;
+using CredentialIssuer = WabiSabi.Native.CredentialIssuer;
 
 namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests;
 

--- a/WalletWasabi.slnx
+++ b/WalletWasabi.slnx
@@ -9,7 +9,7 @@
     <File Path=".gitignore" />
     <File Path="Contrib/release.sh" />
     <File Path="CONTRIBUTING.md" />
-    <File Path="deps.nix" />
+    <File Path="deps.json" />
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
     <File Path="exclusion.dic" />

--- a/WalletWasabi/WabiSabi/Coordinator/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Coordinator/Rounds/Round.cs
@@ -8,6 +8,7 @@ using WalletWasabi.WabiSabi.Coordinator.Models;
 using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using static WalletWasabi.Logging.LoggerTools;
+using CredentialIssuer = WabiSabi.Native.CredentialIssuer;
 
 namespace WalletWasabi.WabiSabi.Coordinator.Rounds;
 
@@ -39,8 +40,8 @@ public class Round
 
 		CoinjoinState = new ConstructionState(Parameters);
 
-		AmountCredentialIssuer = new(new(random), random, Parameters.MaxAmountCredentialValue);
-		VsizeCredentialIssuer = new(new(random), random, Parameters.MaxVsizeCredentialValue);
+		AmountCredentialIssuer = new CredentialIssuer(new CredentialIssuerSecretKey(random), random, Parameters.MaxAmountCredentialValue);
+		VsizeCredentialIssuer = new CredentialIssuer(new CredentialIssuerSecretKey(random), random, Parameters.MaxVsizeCredentialValue);
 		AmountCredentialIssuerParameters = AmountCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 		VsizeCredentialIssuerParameters = VsizeCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -89,7 +89,9 @@
           "LibChaCha20": "1.0.1",
           "LinqKit.Core": "1.2.5",
           "NBitcoin.Secp256k1": "3.1.6",
-          "System.Interactive.Async": "6.0.1"
+          "System.Interactive.Async": "6.0.1",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "8.0.0"
         }
       },
       "System.Linq.Async": {
@@ -103,9 +105,9 @@
       },
       "WabiSabi": {
         "type": "Direct",
-        "requested": "[1.0.1.2, )",
-        "resolved": "1.0.1.2",
-        "contentHash": "e+pMZGVEfWQvkpZHAydGv6grY71urfO47lodjXC9eWtfSFvNtPWjrgqck9O24yIbXhP4K3QrJKzJQFGpAp8rqg==",
+        "requested": "[1.1.4, )",
+        "resolved": "1.1.4",
+        "contentHash": "mH5u5skRMw3R5YAg1TVvgtGf23ur/o5LGTKPMUYxiXbWuefD/eRGER4KN3/3MfElVKE+CfLepkqWZ+CP24rRgA==",
         "dependencies": {
           "NBitcoin.Secp256k1": "3.1.0"
         }
@@ -268,7 +270,10 @@
       "SQLitePCLRaw.core": {
         "type": "Transitive",
         "resolved": "2.1.11",
-        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA==",
+        "dependencies": {
+          "System.Memory": "4.5.3"
+        }
       },
       "SQLitePCLRaw.lib.e_sqlite3": {
         "type": "Transitive",
@@ -287,6 +292,29 @@
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "Ckj+tg2BVOZ0oLp7FAbjfvRyA/BMkUhVxROLd+x22zncRR6KD7CdFzAYp+9Mo2cedxAMo2X9ZNyhZu68jdDITw=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.3",
+        "contentHash": "3oDzvc/zzetpTKWMShs1AADwZjQ/36HnsufHRPcOjyRAAMLDlu2iD33MBI2opxnezcVUtXyqDXXjoFMOU9c7SA=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "yev/k9GHAEGx2Rg3/tU6MQh4HGBXJs70y7j1LaM1i/ER9po+6nnQ6RRqTJn1E7Xu0fbIFK80Nh5EoODxrbxwBQ=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "8.0.4",
+        "contentHash": "bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
+        "dependencies": {
+          "System.Text.Encodings.Web": "8.0.0"
+        }
+      },
+      "System.Threading.Channels": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "CMaFr7v+57RW7uZfZkPExsPB6ljwzhjACWW1gfU35Y56rk72B/Wu+sTqxVmGSk4SFUlPc3cjeKND0zktziyjBA=="
       }
     }
   }

--- a/deps.json
+++ b/deps.json
@@ -1266,8 +1266,8 @@
   },
   {
     "pname": "WabiSabi",
-    "version": "1.0.1.2",
-    "hash": "sha256-Gx+tuXraMABak8s0SeofbXpNLVfTnxz4At4+HejnQeU="
+    "version": "1.1.4",
+    "hash": "sha256-IACtDPYZssjrixbh8pcUJ1WX7oyeRAtKtYu6UMETB6s="
   },
   {
     "pname": "Xaml.Behaviors.Avalonia",


### PR DESCRIPTION
There is a new version of NWabiSabi (https://github.com/WalletWasabi/NWabiSabi) which includes a native implementation written in C language which is 4x faster and consumes 10x less memory. This can increase the reliability, specially for coordinators running in less powerful machines. 

This PR switches from the managed (C#) version to the native )C) version only on the coordinator side. The idea is to dog-food it for a while, then switch also the clients to native and finally create a new nuget package containing only the native (WabiSabi.Native nuget package).

The end goal is to create bindings for other programming languages (I did it for python just for fun) to allow other wallets to coinjoin with WabiSabi coordinators (or implement an ecash system or whatever they want).