### PR TITLE
release.sh: Updates for reproducibility

### DIFF
--- a/Contrib/release.sh
+++ b/Contrib/release.sh
@@ -154,6 +154,7 @@ for PLATFORM in "${PLATFORMS[@]}"; do
             --property:ErrorReport=none \
             --property:DocumentationFile='' \
             --property:Deterministic=true \
+            --property:PathMap="$(pwd -P)=/src" \
             /clp:ErrorsOnly
   done
 
@@ -266,7 +267,7 @@ for ICON_FILE in ./Contrib/Assets/WasabiLogo*.png; do
 done
 
 # Calculate package size (in kilobytes)
-DEBIAN_PACKAGE_SIZE=$(du -s "${BUILD_DIR}/${DEBIAN_FULL_PLATFORM_NAME}" | cut -f1)
+DEBIAN_PACKAGE_SIZE=$(du -ks --apparent-size "${BUILD_DIR}/${DEBIAN_FULL_PLATFORM_NAME}" | cut -f1)
 
 # Create the control file content
 DEBIAN_CONTROL_FILE_CONTENT="Package: ${EXECUTABLE_NAME}


### PR DESCRIPTION
Contributes to #14791

Based on @xrviv suggestions.

## Test

```bash
./Contrib/release.sh debian
```

My SHA256 hash is

```
cd WalletWasabi/packages
sha256sum *
```
reports

```
2cc0fd42b4bef13220556ce634a22206aa13bcee9debb15ce40261578005cd73  Wasabi-2.8.0.deb
```