### PR TITLE
Logger: Configuration only through `Configure` method [3/n]

### DIFF
--- a/WalletWasabi.Fluent.Desktop/Program.cs
+++ b/WalletWasabi.Fluent.Desktop/Program.cs
@@ -54,21 +54,22 @@ public class Program
 	public static int Main(string[] args)
 	{
 		// Crash reporting must be before the "single instance checking".
-		Logger.Configure(Path.Combine(Config.DataDir, "Logs.txt"), LogLevel.Info);
-		try
+		if (CrashReporter.TryGetExceptionFromCliArgs(args, out var exceptionToShow))
 		{
-			if (CrashReporter.TryGetExceptionFromCliArgs(args, out var exceptionToShow))
+			Logger.Configure(Path.Combine(Config.DataDir, "Logs.txt"), LogLevel.Info);
+
+			try
 			{
 				// Show the exception.
 				BuildCrashReporterApp(exceptionToShow).StartWithClassicDesktopLifetime(args);
 				return 1;
 			}
-		}
-		catch (Exception ex)
-		{
-			// If anything happens here just log it and exit.
-			Logger.LogCritical(ex);
-			return 1;
+			catch (Exception ex)
+			{
+				// If anything happens here just log it and exit.
+				Logger.LogCritical(ex);
+				return 1;
+			}
 		}
 
 		try

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -26,29 +26,26 @@ public static class Logger
 		FilePath = filePath;
 		IoHelpers.EnsureContainingDirectoryExists(FilePath);
 
-		if (File.Exists(FilePath))
+		lock (Lock)
 		{
-			lock (Lock)
+			if (File.Exists(FilePath))
 			{
 				LogFileSizeBytes = new FileInfo(FilePath).Length;
 			}
-		}
 
 #if RELEASE
-		logLevel ??= LogLevel.Info;
-		logModes ??= [LogMode.Console, LogMode.File];
+			logLevel ??= LogLevel.Info;
+			logModes ??= [LogMode.Console, LogMode.File];
 #else
-		logLevel ??= LogLevel.Debug;
-		logModes ??= [LogMode.Debug, LogMode.Console, LogMode.File];
+			logLevel ??= LogLevel.Debug;
+			logModes ??= [LogMode.Debug, LogMode.Console, LogMode.File];
 #endif
 
-		MinimumLevel = logLevel.Value;
+			MinimumLevel = logLevel.Value;
 
-		Modes.Clear();
-		Modes.UnionWith(logModes);
+			Modes.Clear();
+			Modes.UnionWith(logModes);
 
-		lock (Lock)
-		{
 			if (MinimumLevel == LogLevel.Trace)
 			{
 				MaximumLogFileSizeBytes = 0;

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -21,40 +21,7 @@ public static class Logger
 	private static long MaximumLogFileSizeBytes { get; set; } = 10_000_000;
 	private static long LogFileSizeBytes { get; set; }
 
-
 	public static void Configure(string filePath, LogLevel? logLevel = null, LogMode[]? logModes = null)
-	{
-		SetFilePath(filePath);
-
-#if RELEASE
-		logLevel ??= LogLevel.Info;
-		logModes ??= [LogMode.Console, LogMode.File];
-#else
-		logLevel ??= LogLevel.Debug;
-		logModes ??= [LogMode.Debug, LogMode.Console, LogMode.File];
-#endif
-
-		SetMinimumLevel(logLevel.Value);
-		SetModes(logModes);
-
-		lock (Lock)
-		{
-			if (MinimumLevel == LogLevel.Trace)
-			{
-				MaximumLogFileSizeBytes = 0;
-			}
-		}
-	}
-
-	public static void SetMinimumLevel(LogLevel level) => MinimumLevel = level;
-
-	public static void SetModes(params LogMode[] modes)
-	{
-		Modes.Clear();
-		Modes.UnionWith(modes);
-	}
-
-	public static void SetFilePath(string filePath)
 	{
 		FilePath = filePath;
 		IoHelpers.EnsureContainingDirectoryExists(FilePath);
@@ -64,6 +31,27 @@ public static class Logger
 			lock (Lock)
 			{
 				LogFileSizeBytes = new FileInfo(FilePath).Length;
+			}
+		}
+
+#if RELEASE
+		logLevel ??= LogLevel.Info;
+		logModes ??= [LogMode.Console, LogMode.File];
+#else
+		logLevel ??= LogLevel.Debug;
+		logModes ??= [LogMode.Debug, LogMode.Console, LogMode.File];
+#endif
+
+		MinimumLevel = logLevel.Value;
+
+		Modes.Clear();
+		Modes.UnionWith(logModes);
+
+		lock (Lock)
+		{
+			if (MinimumLevel == LogLevel.Trace)
+			{
+				MaximumLogFileSizeBytes = 0;
 			}
 		}
 	}


### PR DESCRIPTION
This PR moves towards `Logger.Configure` can be called just once so the logger behavior is predictable.

Final PR #14720.