### PR TITLE
Fix regtest from persisting block header chain

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -173,10 +173,6 @@ public class Global
 	{
 		var blockHeadersFilePath = Path.Combine(p2PDataDir, $"BlockHeaders{Network}.dat");
 
-		// On RegTest the chain can be reset or recreated at will (fresh datadir, -reindex, re-mining),
-		// producing different block hashes for the same heights. A persisted header chain then references
-		// blocks that no longer exist, which breaks filter synchronization with "Block not found".
-		// Always start from a fresh chain on RegTest, mirroring how the filter store is wiped there.
 		if (Network == Network.RegTest)
 		{
 			DeleteBlockHeadersFile(blockHeadersFilePath);
@@ -198,7 +194,6 @@ public class Global
 
 	private static void DeleteBlockHeadersFile(string blockHeadersFilePath)
 	{
-		// SafelyWriteAllBytes may leave ".old"/".new" siblings behind, so remove those too.
 		foreach (var path in new[] { blockHeadersFilePath, $"{blockHeadersFilePath}.old", $"{blockHeadersFilePath}.new" })
 		{
 			if (File.Exists(path))
@@ -795,8 +790,6 @@ public class Global
 					Logger.LogError($"Error during {nameof(WalletManager.RemoveAndStopAllAsync)}: {ex}");
 				}
 
-				// Don't persist the RegTest header chain: it is intentionally rebuilt from scratch on
-				// startup (see ConfigureBlockHeaderChain) so it can never go stale across chain resets.
 				if (Network != Network.RegTest && _blockHeaders.Tip is not null)
 				{
 					var p2PDataDir = GetBitcoinP2PNetworkDirectory();

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -172,6 +172,17 @@ public class Global
 	private ConcurrentChain ConfigureBlockHeaderChain(string p2PDataDir)
 	{
 		var blockHeadersFilePath = Path.Combine(p2PDataDir, $"BlockHeaders{Network}.dat");
+
+		// On RegTest the chain can be reset or recreated at will (fresh datadir, -reindex, re-mining),
+		// producing different block hashes for the same heights. A persisted header chain then references
+		// blocks that no longer exist, which breaks filter synchronization with "Block not found".
+		// Always start from a fresh chain on RegTest, mirroring how the filter store is wiped there.
+		if (Network == Network.RegTest)
+		{
+			DeleteBlockHeadersFile(blockHeadersFilePath);
+			return new ConcurrentChain(Network);
+		}
+
 		var blockHeaders = Result<byte[], Exception>
 			.Catch(() => File.SafelyReadAllBytes(blockHeadersFilePath))
 			.Match(
@@ -183,6 +194,18 @@ public class Global
 				_ => new ConcurrentChain(Network));
 
 		return blockHeaders;
+	}
+
+	private static void DeleteBlockHeadersFile(string blockHeadersFilePath)
+	{
+		// SafelyWriteAllBytes may leave ".old"/".new" siblings behind, so remove those too.
+		foreach (var path in new[] { blockHeadersFilePath, $"{blockHeadersFilePath}.old", $"{blockHeadersFilePath}.new" })
+		{
+			if (File.Exists(path))
+			{
+				File.Delete(path);
+			}
+		}
 	}
 
 	private P2pConnectionManager ConfigureNodeConnectionManager()
@@ -772,7 +795,9 @@ public class Global
 					Logger.LogError($"Error during {nameof(WalletManager.RemoveAndStopAllAsync)}: {ex}");
 				}
 
-				if (_blockHeaders.Tip is not null)
+				// Don't persist the RegTest header chain: it is intentionally rebuilt from scratch on
+				// startup (see ConfigureBlockHeaderChain) so it can never go stale across chain resets.
+				if (Network != Network.RegTest && _blockHeaders.Tip is not null)
 				{
 					var p2PDataDir = GetBitcoinP2PNetworkDirectory();
 					var blockHeadersFilePath = Path.Combine(p2PDataDir, $"BlockHeaders{Network}.dat");


### PR DESCRIPTION
## Problem

On regtest the client can get stuck at startup, looping:

    ERR | Synchronizer.cs:117 | Error fetching filter from bitcoin RPC -
    Block not found. Retrying in 15 seconds...

The regtest chain is disposable (fresh datadir, -reindex, re-mining), so the same heights get different block hashes. The block header chain is persisted across restarts, so after a reset it still holds hashes from the old chain. The RPC filter provider then asks bitcoind for getblockfilter on a stale hash and stucks at "Block not found" forever. 

## Fix

WalletWasabi.Client/Global.cs:
- On regtest, start from a fresh ConcurrentChain and delete the stale BlockHeaders*.dat (and its .old/.new siblings) on startup.
- On regtest, skip persisting the header chain on shutdown.

With an empty header chain, GetBlockHashesAsync takes the RPC branch (getblockhash -> current-chain hashes -> getblockfilter) and sync proceeds.

## Testing

Try running regtest on datadir A, mine a few blocks, then close Wasabi, start regtest on datadir B, mine a few blocks there, and then try to open Wasabi at that new datadir. 

## Disclaimer

This was detected and fixed with AI. As a broader observation: as AI advances and more development tasks become automatable, regtest grows increasingly important for both Bitcoin and Wasabi development. There are tasks you can automate on regtest that are simply not possible on mainnet or testnet; you can spin up a chain, mine blocks on demand, reset, destroy it, and replay scenarios instantly, at no cost and with no risk to real funds. Mainnet involves real money, and testnet is slow, which makes both poorly suited to exhaustive, AI-driven testing.