### PR TITLE
Measure the sync progress in the wallet's own block range

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletLoadWorkflow.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletLoadWorkflow.cs
@@ -11,11 +11,13 @@ using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.Models.Wallets;
 
+
 public record SyncProgressCardModel(uint Initial, uint Current, uint Target)
 {
-	public double Percent => Target <= Initial
-		? (Current >= Target ? 100 : 0)
-		: Math.Clamp(100.0 * (Current - Initial) / (Target - Initial), 0, 100);
+	public double Percent =>
+		Target == 0 ? 0
+		: Target <= Initial ? (Current >= Target ? 100 : 0)
+		: Math.Clamp(100.0 * ((double)Current - Initial) / (Target - Initial), 0, 100);
 
 	public bool IsComplete => Percent >= 100;
 }
@@ -42,11 +44,8 @@ public partial class WalletLoadWorkflow
 	private readonly Subject<WalletLoadProgress> _progress;
 	[AutoNotify] private bool _isLoading;
 
-	// Initial values for progress calculation
-	private readonly uint _initialBlockHeaders;
-	private readonly uint _initialWalletSyncHeight;
-	private readonly uint _initialFilterHeaders;
-	private readonly uint _initialCompactFilters;
+	// The progress of every stage syncing the wallet is measured from.
+	private readonly uint _walletStartHeight;
 
 	public WalletLoadWorkflow(IServices services, Wallet wallet)
 	{
@@ -55,28 +54,17 @@ public partial class WalletLoadWorkflow
 		_progress = new();
 
 		var tipHeight = services.GetTipHeight();
-		var blockHeadersTip = services.GetBlockHeadersTipHeight();
-		var serverTipHeight = services.GetServerTipHeight();
 		var walletBestHeight = (uint)wallet.KeyManager.GetBestHeight();
 
-		// Store initial values for progress calculation
-		_initialBlockHeaders = blockHeadersTip;
-		_initialWalletSyncHeight = walletBestHeight;
-		_initialFilterHeaders = tipHeight;
-		_initialCompactFilters = tipHeight;
-
-		_blockHeadersTip = blockHeadersTip;
+		_blockHeadersTip = services.GetBlockHeadersTipHeight();
 		_filterHeadersTip = tipHeight;
 		_compactFiltersTip = tipHeight;
 		_walletSyncHeight = walletBestHeight;
 
-		_progress.OnNext(new WalletLoadProgress(
-			ChainTip: serverTipHeight,
-			Peers: new SyncProgressCardModel(0, (uint)services.GetPeerCount(), TargetPeers),
-			BlockHeaders: new SyncProgressCardModel(_initialBlockHeaders, _initialBlockHeaders, serverTipHeight),
-			FilterHeaders: new SyncProgressCardModel(_initialFilterHeaders, _initialFilterHeaders, serverTipHeight),
-			CompactFilters: new SyncProgressCardModel(_initialCompactFilters, _initialCompactFilters, serverTipHeight),
-			Blocks: new SyncProgressCardModel(_initialWalletSyncHeight, _walletSyncHeight, serverTipHeight)));
+		// Wallets created before the birth height was introduced don't have one.
+		_walletStartHeight = wallet.KeyManager.GetBirthHeight() is { } birthHeight ? (uint)birthHeight : walletBestHeight;
+
+		UpdateProgress();
 
 		services.EventBus.AsObservable<BlockHeadersTipChanged>()
 			.ObserveOn(RxApp.MainThreadScheduler)
@@ -176,9 +164,12 @@ public partial class WalletLoadWorkflow
 		_progress.OnNext(new WalletLoadProgress(
 			ChainTip: tipHeight,
 			Peers: new SyncProgressCardModel(0, (uint)_services.GetPeerCount(), TargetPeers),
-			BlockHeaders: new SyncProgressCardModel(_initialBlockHeaders, _blockHeadersTip, tipHeight),
-			FilterHeaders: new SyncProgressCardModel(_initialFilterHeaders, _filterHeadersTip, tipHeight),
-			CompactFilters: new SyncProgressCardModel(_initialCompactFilters, _compactFiltersTip, tipHeight),
-			Blocks: new SyncProgressCardModel(_initialWalletSyncHeight, _walletSyncHeight, tipHeight)));
+
+			// Block headers are synced for the whole chain, not only for the range the wallet is scanned in.
+			BlockHeaders: new SyncProgressCardModel(0, _blockHeadersTip, tipHeight),
+
+			FilterHeaders: new SyncProgressCardModel(_walletStartHeight, _filterHeadersTip, tipHeight),
+			CompactFilters: new SyncProgressCardModel(_walletStartHeight, _compactFiltersTip, tipHeight),
+			Blocks: new SyncProgressCardModel(_walletStartHeight, _walletSyncHeight, tipHeight)));
 	}
 }


### PR DESCRIPTION
Closes #14774

### Before

Each card measured its progress in its own window: `(Current - Initial) / (Target - Initial)`, where `Initial` was whatever the corresponding chain reported. That gave two problems:

- The filter chains are initialized asynchronously, so at that moment they still report 0, and their bars ended up measured from the genesis block instead of from the checkpoint the wallet is scanned from. On a first recovery they showed ~50% while "Blocks" (whose starting height comes from the `KeyManager` and is always known) correctly showed 0%. This is the reported issue.
- Because every card had a different window, the bars were not comparable: a card that started further back showed a longer bar than a card sitting at a higher block height, contradicting the heights printed above them, worsening the UI.

### After

The loading screen belongs to a single wallet, so every stage that syncs it (from filter headers to compact filters and blocks) is now measured in the range that wallet is scanned in: from its birth height to the chain tip. One shared window means the bars always agree with the heights above them and can be compared with each other.

Block headers are measured from the genesis block, so they are excluded from this rule.

### Disclaimer

The problem was solved with AI. Also, the AI detected two subtler problems in the same scope and fixed them:

- An unknown tip (all heights `0`, before the network tip arrives) made every card report `100%` and show the completion checkmark. It now reports `0%`.
- `Current - Initial` was `uint` arithmetic, so a `Current` below `Initial` underflowed and filled the bar instead of leaving it empty. Now filters below the wallet's birth height are irrelevant to it and must show no progress.