### PR TITLE
Fix coins wrongly showing anonymity score 2147483647

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -43,6 +43,40 @@ public class TransactionProcessorTests
 	}
 
 	[Fact]
+	public async Task SameWalletLoadedTwiceDoesNotLeakDefaultAnonScoreAsync()
+	{
+		// Reproduces #7453 / #9843 / #12648. The same wallet loaded twice shares one transaction
+		// store, so it shares each SmartTransaction. WalletOutputs is a set keyed by outpoint
+		// (SmartCoin equality is outpoint-only), so only the first instance's coin is kept there and
+		// gets analyzed. The second instance's HdPubKey for the very same output is never analyzed and
+		// would keep the DefaultHighAnonymitySet sentinel (int.MaxValue), wrongly marking the coin
+		// fully private and excluding it from coinjoins.
+		using var txStore = await CreateTransactionStoreAsync();
+
+		var km1 = KeyManager.CreateNew(out var mnemonic, "pw", Network.Main);
+		var km2 = KeyManager.Recover(mnemonic, "pw", Network.Main, km1.SegwitAccountKeyPath, km1.TaprootAccountKeyPath);
+
+		var eventBus = new EventBus();
+		var tp1 = new TransactionProcessor(txStore, null, km1, Money.Coins(0.0001m), eventBus);
+		var tp2 = new TransactionProcessor(txStore, null, km2, Money.Coins(0.0001m), eventBus);
+
+		// A receive to a key both instances of the wallet control (identical derivation).
+		var receiveKey = km1.GetNextReceiveKey(LabelsArray.Empty);
+		var tx = CreateCreditingTransaction(receiveKey.P2wpkhScript, Money.Coins(1.0m), height: 100);
+
+		// The first instance processes it: its coin becomes the analyzed representative (anonset 1).
+		tp1.Process(tx);
+		// The second instance processes the very same shared transaction.
+		tp2.Process(tx);
+
+		var coin1 = Assert.Single(tp1.Coins);
+		var coin2 = Assert.Single(tp2.Coins);
+		Assert.Equal(1, coin1.HdPubKey.AnonymitySet);
+		Assert.NotEqual(HdPubKey.DefaultHighAnonymitySet, coin2.HdPubKey.AnonymitySet);
+		Assert.Equal(1, coin2.HdPubKey.AnonymitySet);
+	}
+
+	[Fact]
 	public async Task SpendToLegacyScriptsAsync()
 	{
 		using var txStore = await CreateTransactionStoreAsync();

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -68,6 +68,33 @@ public static class BlockchainAnalyzer
 		}
 
 		AnalyzeClusters(tx);
+		ResetUncalculatedAnonScores(tx);
+	}
+
+	/// <summary>
+	/// <see cref="HdPubKey.DefaultHighAnonymitySet"/> (<see cref="int.MaxValue"/>) is a sentinel
+	/// meaning "anonymity set not calculated yet". It must never survive as a coin's actual
+	/// anonymity score, otherwise the coin is wrongly considered fully private and silently
+	/// excluded from coinjoins.
+	/// <para>
+	/// It can leak into a wallet output when the transaction is shared between multiple loaded
+	/// wallets (a single <c>AllTransactionStore</c> is shared app-wide), so its inputs may
+	/// temporarily contain another wallet's not-yet-analyzed keys, whose sentinel value then
+	/// propagates through the input-based anonset calculations above.
+	/// As a fail-safe we treat such an output as freshly received (anonymity set <c>1</c>): the
+	/// least private value, so the coin stays eligible for coinjoin rather than being skipped.
+	/// </para>
+	/// <remarks>Context: https://github.com/WalletWasabi/WalletWasabi/issues/7453</remarks>
+	/// </summary>
+	private static void ResetUncalculatedAnonScores(SmartTransaction tx)
+	{
+		foreach (var key in tx.WalletOutputs.Select(x => x.HdPubKey))
+		{
+			if (key.AnonymitySet >= HdPubKey.DefaultHighAnonymitySet)
+			{
+				key.SetAnonymitySet(1, tx.GetHash());
+			}
+		}
 	}
 
 	private static void AnalyzeCancellation(SmartTransaction tx)

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -262,8 +262,32 @@ public class TransactionProcessor(
 		}
 
 		BlockchainAnalyzer.Analyze(result.Transaction);
+		SyncAnonScoresFromSharedTransaction(result.Transaction);
 
 		return result;
+	}
+
+	/// <summary>
+	/// Every loaded wallet shares a single transaction store, hence the same <see cref="SmartTransaction"/>
+	/// instances. <see cref="SmartTransaction.WalletOutputs"/> is a set keyed by outpoint
+	/// (<see cref="SmartCoin"/> equality is outpoint-only), so when the same wallet is loaded more than once
+	/// only the first instance's coin is kept there and gets its anonymity set calculated by the
+	/// <see cref="BlockchainAnalyzer"/>. The other instances' <see cref="HdPubKey"/> objects for the very same
+	/// output are never analyzed and keep the <see cref="HdPubKey.DefaultHighAnonymitySet"/> sentinel
+	/// (<see cref="int.MaxValue"/>), which makes the coin look fully private and silently excludes it from
+	/// coinjoins. Copy the calculated value onto this wallet's own key.
+	/// <remarks>Context: https://github.com/WalletWasabi/WalletWasabi/issues/7453</remarks>
+	/// </summary>
+	private void SyncAnonScoresFromSharedTransaction(SmartTransaction tx)
+	{
+		foreach (var representative in tx.WalletOutputs)
+		{
+			if (KeyManager.TryGetKeyForScriptPubKey(representative.ScriptPubKey, out HdPubKey? ownKey)
+				&& !ReferenceEquals(ownKey, representative.HdPubKey))
+			{
+				ownKey.SetAnonymitySet(representative.HdPubKey.AnonymitySet);
+			}
+		}
 	}
 
 	private bool CanBeConsideredDustAttack(TxOut output, HdPubKey hdPubKey, bool weAreAmongTheSender) =>


### PR DESCRIPTION
### Problem

Some coins wrongly display an anonymity score of 2147483647 (`int.MaxValue`), blocking the user from making them private. (Recurrence of #7453, #9843 and #12648.)

`2147483647` is `HdPubKey.DefaultHighAnonymitySet`, the sentinel value every key starts at, meaning "anonymity set not calculated yet". The bug is that this sentinel leaks out in certain case.

### Root cause

A single `AllTransactionStore` is shared by every loaded wallet, so all wallets share the same `SmartTransaction` instances. 

When the same wallet is loaded twice (i.e., because the first wallet might be corrupted)

- The first instance to process a transaction puts its coin into the shared set and gets it analyzed (real anonymity set computed).
- The second instance's coin has the same outpoint, so `TryAddWalletOutput` rejects it as a duplicate, so the coin's `HdPubKey` is never added to the analyzed set, and is never touched by `BlockchainAnalyzer`, keeping the `int.MaxValue` sentinel.

It is a per-transaction race, so only some coins are affected.

### Fix

`TransactionProcessor.SyncAnonScoresFromSharedTransaction` (runs right after `BlockchainAnalyzer.Analyze`): for every coin in the shared transaction's `WalletOutputs`, if this wallet owns the same script through a different `HdPubKey` instance, copy the calculated anonymity set onto this wallet's own key. For a single loaded wallet the key instances are identical, so this is a no-op.

A secondary guard, `BlockchainAnalyzer.ResetUncalculatedAnonScores`, enforces the invariant that the analyzer itself never emits the sentinel onto a wallet output (dropping to anonymity score 1, as fail-safe.)

As a disclaimer: The code is written with AI. I think it is fairly simple to understand. 