### PR TITLE
Make BIP39 the default option for wallet recovery

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/WalletBackupTypeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/WalletBackupTypeViewModel.cs
@@ -37,14 +37,14 @@ public partial class WalletBackupTypeViewModel : RoutableViewModel
 			{
 				_walletBackupTypes =
 				[
-					new WalletBackupType.MultiShare(
-						new WalletBackupTypeOptions(
-							Description: "Parts of Shamir's Secret Sharing (SLIP-0039)",
-							HelpText: "Use a backup that was split into multiple parts. You’ll need some of them to restore your wallet.")),
 					new WalletBackupType.RecoveryWords(
 						new WalletBackupTypeOptions(
 							Description: "Single mnemonic phrase (BIP39)",
 							HelpText: "Use a backup generated from a set of 12, 18, or 24 words.")),
+					new WalletBackupType.MultiShare(
+						new WalletBackupTypeOptions(
+							Description: "Parts of Shamir's Secret Sharing (SLIP-0039)",
+							HelpText: "Use a backup that was split into multiple parts. You’ll need some of them to restore your wallet.")),
 				];
 
 				break;


### PR DESCRIPTION
Makes BIP39 the default option for wallet recovery, because it is far more widely used than SLIP39. 