### PR TITLE
Fix GUI staying frozen after Ctrl-C when shutdown is prevented

### DIFF
--- a/WalletWasabi.Fluent/ApplicationStateManager.cs
+++ b/WalletWasabi.Fluent/ApplicationStateManager.cs
@@ -177,6 +177,11 @@ public class ApplicationStateManager : IMainWindowService
 
 	private void CreateAndShowMainWindow()
 	{
+		if (_isShuttingDown)
+		{
+			return;
+		}
+
 		if (_lifetime.MainWindow is { })
 		{
 			return;
@@ -207,6 +212,8 @@ public class ApplicationStateManager : IMainWindowService
 					_isShuttingDown = true;
 					tup.EventArgs.Cancel = false;
 					_stateMachine.Fire(Trigger.ShutdownRequested);
+
+					return;
 				}
 
 				// _hideRequest flag is used to distinguish what is the user's intent.


### PR DESCRIPTION
Closes #13719.

## Problem

Pressing Ctrl-C in the terminal sometimes left the main window on screen, frozen and unresponsive, while the process kept running. Reproducible whenever shutdown prevention was active at the moment of Ctrl-C: a coinjoin in critical phase, or an open dialog with wallets loaded.

## Fix

- Add the missing `return` after the enforced-shutdown branch so Ctrl-C never falls into the shutdown-prevented logic.
- Guard `CreateAndShowMainWindow()` with `_isShuttingDown` so no code path can create a window once shutdown has started.

## Verify

Run from a terminal, create a wallet, open Settings (leave it open), press Ctrl-C on your terminal. 