### PR TITLE
Fix coin labels bleeding across wallets

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionProcessorTests.cs
@@ -1123,6 +1123,40 @@ public class TransactionProcessorTests
 	}
 
 	[Fact]
+	public async Task LabelsDoNotBleedAcrossWalletsAsync()
+	{
+		// Repro for #10980: two wallets loaded in the same Wasabi instance share a single
+		// AllTransactionStore, hence the same SmartTransaction instances. When wallet A sends
+		// to wallet B, the shared tx.WalletInputs keeps A's spent coin, and B's AnalyzeClusters
+		// merges B's received coin cluster with A's input cluster -> labels leak across wallets.
+		using var txStore = await CreateTransactionStoreAsync();
+		var walletA = CreateTransactionProcessor(txStore);
+		var walletB = CreateTransactionProcessor(txStore);
+
+		// Wallet A is funded with 50 000 sats on an address labeled "Alice".
+		var aliceKey = walletA.NewKey("Alice");
+		var tx0 = CreateCreditingTransaction(aliceKey.P2wpkhScript, Money.Satoshis(50_000));
+		walletA.Process(tx0);
+		var aliceCoin = walletA.Coins.First();
+		Assert.Equal("Alice", aliceCoin.HdPubKey.ClusterLabels.ToString());
+
+		// Wallet A pays wallet B (address labeled "Bob"), with change back to wallet A.
+		var bobKey = walletB.NewKey("Bob");
+		var changeKey = walletA.NewKey("");
+		var tx1 = CreateSpendingTransaction(new[] { aliceCoin.Coin }, bobKey.P2wpkhScript, changeKey.P2wpkhScript);
+
+		walletA.Process(tx1);
+		walletB.Process(tx1);
+
+		var bobCoin = walletB.Coins.Single(c => c.HdPubKey == bobKey);
+		var changeCoin = walletA.Coins.Single(c => c.HdPubKey == changeKey);
+
+		// Neither wallet may ever see the other's private label.
+		Assert.Equal("Bob", bobCoin.HdPubKey.ClusterLabels.ToString());     // B must not gain "Alice".
+		Assert.Equal("Alice", changeCoin.HdPubKey.ClusterLabels.ToString()); // A must not gain "Bob".
+	}
+
+	[Fact]
 	public async Task MultipleDirectClusteringAsync()
 	{
 		// --tx0---> (A) --+

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -67,7 +67,6 @@ public static class BlockchainAnalyzer
 			AdjustWalletInputs(tx, startingOutputAnonset);
 		}
 
-		AnalyzeClusters(tx);
 		ResetUncalculatedAnonScores(tx);
 	}
 
@@ -363,9 +362,20 @@ public static class BlockchainAnalyzer
 		}
 	}
 
-	private static void AnalyzeClusters(SmartTransaction tx)
+	/// <summary>
+	/// Merges the clusters (hence the labels) of the coins the wallet spent and created in this transaction.
+	/// <para>
+	/// Only <paramref name="keyManager"/>'s own coins are considered. The transaction store is shared by every
+	/// loaded wallet, so the same <see cref="SmartTransaction"/> instance's <see cref="SmartTransaction.WalletInputs"/>
+	/// and <see cref="SmartTransaction.WalletOutputs"/> may also hold other wallets' coins. Merging clusters across
+	/// that boundary would leak one wallet's private labels into another.
+	/// </para>
+	/// <remarks>Context: https://github.com/WalletWasabi/WalletWasabi/issues/10980</remarks>
+	/// </summary>
+	public static void AnalyzeClusters(SmartTransaction tx, KeyManager keyManager)
 	{
-		foreach (var newCoin in tx.WalletOutputs)
+		var walletInputs = tx.GetWalletInputs(keyManager).ToList();
+		foreach (var newCoin in tx.GetWalletOutputs(keyManager))
 		{
 			// Forget clusters when no unique outputs created in coinjoins,
 			// otherwise in half mixed wallets all the labels quickly gravitate into a single cluster
@@ -373,7 +383,7 @@ public static class BlockchainAnalyzer
 			if (newCoin.HdPubKey.AnonymitySet < Constants.SemiPrivateThreshold)
 			{
 				// Set clusters.
-				foreach (var spentCoin in tx.WalletInputs)
+				foreach (var spentCoin in walletInputs)
 				{
 					newCoin.HdPubKey.Cluster.Merge(spentCoin.HdPubKey.Cluster);
 				}

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -262,6 +262,7 @@ public class TransactionProcessor(
 		}
 
 		BlockchainAnalyzer.Analyze(result.Transaction);
+		BlockchainAnalyzer.AnalyzeClusters(result.Transaction, KeyManager);
 		SyncAnonScoresFromSharedTransaction(result.Transaction);
 
 		return result;


### PR DESCRIPTION
Closes #10980

**Problem**

Every loaded wallet shares a single `AllTransactionStore`, so they share the same `SmartTransaction` instances. A transaction's WalletInputs / WalletOutputs therefore accumulate coins from every loaded wallet that has processed it.

`BlockchainAnalyzer.AnalyzeClusters` iterated those shared collections and merged the cluster of each output with the cluster of every input. So when wallet A pays wallet B (or both take part in the same coinjoin) and both wallets are loaded, A's input cluster gets merged into B's output cluster. The result is that A's private labels leak into B's coins and vice-versa.

It needs to be noted that this is not about cosmetic label. `ClusterLabels` is used in pocket boundaries in the Send flow and `SmartCoinSelector`'s coin-selection scoring, so one wallet's labels end up influencing another wallet's on-chain spending decisions.

**Fix**

`AnalyzeClusters` now requires a `KeyManager` and only merges the current wallet's own coins, using the existing `SmartTransaction.GetWalletInputs/GetWalletOutputs(keyManager)` script-ownership filter. It is called from `TransactionProcessor` right after `Analyze`, with the processor's own `KeyManager`.

Unit test added: LabelsDoNotBleedAcrossWalletsAsync. Two wallets sharing one store, A pays B. Asserts B's coin keeps only its own label and A's change keeps only its own label.

**Disclaimers**

- This PR only fixes the cross-wallet leak in cluster labels, which surface in the UTXO list, Send pockets, and SmartCoinSelector. It does NOT change the transaction history. History labels come from a different field (SmartTransaction.Labels) which is also shared across wallets and has its own cross-wallet leak. That's a separate issue.
- Again, this code is written with AI, and I consider it simple to read and explain. 