### PR TITLE
BlockProviders: Download blocks from 1-3 P2P peers to speed up block downloading

### DIFF
--- a/WalletWasabi/Services/NodesManagement/P2pConnectionManager.cs
+++ b/WalletWasabi/Services/NodesManagement/P2pConnectionManager.cs
@@ -1,15 +1,16 @@
 using NBitcoin;
 using NBitcoin.Protocol;
-using WabiSabi.Crypto.Randomness;
 using NBitcoin.Protocol.Behaviors;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -17,50 +18,115 @@ using static WalletWasabi.Services.Workers;
 
 namespace WalletWasabi.Services.NodesManagement;
 
-public record P2pNodeClient(
-	Node Node,
+public record P2pNodeGroupClient(
+	Node[] Nodes,
 	double Timeout,
 	Action<int> IncreaseTimeout,
-	Action<P2pConnectionManager.MisbehaviorType> Error)
+	Action<Node, P2pConnectionManager.MisbehaviorType> Error)
 {
+	private static readonly Meter Meter = new("P2pNodeGroupClient", "1.0.0");
+
+	private static readonly Histogram<double> BlockDownloadDuration = Meter.CreateHistogram<double>("p2p.block.download.duration","ms", "Time taken to download and validate a block");
+	private static readonly Counter<long> BlockDownloadAttempts = Meter.CreateCounter<long>("p2p.block.download.attempts", description: "Total number of block download attempts across all nodes");
+	private static readonly Counter<long> BlockDownloadSuccesses = Meter.CreateCounter<long>("p2p.block.download.successes", description: "Number of successful block downloads");
+	private static readonly Counter<long> BlockDownloadFailures = Meter.CreateCounter<long>("p2p.block.download.failures", description: "Number of failed block download attempts");
+
+	/// <summary>
+	/// Attempts to download the block from <see cref="Nodes"/> in parallel and return the first valid block it receives.
+	/// </summary>
 	public async Task<Block?> GetBlockAsync(uint256 blockHash, CancellationToken cancellationToken)
 	{
+		var blockHashStr = blockHash.ToString();
+		BlockDownloadAttempts.Add(1, new KeyValuePair<string, object?>("block_hash", blockHashStr));
+
+		Block? result = null;
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(Timeout));
+		using var lts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken);
+
+		// Map download tasks to their corresponding P2P nodes.
+		var tasksToNodes = Nodes.ToDictionary(x => x.DownloadBlockAsync(blockHash, lts.Token), x => x);
+		var tasks = tasksToNodes.Keys;
+		var taskCount = tasks.Count;
+
+		Stopwatch stopwatch = Stopwatch.StartNew();
+
+		for (int i = 0; i < taskCount; i++)
+		{
+			// Wait for a single download task to complete.
+			var task = await Task.WhenAny(tasks).ConfigureAwait(false);
+			var node = tasksToNodes[task];
+
+			try
+			{
+				var block = await task.ConfigureAwait(false);
+
+				// Validate block
+				if (block.Check())
+				{
+					TrackSuccess(blockHashStr, stopwatch, node);
+					IncreaseTimeout(-1);
+
+					Logger.LogInfo($"Block ({block.GetCoinbaseHeight()}) downloaded: {block.GetHash()}.");
+					result = block;
+					break;
+				}
+
+				ReportError(blockHashStr, node, P2pConnectionManager.MisbehaviorType.ProvidedInvalidData);
+			}
+			catch (Exception ex)
+			{
+				if (ex is OperationCanceledException or TimeoutException)
+				{
+					IncreaseTimeout(+1);
+					// It could be a slow connection and not a misbehaving node.
+					ReportError(blockHashStr, node, P2pConnectionManager.MisbehaviorType.TimedOutDownloadingBlock, ex);
+
+					// If the download was canceled due to timeout, we can break the loop and return null.
+					break;
+				}
+				else
+				{
+					Logger.LogDebug(ex);
+					ReportError(blockHashStr, node, P2pConnectionManager.MisbehaviorType.Unknown, ex);
+				}
+			}
+
+			// Remove task to node mapping to avoid waiting for it again.
+			tasksToNodes.Remove(task);
+			tasks = tasksToNodes.Keys;
+		}
+
+		// Cancel all downloads if any.
+		await lts.CancelAsync().ConfigureAwait(false);
+
+		// Wait for all tasks to complete, ignoring exceptions.
 		try
 		{
-			using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(Timeout));
-			using var lts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken);
-			var block = await Node.DownloadBlockAsync(blockHash, lts.Token).ConfigureAwait(false);
-
-			// Validate block
-			if (!block.Check())
-			{
-				Error(P2pConnectionManager.MisbehaviorType.ProvidedInvalidData);
-				return null;
-			}
-
-			Logger.LogInfo($"Block ({block.GetCoinbaseHeight()}) downloaded: {block.GetHash()}.");
-			IncreaseTimeout(-1);
-			return block;
+			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
-		catch (Exception ex)
+		catch
 		{
-			if (ex is OperationCanceledException or TimeoutException)
-			{
-				IncreaseTimeout(+1);
-				// It could be a slow connection and not a misbehaving node.
-				Error(P2pConnectionManager.MisbehaviorType.TimedOutDownloadingBlock);
-			}
-			else
-			{
-				Logger.LogDebug(ex);
-				Error(P2pConnectionManager.MisbehaviorType.Unknown);
-			}
-			return null;
+		}
+
+		return result;
+
+		static void TrackSuccess(string blockHashStr, Stopwatch stopwatch, Node node)
+		{
+			BlockDownloadDuration.Record(stopwatch.ElapsedMilliseconds,
+				new("block_hash", blockHashStr), new("status", "success"), new("node", node.RemoteSocketEndpoint?.ToString() ?? "unknown"));
+			BlockDownloadSuccesses.Add(1, new KeyValuePair<string, object?>("block_hash", blockHashStr));
+		}
+
+		void ReportError(string blockHashStr, Node node, P2pConnectionManager.MisbehaviorType misbehaviorType, Exception? ex = null)
+		{
+			Error(node, misbehaviorType);
+			BlockDownloadFailures.Add(1, new("block_hash", blockHashStr), new("misbehavior", misbehaviorType), new("exception", ex?.GetType().FullName));
 		}
 	}
 }
 
-public delegate Task<P2pNodeClient> P2pNodeProvider(CancellationToken cancellationToken);
+public delegate Task<P2pNodeGroupClient> P2pNodeProvider(CancellationToken cancellationToken);
 
 /// <summary>Snapshot of currently connected P2P nodes.</summary>
 public delegate ImmutableArray<Node> P2pNodeListProvider();
@@ -206,7 +272,8 @@ public class P2pConnectionManager : IDisposable
 		}
 	}
 
-	public async Task<P2pNodeClient> GetSingleUseNodeAsync(CancellationToken cancellationToken)
+	/// <seealso cref="P2pNodeProvider"/>
+	public async Task<P2pNodeGroupClient> GetSingleUseNodeAsync(CancellationToken cancellationToken)
 	{
 		while (!cancellationToken.IsCancellationRequested)
 		{
@@ -218,23 +285,18 @@ public class P2pConnectionManager : IDisposable
 				continue;
 			}
 
-			var node = nodes.RandomElement(SecureRandom.Instance);
+			// Get random nodes from the connected nodes. The random sample contains 1 to 3 nodes.
+			var randomNodes = nodes.ToShuffled(SecureRandom.Instance).Take(3).ToArray();
 
-			if (node is not null && node.IsConnected)
-			{
-				return new P2pNodeClient(
-					node,
-					GetCurrentTimeout(),
-					UpdateTimeout,
-					misbehavior =>
-					{
-						DisconnectNode(node, misbehavior);
-						ReportMisbehavior(node.RemoteSocketEndpoint, misbehavior);
-					});
-			}
-
-			Logger.LogTrace("Selected node is null or disconnected.");
-			await Task.Delay(10, cancellationToken).ConfigureAwait(false);
+			return new P2pNodeGroupClient(
+				randomNodes,
+				GetCurrentTimeout(),
+				UpdateTimeout,
+				(node, misbehavior) =>
+				{
+					DisconnectNode(node, misbehavior);
+					ReportMisbehavior(node.RemoteSocketEndpoint, misbehavior);
+				});
 		}
 
 		cancellationToken.ThrowIfCancellationRequested();

--- a/WalletWasabi/Wallets/BlockProviders.cs
+++ b/WalletWasabi/Wallets/BlockProviders.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Logging;
-using WalletWasabi.Services;
 using WalletWasabi.Services.NodesManagement;
 
 namespace WalletWasabi.Wallets;
@@ -34,8 +33,8 @@ public static class BlockProviders
 		{
 			while (!cancellationToken.IsCancellationRequested)
 			{
-				var singleUseNode = await getNode(cancellationToken).ConfigureAwait(false);
-				var block = await singleUseNode.GetBlockAsync(blockHash, cancellationToken).ConfigureAwait(false);
+				var singleUseNodeGroup = await getNode(cancellationToken).ConfigureAwait(false);
+				var block = await singleUseNodeGroup.GetBlockAsync(blockHash, cancellationToken).ConfigureAwait(false);
 				if (block is not null)
 				{
 					return block;


### PR DESCRIPTION
Stacked on top of #14713

This PR is a replacement for #14718 and it attempts to implement changes from #14025.

The idea of the PR is to: _Download Bitcoin blocks from up to 3 P2P connected nodes **in parallel** instead of just one to speed up block downloading_. 

Regarding privacy, all blocks are downloaded over Tor (if enabled), so the P2P nodes do not know who downloads blocks from them.

## Stats

```
=== metrics.1.json ===
Download blocks from 1 random peer from the set of peers we are connected to

Block count:    156
Total:    171069 ms
Average:  1096 ms

=== metrics.3.json ===
Download blocks from up to 3 random peers we are connected to.

Block count:    156
Total:    52134 ms
Average:  334 ms
```

So in this particular instance, it was about **3 times faster** to download blocks with this PR than on master.

## Repro

```bash
## First terminal tab
#
# Modify your wallet.json file
# "BlockchainState": {
#    "Network": "Main",
#    "Height": "850000",  // Set height to 850k
#    "BirthHeight": 940000 // your birth height
# },
# Blocks need to be deleted from your profile
rm ~/WalletWasabi/Client/BitcoinStore/Main/Blocks/* && dotnet run --project WalletWasabi.Fluent.Desktop

## Second terminal tab 
#
# Setup step. Install `dotnet-counters` (https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters)
dotnet tool update -g dotnet-counters
#
# Measure with the following two lines in `WalletWasabi/Services/NodesManagement/P2pConnectionManager.cs`:
# var randomNodes = nodes.ToShuffled(SecureRandom.Instance).Take(3).ToArray(); // up to 3 random P2P nodes (PR)
# var randomNodes = nodes.ToShuffled(SecureRandom.Instance).Take(1).ToArray(); // 1 random P2P node (this PR with a minor modifcation)
dotnet-counters collect --name WalletWasabi.Fluent.Desktop --counters P2pNodeGroupClient --maxHistograms 100000 --format json --output metrics.3.json
```

The following simple script was used to generate the stats above (requires just `jq` tool):

```bash
#!/bin/bash

for file in metrics.1.json metrics.3.json; do
  echo "=== $file ==="
  jq -r '
    [.Events[] | select(.name | startswith("p2p.block.download.duration")) | .value] as $d
    | "Block count:    \($d | length)",
      "Total:    \($d | add) ms",
      "Average:  \($d | (add / length)) ms\n"
  ' "$file"
done
```

`metrics.3.json` sample 

```json
{
    "TargetProcess": "WalletWasabi.Fluent.Desktop",
    "StartTime": "2026-07-07T12:17:06.7683463+02:00",
    "Events": [
        {
            "timestamp": "2026-07-07T12:17:15.9627474+02:00",
            "provider": "P2pNodeGroupClient",
            "name": "p2p.block.download.failures (Count / 1 sec)",
            "tags": "block_hash=00000000000000000000efa659caab8fac938f7a4440086fcfab82726d65f1e0,exception=System.InvalidOperationException,misbehavior=Unknown",
            "counterType": "Rate",
            "meterTags": "",
            "instrumentTags": "",
            "value": 1
        },
        {
            "timestamp": "2026-07-07T12:17:15.9678080+02:00",
            "provider": "P2pNodeGroupClient",
            "name": "p2p.block.download.attempts (Count / 1 sec)",
            "tags": "block_hash=00000000000000000000efa659caab8fac938f7a4440086fcfab82726d65f1e0",
            "counterType": "Rate",
            "meterTags": "",
            "instrumentTags": "",
            "value": 1
        },
        {
            "timestamp": "2026-07-07T12:17:16.9380022+02:00",
            "provider": "P2pNodeGroupClient",
            "name": "p2p.block.download.failures (Count / 1 sec)",
            "tags": "block_hash=00000000000000000000efa659caab8fac938f7a4440086fcfab82726d65f1e0,exception=System.InvalidOperationException,misbehavior=Unknown",
            "counterType": "Rate",
            "meterTags": "",
            "instrumentTags": "",
            "value": 0
        },
        {
            "timestamp": "2026-07-07T12:17:16.9409973+02:00",
            "provider": "P2pNodeGroupClient",
            "name": "p2p.block.download.duration (ms)",
            "tags": "block_hash=00000000000000000000efa659caab8fac938f7a4440086fcfab82726d65f1e0,node=[::ffff:145.40.231.246]:8333,status=success,Percentile=50",
            "counterType": "Metric",
            "meterTags": "",
            "instrumentTags": "",
            "value": 559
        },
        {
            "timestamp": "2026-07-07T12:17:16.9410267+02:00",
            "provider": "P2pNodeGroupClient",
            "name": "p2p.block.download.duration (ms)",
            "tags": "block_hash=00000000000000000000efa659caab8fac938f7a4440086fcfab82726d65f1e0,node=[::ffff:145.40.231.246]:8333,status=success,Percentile=95",
            "counterType": "Metric",
            "meterTags": "",
            "instrumentTags": "",
            "value": 559
        },
        {
            "timestamp": "2026-07-07T12:17:16.9410327+02:00",
            "provider": "P2pNodeGroupClient",
            "name": "p2p.block.download.duration (ms)",
            "tags": "block_hash=00000000000000000000efa659caab8fac938f7a4440086fcfab82726d65f1e0,node=[::ffff:145.40.231.246]:8333,status=success,Percentile=99",
            "counterType": "Metric",
            "meterTags": "",
            "instrumentTags": "",
            "value": 559
        },
        {
            "timestamp": "2026-07-07T12:17:16.9410801+02:00",
            "provider": "P2pNodeGroupClient",
            "name": "p2p.block.download.attempts (Count / 1 sec)",
            "tags": "block_hash=00000000000000000000efa659caab8fac938f7a4440086fcfab82726d65f1e0",
            "counterType": "Rate",
            "meterTags": "",
            "instrumentTags": "",
            "value": 0
        },
        {
            "timestamp": "2026-07-07T12:17:16.9411056+02:00",
            "provider": "P2pNodeGroupClient",
            "name": "p2p.block.download.successes (Count / 1 sec)",
            "tags": "block_hash=00000000000000000000efa659caab8fac938f7a4440086fcfab82726d65f1e0",
            "counterType": "Rate",
            "meterTags": "",
            "instrumentTags": "",
            "value": 1
        },
        {
            "timestamp": "2026-07-07T12:17:17.9463281+02:00",
            "provider": "P2pNodeGroupClient",
            "name": "p2p.block.download.failures (Count / 1 sec)",
            "tags": "block_hash=00000000000000000000efa659caab8fac938f7a4440086fcfab82726d65f1e0,exception=System.InvalidOperationException,misbehavior=Unknown",
            "counterType": "Rate",
            "meterTags": "",
            "instrumentTags": "",
            "value": 0
        }
    ]
}
```

Simple queries for `metrics.3.json` files are possible:

```bash
# Number of successful downloads
jq '[.Events[] | select(.name | startswith("p2p.block.download.duration"))] | length' ./metrics.3.json

# Total cumulative download time 
jq '[.Events[] | select(.name | startswith("p2p.block.download.duration")) | .value] | add' ./metrics.3.json 

# Number of failures
jq '[.Events[] | select(.name | startswith("p2p.block.download.failures")) | .value] | add' ./metrics.3.json
```