### PR TITLE
[codex] Limit RPC filter sync batches

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Services/FilterProvidersTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/FilterProvidersTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using NBitcoin.RPC;
+using WalletWasabi.Services;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Services;
+
+public class FilterProvidersTests
+{
+	private static readonly byte[] DummyFilterData = Convert.FromHexString("02832810ec08a0");
+
+	[Fact]
+	public async Task BitcoinRpcProviderFetchesBoundedPageAndKeepsBestHeightAsync()
+	{
+		using CancellationTokenSource testCts = new(TimeSpan.FromMinutes(1));
+
+		var blockHashes = Enumerable.Range(1, 250)
+			.ToDictionary(x => x, x => new uint256((ulong)x));
+		List<int> requestedBlockHeights = [];
+		List<uint256> requestedFilterHashes = [];
+
+		MockRpcClient rpc = new()
+		{
+			Network = Network.Main,
+			OnGetBlockCountAsync = () => Task.FromResult(250),
+			OnGetBlockHashAsync = height =>
+			{
+				requestedBlockHeights.Add(height);
+				return Task.FromResult(blockHashes[height]);
+			},
+			OnGetBlockFilterAsync = blockHash =>
+			{
+				requestedFilterHashes.Add(blockHash);
+				return Task.FromResult(CreateBlockFilter(blockHash));
+			}
+		};
+
+		var provider = FilterProviders.CreateBitcoinRpcFilterProvider(rpc, new ConcurrentChain(Network.Main));
+		var result = await provider(fromHeight: 0, fromHash: uint256.Zero, testCts.Token);
+
+		Assert.True(result.IsOk);
+		var newFilters = Assert.IsType<FiltersResponse.NewFiltersAvailable>(result.Value);
+		Assert.Equal(250u, newFilters.BestHeight.Height);
+		Assert.Equal(100, newFilters.Filters.Length);
+		Assert.Equal(Enumerable.Range(1, 100), requestedBlockHeights);
+		Assert.Equal(Enumerable.Range(1, 100).Select(x => blockHashes[x]), requestedFilterHashes);
+		Assert.Equal(1u, newFilters.Filters[0].Header.Height.Height);
+		Assert.Equal(100u, newFilters.Filters[^1].Header.Height.Height);
+	}
+
+	private static BlockFilter CreateBlockFilter(uint256 blockHash) =>
+		new(new GolombRiceFilter(DummyFilterData, 20, 1 << 20), blockHash);
+}

--- a/WalletWasabi/Services/Synchronizer.cs
+++ b/WalletWasabi/Services/Synchronizer.cs
@@ -30,6 +30,8 @@ public delegate Task<FilterFetchingResult> FilterProvider(uint fromHeight, uint2
 
 public static class FilterProviders
 {
+	private const int MaxFiltersPerBitcoinRpcRequest = 100;
+
 	private static readonly FiltersResponse.AlreadyOnBestBlock AlreadyOnBestBlock = new();
 	private static readonly FiltersResponse.BestBlockUnknown BestBlockUnknown = new();
 	private static FiltersResponse.NewFiltersAvailable NewFiltersAvailable(ChainHeight bestHeight, FilterModel[] filters) => new(bestHeight, filters);
@@ -40,23 +42,25 @@ public static class FilterProviders
 	public static FilterProvider CreateBitcoinP2pFilterProvider(FilterHeaderChain filterHeadersChain, ConcurrentChain blockHeadersChain, CompactFilterBehavior.FilterSynchronizationState synchronizationState) =>
 		(fromHeight, fromHash, cancellationToken) => GetFiltersFromBitcoinP2pAsync(filterHeadersChain, blockHeadersChain, synchronizationState, fromHeight, fromHash, cancellationToken);
 
-	private static async Task<uint256[]> GetBlockHashesAsync(IRPCClient bitcoinRpcClient,
+	private static async Task<(ChainHeight BestHeight, uint256[] BlockHashes)> GetBlockHashesAsync(IRPCClient bitcoinRpcClient,
 	ConcurrentChain blockHeaderChain, uint256 fromHash, uint fromHeight, CancellationToken cancellationToken)
 	{
 		if (blockHeaderChain.Tip?.Height > fromHeight)
 		{
-			return blockHeaderChain
+			var chainBlockHashes = blockHeaderChain
 				.EnumerateAfter(fromHash)
 				.Select(x => x.HashBlock)
-				.Take(1_000)
+				.Take(MaxFiltersPerBitcoinRpcRequest)
 				.ToArray();
+
+			return ((uint)blockHeaderChain.Tip.Height, chainBlockHashes);
 		}
 
 		var currentHeight = await bitcoinRpcClient.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
-		var nbOfFiltersToFetch = Math.Min(1_000, currentHeight - fromHeight);
+		var nbOfFiltersToFetch = Math.Min(MaxFiltersPerBitcoinRpcRequest, currentHeight - fromHeight);
 		if (nbOfFiltersToFetch == 0)
 		{
-			return [];
+			return ((uint)currentHeight, []);
 		}
 
 		var batchClient = bitcoinRpcClient.PrepareBatch();
@@ -66,14 +70,14 @@ public static class FilterProviders
 		await batchClient.SendBatchAsync(cancellationToken).ConfigureAwait(false);
 
 		var blockHashes = await Task.WhenAll(blockHashTasks).ConfigureAwait(false);
-		return blockHashes;
+		return ((uint)currentHeight, blockHashes);
 	}
 
 	private static async Task<FilterFetchingResult> GetFiltersFromBitcoinRpcAsync(IRPCClient bitcoinRpcClient, ConcurrentChain blockHeaderChain, uint256 fromHash, uint fromHeight, CancellationToken cancellationToken)
 	{
 		try
 		{
-			var blockHashes = await GetBlockHashesAsync(bitcoinRpcClient, blockHeaderChain, fromHash, fromHeight, cancellationToken).ConfigureAwait(false);
+			var (bestHeight, blockHashes) = await GetBlockHashesAsync(bitcoinRpcClient, blockHeaderChain, fromHash, fromHeight, cancellationToken).ConfigureAwait(false);
 			if (blockHashes.Length == 0)
 			{
 				return AlreadyOnBestBlock;
@@ -99,7 +103,7 @@ public static class FilterProviders
 				height++;
 			}
 
-			return NewFiltersAvailable(height, filters);
+			return NewFiltersAvailable(bestHeight, filters);
 		}
 		catch (RPCException e) when (e.RPCCode == RPCErrorCode.RPC_INVALID_PARAMETER) // Block height out of range
 		{


### PR DESCRIPTION
I didn't actually look into it, just let GPT 5.5 on xhigh onto it.

## Summary
- Limit Bitcoin RPC filter sync pages to 100 filters instead of 1,000 so slower RPC endpoints can make progress without repeatedly hitting the 30s HTTP timeout.
- Preserve the real best height reported by the RPC/header-chain source instead of using the last downloaded filter height + 1.
- Add unit coverage for the bounded RPC page behavior and best-height reporting.

## Root cause
The RPC filter provider requested up to 1,000 `getblockfilter` calls in one JSON-RPC batch. On slower local/public RPC endpoints, that oversized response can exceed NBitcoin's underlying 30s HTTP timeout. Because the failed batch persists nothing, the synchronizer retries the same oversized request forever, leaving the chain tip at "No data".

Related: #14345

## Validation
- `dotnet test WalletWasabi.Tests\WalletWasabi.Tests.csproj --filter "FullyQualifiedName~FilterProvidersTests|FullyQualifiedName~FilterStoreTests|FullyQualifiedName~BlockFilterSqliteStorageTests" --no-restore`
- Attempted `dotnet test WalletWasabi.Tests\WalletWasabi.Tests.csproj --no-restore`, but it exceeded the 3-minute command timeout before returning results.
