### PR TITLE
Pay in coinjoin regardless of anonymity score

### DIFF
--- a/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
@@ -136,6 +136,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 			["isHardwareWallet"] = activeWallet.KeyManager.IsHardwareWallet,
 			["isAutoCoinjoin"] = activeWallet.KeyManager.AutoCoinJoin,
 			["isNonPrivateCoinIsolation"] = activeWallet.KeyManager.NonPrivateCoinIsolation,
+			["allowPaymentsRegardlessOfAnonScore"] = activeWallet.KeyManager.AllowPaymentsRegardlessOfAnonScore,
 			["accounts"] = new[] { segwit }
 		};
 

--- a/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
@@ -23,6 +23,7 @@ public partial class WalletSettingsModel : ReactiveObject
 	[AutoNotify] private Money _plebStopThreshold;
 	[AutoNotify] private int _anonScoreTarget;
 	[AutoNotify] private bool _nonPrivateCoinIsolation;
+	[AutoNotify] private bool _allowPaymentsRegardlessOfAnonScore;
 	[AutoNotify] private WalletId? _outputWalletId;
 	[AutoNotify] private ScriptType _defaultReceiveScriptType;
 	[AutoNotify] private PreferredScriptPubKeyType _changeScriptPubKeyType;
@@ -42,6 +43,7 @@ public partial class WalletSettingsModel : ReactiveObject
 		_plebStopThreshold = _keyManager.PlebStopThreshold ?? KeyManager.DefaultPlebStopThreshold;
 		_anonScoreTarget = _keyManager.AnonScoreTarget;
 		_nonPrivateCoinIsolation = _keyManager.NonPrivateCoinIsolation;
+		_allowPaymentsRegardlessOfAnonScore = _keyManager.AllowPaymentsRegardlessOfAnonScore;
 
 		if (!isNewWallet)
 		{
@@ -59,7 +61,8 @@ public partial class WalletSettingsModel : ReactiveObject
 				x => x.PreferPsbtWorkflow,
 				x => x.PlebStopThreshold,
 				x => x.AnonScoreTarget,
-				x => x.NonPrivateCoinIsolation)
+				x => x.NonPrivateCoinIsolation,
+				x => x.AllowPaymentsRegardlessOfAnonScore)
 			.Skip(1)
 			.Do(_ => SetValues())
 			.Subscribe();
@@ -106,6 +109,7 @@ public partial class WalletSettingsModel : ReactiveObject
 		_keyManager.PlebStopThreshold = PlebStopThreshold;
 		_keyManager.AnonScoreTarget = AnonScoreTarget;
 		_keyManager.NonPrivateCoinIsolation = NonPrivateCoinIsolation;
+		_keyManager.AllowPaymentsRegardlessOfAnonScore = AllowPaymentsRegardlessOfAnonScore;
 		_keyManager.DefaultSendWorkflow = DefaultSendWorkflow;
 		_keyManager.DefaultReceiveScriptType = ScriptType.ToScriptPubKeyType(DefaultReceiveScriptType);
 		_keyManager.ChangeScriptPubKeyType = ChangeScriptPubKeyType;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -7,6 +7,7 @@ using WalletWasabi.Fluent.Infrastructure;
 using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.State;
 using WalletWasabi.Fluent.ViewModels.Wallets.Settings;
+using WalletWasabi.Services;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
 using WalletWasabi.WabiSabi.Coordinator.Rounds;
@@ -112,10 +113,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.Subscribe();
 
 		// Refresh the paused music box when a pending payment is added or removed (when paying in coinjoin regardless of anon score)
-		Observable
-			.FromEventPattern(
-				h => _walletInstance.BatchedPayments.PaymentsChanged += h,
-				h => _walletInstance.BatchedPayments.PaymentsChanged -= h)
+		UiContext.Services.EventBus.AsObservable<PaymentBatchChanged>()
 			.ObserveOn(RxApp.MainThreadScheduler)
 			.Do(_ => _stateMachine.Fire(Trigger.PendingPaymentsChanged))
 			.Subscribe();

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -37,6 +37,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 	private const string NoCoinsEligibleToMixMessage = "Insufficient funds eligible for coinjoin";
 	private const string UserInSendWorkflowMessage = "Awaiting closure of send dialog";
 	private const string AllPrivateMessage = "Hurray! All your funds are private!";
+	private const string AllCoinsArePrivate = "All coins are private";
 	private const string GeneralErrorMessage = "Awaiting valid conditions";
 	private const string WaitingForConfirmedFunds = "Awaiting confirmed funds";
 	private const string CoinsRejectedMessage = "Some funds are rejected from coinjoining";
@@ -52,6 +53,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 	[AutoNotify] private bool _isAutoWaiting;
 	[AutoNotify] private bool _playVisible;
+	[AutoNotify] private bool _playEnabled = true;
 	[AutoNotify] private bool _pauseVisible;
 	[AutoNotify] private bool _pauseSpreading;
 	[AutoNotify] private bool _stopVisible;
@@ -107,6 +109,22 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 
 		this.WhenAnyValue(x => x.AreAllCoinsPrivate)
 			.Do(_ => _stateMachine.Fire(Trigger.AreAllCoinsPrivateChanged))
+			.Subscribe();
+
+		// Refresh the paused music box when a pending payment is added or removed (when paying in coinjoin regardless of anon score)
+		Observable
+			.FromEventPattern(
+				h => _walletInstance.BatchedPayments.PaymentsChanged += h,
+				h => _walletInstance.BatchedPayments.PaymentsChanged -= h)
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Do(_ => _stateMachine.Fire(Trigger.PendingPaymentsChanged))
+			.Subscribe();
+
+		// Same refresh when the "pay in coinjoin regardless of anonymity score" toggle flips.
+		wallet.Settings.WhenAnyValue(x => x.AllowPaymentsRegardlessOfAnonScore)
+			.Skip(1)
+			.ObserveOn(RxApp.MainThreadScheduler)
+			.Do(_ => _stateMachine.Fire(Trigger.PendingPaymentsChanged))
 			.Subscribe();
 
 		PlayCommand = ReactiveCommand.CreateFromTask(async () =>
@@ -196,7 +214,8 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		WalletStartedCoinJoin,
 		WalletStoppedCoinJoin,
 		AutoCoinJoinOff,
-		AreAllCoinsPrivateChanged
+		AreAllCoinsPrivateChanged,
+		PendingPaymentsChanged
 	}
 
 	public IObservable<bool> CanNavigateToCoinjoinSettings { get; }
@@ -267,6 +286,10 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 				// Refresh the UI according to AreAllCoinsPrivate, the play button and the left-text.
 				RefreshButtonAndTextInStateStoppedOrPaused();
 			})
+			.OnTrigger(Trigger.PendingPaymentsChanged, () =>
+			{
+				RefreshButtonAndTextInStateStoppedOrPaused();
+			})
 			.OnExit(() => LeftText = "");
 
 		_stateMachine.Configure(State.Playing)
@@ -307,18 +330,32 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 		if (IsAutoCoinJoinEnabled)
 		{
 			PlayVisible = true;
+			PlayEnabled = true;
 			CurrentStatus = PauseMessage;
 			LeftText = PressPlayToStartMessage;
 		}
 		else if (AreAllCoinsPrivate)
 		{
-			PlayVisible = false;
-			LeftText = "";
-			CurrentStatus = AllPrivateMessage;
+			if (_wallet.Settings.AllowPaymentsRegardlessOfAnonScore)
+			{
+				var hasPendingPayments = _walletInstance.BatchedPayments.AreTherePendingPayments;
+				PlayVisible = true;
+				PlayEnabled = hasPendingPayments;
+				CurrentStatus = hasPendingPayments ? StoppedMessage : AllCoinsArePrivate;
+				LeftText = hasPendingPayments ? PressPlayToStartMessage : "";
+			}
+			else
+			{
+				PlayVisible = false;
+				PlayEnabled = true;
+				LeftText = "";
+				CurrentStatus = AllPrivateMessage;
+			}
 		}
 		else
 		{
 			PlayVisible = true;
+			PlayEnabled = true;
 			CurrentStatus = StoppedMessage;
 			LeftText = PressPlayToStartMessage;
 		}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletCoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletCoinJoinSettingsViewModel.cs
@@ -29,6 +29,7 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 
 	[AutoNotify] private string _anonScoreTarget;
 	[AutoNotify] private bool _nonPrivateCoinIsolation;
+	[AutoNotify] private bool _allowPaymentsRegardlessOfAnonScore;
 	[AutoNotify] private bool _maximizePrivacyProfileSelected;
 	[AutoNotify] private bool _defaultProfileSelected;
 	[AutoNotify] private bool _economicalProfileSelected;
@@ -48,6 +49,7 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 		_plebStopThreshold = _wallet.Settings.PlebStopThreshold.ToString();
 		_anonScoreTarget = _wallet.Settings.AnonScoreTarget.ToString();
 		_nonPrivateCoinIsolation = _wallet.Settings.NonPrivateCoinIsolation;
+		_allowPaymentsRegardlessOfAnonScore = _wallet.Settings.AllowPaymentsRegardlessOfAnonScore;
 
 		_selectedOutputWallet = UiContext.WalletRepository.Wallets.Items.First(x => x.Id == _wallet.Settings.OutputWalletId);
 
@@ -70,6 +72,13 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 			return Task.CompletedTask;
 		});
 
+		SetAllowPaymentsRegardlessOfAnonScoreCommand = ReactiveCommand.CreateFromTask(() =>
+		{
+			_wallet.Settings.AllowPaymentsRegardlessOfAnonScore = AllowPaymentsRegardlessOfAnonScore;
+			_wallet.Settings.Save();
+			return Task.CompletedTask;
+		});
+
 		SelectMaximizePrivacySettings = ReactiveCommand.CreateFromTask(() => SetProfile("MaximizePrivacy"));
 
 		SelectDefaultSettings = ReactiveCommand.CreateFromTask(() => SetProfile("Default"));
@@ -78,7 +87,8 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 
 		this.WhenAnyValue(
 				x => x.AnonScoreTarget,
-				x => x.NonPrivateCoinIsolation)
+				x => x.NonPrivateCoinIsolation,
+				x => x.AllowPaymentsRegardlessOfAnonScore)
 			.ObserveOn(RxApp.TaskpoolScheduler)
 			.Subscribe(_ =>
 			{
@@ -86,7 +96,8 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 					.FirstOrDefault(p =>
 						p.Equals(
 							int.TryParse(AnonScoreTarget, out var anonScoreTarget) ? anonScoreTarget : 0,
-							NonPrivateCoinIsolation));
+							NonPrivateCoinIsolation,
+							AllowPaymentsRegardlessOfAnonScore));
 
 				MaximizePrivacyProfileSelected = selectedProfile?.Name == "MaximizePrivacy";
 				EconomicalProfileSelected = selectedProfile?.Name == "Economical";
@@ -123,6 +134,7 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 
 	public ICommand SetAutoCoinJoin { get; }
 	public ICommand SetNonPrivateCoinIsolationCommand { get; }
+	public ICommand SetAllowPaymentsRegardlessOfAnonScoreCommand { get; }
 	public ICommand SelectMaximizePrivacySettings { get; }
 	public ICommand SelectDefaultSettings { get; }
 	public ICommand SelectEconomicalSettings { get; }
@@ -177,6 +189,9 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 
 		NonPrivateCoinIsolation = profile.NonPrivateCoinIsolation;
 		_wallet.Settings.NonPrivateCoinIsolation = profile.NonPrivateCoinIsolation;
+
+		AllowPaymentsRegardlessOfAnonScore = profile.AllowPaymentsRegardlessOfAnonScore;
+		_wallet.Settings.AllowPaymentsRegardlessOfAnonScore = profile.AllowPaymentsRegardlessOfAnonScore;
 
 		_wallet.Settings.Save();
 		return Task.CompletedTask;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/WalletViewModel.cs
@@ -38,6 +38,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 
 	[AutoNotify(SetterModifier = AccessModifier.Private)] private bool _isWalletBalanceZero;
 	[AutoNotify(SetterModifier = AccessModifier.Private)] private bool _areAllCoinsPrivate;
+	[AutoNotify(SetterModifier = AccessModifier.Private)] private bool _allowPaymentsRegardlessOfAnonScore;
 	[AutoNotify(SetterModifier = AccessModifier.Private)] private bool _hasMusicBoxBeenDisplayed;
 	[AutoNotify] private bool _isMusicBoxFlyoutDisplayed;
 
@@ -93,6 +94,9 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 		 WalletModel.Privacy.IsWalletPrivate
 			 .BindTo(this, x => x.AreAllCoinsPrivate);
 
+		 WalletModel.Settings.WhenAnyValue(x => x.AllowPaymentsRegardlessOfAnonScore)
+			 .BindTo(this, x => x.AllowPaymentsRegardlessOfAnonScore);
+
 		 IsMusicBoxVisible = this.WhenAnyValue(
 			 x => x.HasMusicBoxBeenDisplayed,
 			 x => x.IsSelected,
@@ -100,7 +104,8 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 			 x => x.AreAllCoinsPrivate,
 			 x => x.IsPointerOver,
 			 x => x.IsMusicBoxFlyoutDisplayed,
-			 (hasBeenDisplayed, isSelected, hasNoBalance, areAllCoinsPrivate, isPointerOver, isMusicBoxFlyoutDisplayed) =>
+			 x => x.AllowPaymentsRegardlessOfAnonScore,
+			 (hasBeenDisplayed, isSelected, hasNoBalance, areAllCoinsPrivate, isPointerOver, isMusicBoxFlyoutDisplayed, allowPaymentsRegardlessOfAnonScore) =>
 			 {
 				 if (!hasBeenDisplayed)
 				 {
@@ -119,7 +124,7 @@ public partial class WalletViewModel : RoutableViewModel, IWalletViewModel
 					 return isSelected && !WalletModel.IsCoinJoinEnabled && (isPointerOver || isMusicBoxFlyoutDisplayed);
 				 }
 
-				 return (isSelected && !hasNoBalance && (!areAllCoinsPrivate || (isPointerOver || isMusicBoxFlyoutDisplayed))) && !WalletModel.IsWatchOnlyWallet;
+				 return (isSelected && !hasNoBalance && (!areAllCoinsPrivate || allowPaymentsRegardlessOfAnonScore || isPointerOver || isMusicBoxFlyoutDisplayed)) && !WalletModel.IsWatchOnlyWallet;
 			 });
 
 

--- a/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/MusicControlsView.axaml
@@ -92,6 +92,7 @@
 
               <Button Classes="plain"
                       IsVisible="{Binding CoinJoinStateViewModel.PlayVisible}"
+                      IsEnabled="{Binding CoinJoinStateViewModel.PlayEnabled}"
                       Command="{Binding CoinJoinStateViewModel.PlayCommand}">
                 <PathIcon Data="{StaticResource play_regular}" />
               </Button>

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
@@ -53,6 +53,11 @@
       <ToggleSwitch IsChecked="{Binding NonPrivateCoinIsolation}" Command="{Binding SetNonPrivateCoinIsolationCommand}" />
     </DockPanel>
 
+    <DockPanel ToolTip.Tip="When enabled, payments in coinjoin can be funded with private coins, so you can pay without mixing non-private coins first. Disable it to save fees.">
+      <TextBlock Text="Pay in coinjoin regardless of anonymity score" />
+      <ToggleSwitch IsChecked="{Binding AllowPaymentsRegardlessOfAnonScore}" Command="{Binding SetAllowPaymentsRegardlessOfAnonScoreCommand}" />
+    </DockPanel>
+
     <DockPanel>
       <TextBlock Text="Anonymity score target" ToolTip.Tip="Minimum anonymity score to consider a coin private." />
       <TextBox Classes="standalone" Name="AnonScoreTargetTextBox" Text="{Binding AnonScoreTarget}" DockPanel.Dock="Right" Watermark="Choose between 2 and 300." MaxLength="3" />

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -66,6 +66,40 @@ public class CoinJoinCoinSelectionTests
 		Assert.Empty(coins);
 	}
 
+	/// <summary>
+	/// This test is to make sure private coins are selected to fund a payment when the user opted in to
+	/// pay in coinjoin regardless of the anonymity score.
+	/// </summary>
+	[Fact]
+	public void SelectPrivateCoinsToPayRegardlessOfAnonScore()
+	{
+		const int AnonymitySet = 10;
+		var km = KeyManager.CreateNew(out _, "", Network.Main);
+		var coinsToSelectFrom = Enumerable
+			.Range(0, 10)
+			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1))
+			.ToList();
+
+		// Make sure the distance from external keys is sufficient.
+		foreach (var sc in coinsToSelectFrom)
+		{
+			var sci = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1);
+			sci.Transaction.TryAddWalletInput(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1));
+			sc.Transaction.TryAddWalletInput(sci);
+		}
+
+		CoinJoinCoinSelectorRandomnessGenerator generator = CreateSelectorGenerator(inputTarget: 5);
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: AnonymitySet, semiPrivateThreshold: 0, generator, allowPaymentsRegardlessOfAnonScore: true);
+
+		var coins = coinJoinCoinSelector.SelectCoinsForRound(
+			coins: coinsToSelectFrom,
+			CreateUtxoSelectionParameters(),
+			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
+
+		Assert.NotEmpty(coins);
+		Assert.All(coins, coin => Assert.Contains(coin, coinsToSelectFrom));
+	}
+
 	[Fact]
 	public void SelectNothingFromTooSmallCoin()
 	{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -68,7 +68,8 @@ public class CoinJoinCoinSelectionTests
 
 	/// <summary>
 	/// This test is to make sure private coins are selected to fund a payment when the user opted in to
-	/// pay in coinjoin regardless of the anonymity score.
+	/// pay in coinjoin regardless of the anonymity score. In that case <see cref="CoinJoinCoinSelector.FromWallet"/>
+	/// lifts the anonymity score target so every private coin becomes selectable.
 	/// </summary>
 	[Fact]
 	public void SelectPrivateCoinsToPayRegardlessOfAnonScore()
@@ -89,7 +90,7 @@ public class CoinJoinCoinSelectionTests
 		}
 
 		CoinJoinCoinSelectorRandomnessGenerator generator = CreateSelectorGenerator(inputTarget: 5);
-		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: AnonymitySet, semiPrivateThreshold: 0, generator, allowPaymentsRegardlessOfAnonScore: true);
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: int.MaxValue, semiPrivateThreshold: 0, generator);
 
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -199,6 +199,8 @@ public class KeyManager
 
 	public bool NonPrivateCoinIsolation { get; set; } = PrivacyProfiles.DefaultProfile.NonPrivateCoinIsolation;
 
+	public bool AllowPaymentsRegardlessOfAnonScore { get; set; } = PrivacyProfiles.DefaultProfile.AllowPaymentsRegardlessOfAnonScore;
+
 	public ScriptPubKeyType DefaultReceiveScriptType { get; set; } = ScriptPubKeyType.TaprootBIP86;
 
 	public PreferredScriptPubKeyType ChangeScriptPubKeyType { get; set; } = PreferredScriptPubKeyType.Unspecified.Instance;
@@ -758,6 +760,7 @@ public class KeyManager
 			("Icon", Encode.Optional(keyManager.Icon, Encode.String)),
 			("AnonScoreTarget", Encode.Int(keyManager.AnonScoreTarget)),
 			("RedCoinIsolation", Encode.Bool(keyManager.NonPrivateCoinIsolation)),
+			("AllowPaymentsRegardlessOfAnonScore", Encode.Bool(keyManager.AllowPaymentsRegardlessOfAnonScore)),
 			("DefaultReceiveScriptType", Encode.ScriptPubKeyType(keyManager.DefaultReceiveScriptType)),
 			("ChangeScriptPubKeyType", Encode.PreferredScriptPubKeyType(keyManager.ChangeScriptPubKeyType)),
 			("DefaultSendWorkflow", Encode.SendWorkflow(keyManager.DefaultSendWorkflow)),
@@ -796,6 +799,7 @@ public class KeyManager
 				Icon = get.Optional("Icon", Decode.String),
 				AnonScoreTarget = get.Optional("AnonScoreTarget", Decode.Int, 10),
 				NonPrivateCoinIsolation = get.Optional("RedCoinIsolation", Decode.Bool, false),
+				AllowPaymentsRegardlessOfAnonScore = get.Optional("AllowPaymentsRegardlessOfAnonScore", Decode.Bool, false),
 				DefaultReceiveScriptType = get.Optional("DefaultReceiveScriptType", Decode.ScriptPubKeyType, ScriptPubKeyType.TaprootBIP86),
 				ChangeScriptPubKeyType = get.Optional("ChangeScriptPubKeyType", Decode.PreferredScriptPubKeyType) ?? PreferredScriptPubKeyType.Unspecified.Instance,
 				DefaultSendWorkflow = get.Optional("DefaultSendWorkflow", Decode.SendWorkflow, SendWorkflow.Automatic),

--- a/WalletWasabi/CoinJoinProfiles/IPrivacyProfile.cs
+++ b/WalletWasabi/CoinJoinProfiles/IPrivacyProfile.cs
@@ -5,8 +5,11 @@ public interface IPrivacyProfile
 	string Name => GetType().Name;
 	int AnonScoreTarget { get; }
 	bool NonPrivateCoinIsolation { get; }
-	public bool Equals(int anonScoreTarget, bool redCoinIsolation)
+	bool AllowPaymentsRegardlessOfAnonScore { get; }
+	public bool Equals(int anonScoreTarget, bool redCoinIsolation, bool allowPaymentsRegardlessOfAnonScore)
 	{
-		return anonScoreTarget == AnonScoreTarget && redCoinIsolation == NonPrivateCoinIsolation;
+		return anonScoreTarget == AnonScoreTarget
+			&& redCoinIsolation == NonPrivateCoinIsolation
+			&& allowPaymentsRegardlessOfAnonScore == AllowPaymentsRegardlessOfAnonScore;
 	}
 }

--- a/WalletWasabi/CoinJoinProfiles/PrivacyProfiles.cs
+++ b/WalletWasabi/CoinJoinProfiles/PrivacyProfiles.cs
@@ -20,12 +20,14 @@ public static class PrivacyProfiles
 	{
 		public int AnonScoreTarget => 10;
 		public bool NonPrivateCoinIsolation => true;
+		public bool AllowPaymentsRegardlessOfAnonScore => true;
 	}
 
 	public record Economical : IPrivacyProfile
 	{
 		public int AnonScoreTarget => 5;
 		public bool NonPrivateCoinIsolation => false;
+		public bool AllowPaymentsRegardlessOfAnonScore => true;
 	}
 
 	public record MaximizePrivacy : IPrivacyProfile
@@ -35,6 +37,7 @@ public static class PrivacyProfiles
 
 		public int AnonScoreTarget { get; } = GetAnonScoreTarget();
 		public bool NonPrivateCoinIsolation => true;
+		public bool AllowPaymentsRegardlessOfAnonScore => false;
 
 		/// <summary>
 		/// This algo linearly decreases the probability of increasing the anonset target, starting from minExclusive.

--- a/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
+++ b/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
@@ -21,6 +21,8 @@ public class PaymentBatch
 	private IEnumerable<Payment> PendingPayments => GetPayments().Where(p => p.State is PendingPayment);
 	private IEnumerable<Payment> InProgressPayments => GetPayments().Where(p => p.State is InProgressPayment);
 
+	public event EventHandler? PaymentsChanged;
+
 	public Guid AddPayment(IDestination destination, Money amount)
 	{
 		var payment = new Payment(destination, amount);
@@ -29,6 +31,7 @@ public class PaymentBatch
 			_payments.Add(payment);
 		}
 		Logger.LogInfo($"Payment {payment.Id} for {payment.Amount} BTC to {payment.Destination.ScriptPubKey}.");
+		PaymentsChanged?.Invoke(this, EventArgs.Empty);
 		return payment.Id;
 	}
 
@@ -55,6 +58,8 @@ public class PaymentBatch
 				throw new InvalidOperationException("Payment was not found.");
 			}
 		}
+
+		PaymentsChanged?.Invoke(this, EventArgs.Empty);
 	}
 
 	public PaymentSet GetBestPaymentSet(Money availableAmount, int availableVsize, RoundParameters roundParameters)
@@ -111,6 +116,8 @@ public class PaymentBatch
 				_payments.Add(move(payment));
 			}
 		}
+
+		PaymentsChanged?.Invoke(this, EventArgs.Empty);
 	}
 
 	public ReadOnlyCollection<Payment> GetPayments()

--- a/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
+++ b/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
@@ -21,8 +21,6 @@ public class PaymentBatch
 	private IEnumerable<Payment> PendingPayments => GetPayments().Where(p => p.State is PendingPayment);
 	private IEnumerable<Payment> InProgressPayments => GetPayments().Where(p => p.State is InProgressPayment);
 
-	public event EventHandler? PaymentsChanged;
-
 	public Guid AddPayment(IDestination destination, Money amount)
 	{
 		var payment = new Payment(destination, amount);
@@ -31,7 +29,6 @@ public class PaymentBatch
 			_payments.Add(payment);
 		}
 		Logger.LogInfo($"Payment {payment.Id} for {payment.Amount} BTC to {payment.Destination.ScriptPubKey}.");
-		PaymentsChanged?.Invoke(this, EventArgs.Empty);
 		return payment.Id;
 	}
 
@@ -58,8 +55,6 @@ public class PaymentBatch
 				throw new InvalidOperationException("Payment was not found.");
 			}
 		}
-
-		PaymentsChanged?.Invoke(this, EventArgs.Empty);
 	}
 
 	public PaymentSet GetBestPaymentSet(Money availableAmount, int availableVsize, RoundParameters roundParameters)
@@ -116,8 +111,6 @@ public class PaymentBatch
 				_payments.Add(move(payment));
 			}
 		}
-
-		PaymentsChanged?.Invoke(this, EventArgs.Empty);
 	}
 
 	public ReadOnlyCollection<Payment> GetPayments()

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
@@ -12,18 +12,15 @@ public class CoinJoinCoinSelector
 	/// <param name="consolidationMode">If true it attempts to select as many coins as it can.</param>
 	/// <param name="anonScoreTarget">Tries to select few coins over this threshold.</param>
 	/// <param name="semiPrivateThreshold">Minimum anonymity of coins that can be selected together.</param>
-	/// <param name="allowPaymentsRegardlessOfAnonScore">If true, a pending payment can be funded with private coins even when the wallet has no non-private coins to mix.</param>
 	public CoinJoinCoinSelector(
 		bool consolidationMode,
 		int anonScoreTarget,
 		int semiPrivateThreshold,
-		CoinJoinCoinSelectorRandomnessGenerator? generator = null,
-		bool allowPaymentsRegardlessOfAnonScore = false)
+		CoinJoinCoinSelectorRandomnessGenerator? generator = null)
 	{
 		ConsolidationMode = consolidationMode;
 		AnonScoreTarget = anonScoreTarget;
 		SemiPrivateThreshold = semiPrivateThreshold;
-		AllowPaymentsRegardlessOfAnonScore = allowPaymentsRegardlessOfAnonScore;
 
 		_generator = generator ?? new(MaxInputsRegistrableByWallet, RandomnessProviders.Secure);
 	}
@@ -31,18 +28,20 @@ public class CoinJoinCoinSelector
 	public bool ConsolidationMode { get; }
 	public int AnonScoreTarget { get; }
 	public int SemiPrivateThreshold { get; }
-
-	public bool AllowPaymentsRegardlessOfAnonScore { get; }
-
 	private RandomnessProvider Rnd => _generator.Rnd;
 	private readonly CoinJoinCoinSelectorRandomnessGenerator _generator;
 
-	public static CoinJoinCoinSelector FromWallet(Wallet wallet) =>
-		new(
+	public static CoinJoinCoinSelector FromWallet(Wallet wallet)
+	{
+		var payWithPrivateCoins = wallet.AllowPaymentsRegardlessOfAnonScore
+			&& wallet.IsWalletPrivate()
+			&& wallet.BatchedPayments.AreTherePendingPayments;
+
+		return new(
 			wallet.ConsolidationMode,
-			wallet.AnonScoreTarget,
-			wallet.NonPrivateCoinIsolation ? Constants.SemiPrivateThreshold : 0,
-			allowPaymentsRegardlessOfAnonScore: wallet.AllowPaymentsRegardlessOfAnonScore);
+			payWithPrivateCoins ? int.MaxValue : wallet.AnonScoreTarget,
+			wallet.NonPrivateCoinIsolation ? Constants.SemiPrivateThreshold : 0);
+	}
 
 	/// <param name="liquidityClue">Weakly prefer not to select inputs over this.</param>
 	public ImmutableList<SmartCoin> SelectCoinsForRound(IEnumerable<SmartCoin> coins, UtxoSelectionParameters parameters, Money liquidityClue)
@@ -76,22 +75,10 @@ public class CoinJoinCoinSelector
 			.Where(x => x.IsRedCoin(SemiPrivateThreshold))
 			.ToArray();
 
-		var coinsToSpend = semiPrivateCoins;
-		var accompanyingPrivateCoins = privateCoins;
-
 		if (semiPrivateCoins.Length + redCoins.Length == 0)
 		{
-
-			if (!AllowPaymentsRegardlessOfAnonScore)
-			{
-				Logger.LogDebug("No suitable coins for this round.");
-				return ImmutableList<SmartCoin>.Empty;
-			}
-
-			Logger.LogDebug("No non-private coins available; funding a pending payment with private coins.");
-
-			coinsToSpend = privateCoins;
-			accompanyingPrivateCoins = [];
+			Logger.LogDebug("No suitable coins for this round.");
+			return ImmutableList<SmartCoin>.Empty;
 		}
 
 		Logger.LogDebug($"Coin selection started:");
@@ -101,7 +88,7 @@ public class CoinJoinCoinSelector
 		Logger.LogDebug($"{nameof(redCoins)}: {redCoins.Length} coins, valued at {Money.Satoshis(redCoins.Sum(x => x.Amount)).ToString(false, true)} BTC.");
 
 		// We want to isolate red coins from each other. We only let a single red coin get into our selection candidates.
-		var allowedNonPrivateCoins = coinsToSpend.ToList();
+		var allowedNonPrivateCoins = semiPrivateCoins.ToList();
 		var red = redCoins.RandomElement(Rnd);
 		if (red is not null)
 		{
@@ -112,7 +99,7 @@ public class CoinJoinCoinSelector
 		Logger.LogDebug($"{nameof(allowedNonPrivateCoins)}: {allowedNonPrivateCoins.Count} coins, valued at {Money.Satoshis(allowedNonPrivateCoins.Sum(x => x.Amount)).ToString(false, true)} BTC.");
 
 		int inputCount = Math.Min(
-			accompanyingPrivateCoins.Length + allowedNonPrivateCoins.Count,
+			privateCoins.Length + allowedNonPrivateCoins.Count,
 			ConsolidationMode ? MaxInputsRegistrableByWallet : _generator.GetInputTarget());
 		if (ConsolidationMode)
 		{
@@ -120,7 +107,7 @@ public class CoinJoinCoinSelector
 		}
 		Logger.LogDebug($"Targeted {nameof(inputCount)}: {inputCount}.");
 
-		var biasShuffledPrivateCoins = AnonScoreTxSourceBiasedShuffle(accompanyingPrivateCoins).ToArray();
+		var biasShuffledPrivateCoins = AnonScoreTxSourceBiasedShuffle(privateCoins).ToArray();
 
 		// Deprioritize private coins those are too large.
 		var smallerPrivateCoins = biasShuffledPrivateCoins.Where(x => x.Amount <= liquidityClue);

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
@@ -12,15 +12,18 @@ public class CoinJoinCoinSelector
 	/// <param name="consolidationMode">If true it attempts to select as many coins as it can.</param>
 	/// <param name="anonScoreTarget">Tries to select few coins over this threshold.</param>
 	/// <param name="semiPrivateThreshold">Minimum anonymity of coins that can be selected together.</param>
+	/// <param name="allowPaymentsRegardlessOfAnonScore">If true, a pending payment can be funded with private coins even when the wallet has no non-private coins to mix.</param>
 	public CoinJoinCoinSelector(
 		bool consolidationMode,
 		int anonScoreTarget,
 		int semiPrivateThreshold,
-		CoinJoinCoinSelectorRandomnessGenerator? generator = null)
+		CoinJoinCoinSelectorRandomnessGenerator? generator = null,
+		bool allowPaymentsRegardlessOfAnonScore = false)
 	{
 		ConsolidationMode = consolidationMode;
 		AnonScoreTarget = anonScoreTarget;
 		SemiPrivateThreshold = semiPrivateThreshold;
+		AllowPaymentsRegardlessOfAnonScore = allowPaymentsRegardlessOfAnonScore;
 
 		_generator = generator ?? new(MaxInputsRegistrableByWallet, RandomnessProviders.Secure);
 	}
@@ -28,6 +31,9 @@ public class CoinJoinCoinSelector
 	public bool ConsolidationMode { get; }
 	public int AnonScoreTarget { get; }
 	public int SemiPrivateThreshold { get; }
+
+	public bool AllowPaymentsRegardlessOfAnonScore { get; }
+
 	private RandomnessProvider Rnd => _generator.Rnd;
 	private readonly CoinJoinCoinSelectorRandomnessGenerator _generator;
 
@@ -35,7 +41,8 @@ public class CoinJoinCoinSelector
 		new(
 			wallet.ConsolidationMode,
 			wallet.AnonScoreTarget,
-			wallet.NonPrivateCoinIsolation ? Constants.SemiPrivateThreshold : 0);
+			wallet.NonPrivateCoinIsolation ? Constants.SemiPrivateThreshold : 0,
+			allowPaymentsRegardlessOfAnonScore: wallet.AllowPaymentsRegardlessOfAnonScore);
 
 	/// <param name="liquidityClue">Weakly prefer not to select inputs over this.</param>
 	public ImmutableList<SmartCoin> SelectCoinsForRound(IEnumerable<SmartCoin> coins, UtxoSelectionParameters parameters, Money liquidityClue)
@@ -69,10 +76,22 @@ public class CoinJoinCoinSelector
 			.Where(x => x.IsRedCoin(SemiPrivateThreshold))
 			.ToArray();
 
+		var coinsToSpend = semiPrivateCoins;
+		var accompanyingPrivateCoins = privateCoins;
+
 		if (semiPrivateCoins.Length + redCoins.Length == 0)
 		{
-			Logger.LogDebug("No suitable coins for this round.");
-			return ImmutableList<SmartCoin>.Empty;
+
+			if (!AllowPaymentsRegardlessOfAnonScore)
+			{
+				Logger.LogDebug("No suitable coins for this round.");
+				return ImmutableList<SmartCoin>.Empty;
+			}
+
+			Logger.LogDebug("No non-private coins available; funding a pending payment with private coins.");
+
+			coinsToSpend = privateCoins;
+			accompanyingPrivateCoins = [];
 		}
 
 		Logger.LogDebug($"Coin selection started:");
@@ -82,7 +101,7 @@ public class CoinJoinCoinSelector
 		Logger.LogDebug($"{nameof(redCoins)}: {redCoins.Length} coins, valued at {Money.Satoshis(redCoins.Sum(x => x.Amount)).ToString(false, true)} BTC.");
 
 		// We want to isolate red coins from each other. We only let a single red coin get into our selection candidates.
-		var allowedNonPrivateCoins = semiPrivateCoins.ToList();
+		var allowedNonPrivateCoins = coinsToSpend.ToList();
 		var red = redCoins.RandomElement(Rnd);
 		if (red is not null)
 		{
@@ -93,7 +112,7 @@ public class CoinJoinCoinSelector
 		Logger.LogDebug($"{nameof(allowedNonPrivateCoins)}: {allowedNonPrivateCoins.Count} coins, valued at {Money.Satoshis(allowedNonPrivateCoins.Sum(x => x.Amount)).ToString(false, true)} BTC.");
 
 		int inputCount = Math.Min(
-			privateCoins.Length + allowedNonPrivateCoins.Count,
+			accompanyingPrivateCoins.Length + allowedNonPrivateCoins.Count,
 			ConsolidationMode ? MaxInputsRegistrableByWallet : _generator.GetInputTarget());
 		if (ConsolidationMode)
 		{
@@ -101,7 +120,7 @@ public class CoinJoinCoinSelector
 		}
 		Logger.LogDebug($"Targeted {nameof(inputCount)}: {inputCount}.");
 
-		var biasShuffledPrivateCoins = AnonScoreTxSourceBiasedShuffle(privateCoins).ToArray();
+		var biasShuffledPrivateCoins = AnonScoreTxSourceBiasedShuffle(accompanyingPrivateCoins).ToArray();
 
 		// Deprioritize private coins those are too large.
 		var smallerPrivateCoins = biasShuffledPrivateCoins.Where(x => x.Amount <= liquidityClue);

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -584,8 +584,9 @@ public class CoinJoinManager : BackgroundService
 		{
 			NotifyWalletStoppedCoinJoin(wallet);
 		}
-		else if (wallet.IsWalletPrivate())
+		else if (wallet.IsWalletPrivate() && !(wallet.AllowPaymentsRegardlessOfAnonScore && wallet.BatchedPayments.AreTherePendingPayments))
 		{
+			// A fully private wallet is done mixing, unless it is allowed to fund a pending payment with private coins.
 			NotifyCoinJoinStartError(wallet, CoinjoinError.AllCoinsPrivate);
 			if (!finishedCoinJoin.StopWhenAllMixed)
 			{

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -102,6 +102,8 @@ public class Wallet : BackgroundService
 
 	public bool NonPrivateCoinIsolation => KeyManager.NonPrivateCoinIsolation;
 
+	public bool AllowPaymentsRegardlessOfAnonScore => KeyManager.AllowPaymentsRegardlessOfAnonScore;
+
 	public Network Network { get; }
 	public TransactionProcessor TransactionProcessor { get; }
 


### PR DESCRIPTION
Closes #14664

This PR lets a wallet pay in a coinjoin regardless of the anonymity set, with an opt-out toggle.

### Coin selection
When the wallet has no non-private coins it used to return an empty selection in `CoinJoinCoinSelector`. It now funds a pending payment with private coins when the new setting is enabled.

### New per-wallet setting

New toggle "Pay in coinjoin regardless of anonymity score". New wallets default to on; existing wallets missing the key decode to false. Selecting "Enhance Privacy" turns it off, while "Default Strategy" and "Reduce Costs" turns it on.

### UI: keep the music box usable when all coins are private
A fully private wallet normally hides the coinjoin music box, leaving no way to schedule a payment. Now, when the toggle is on:
- **`WalletViewModel`** keeps the music box visible.
- **`CoinJoinStateViewModel`** enables Play only when a coinjoin payment is pending; otherwise Play is visible but disabled with an "All coins are private" hint. With a pending payment, pressing Play just starts the round (no warning).
- **`PaymentBatch`** raises a new `PaymentsChanged` event so the box reacts the moment a payment is added or canceled.

### Testing
- Added `SelectPrivateCoinsToPayRegardlessOfAnonScore` to `CoinJoinCoinSelectionTests`.
- Verified end-to-end on regtest using edge cases. (AI helped by running coordinator and miner.)

### Disclaimer

Code is written using AI. I have read it, and cleaned it. 