### PR TITLE
WalletJsonRpcService: Wallet loading should be awaited otherwise late…

### DIFF
--- a/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
@@ -108,9 +108,14 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("loadwallet", initializable: false)]
-	public void LoadWallet(string walletName)
+	public async Task LoadWalletAsync(string walletName)
 	{
-		SelectWallet(walletName, ensureLoaded: true);
+		var wallet = SelectWallet(walletName);
+
+		if (!wallet.Loaded)
+		{
+			await Global.WalletManager.StartWalletAsync(wallet).ConfigureAwait(false);
+		}
 	}
 
 	[JsonRpcMethod("getwalletinfo")]
@@ -582,18 +587,14 @@ public class WasabiJsonRpcService : IJsonRpcService
 		};
 	}
 
-	private void SelectWallet(string walletName, bool ensureLoaded = false)
+	private Wallet SelectWallet(string walletName)
 	{
 		walletName = Guard.NotNullOrEmptyOrWhitespace(nameof(walletName), walletName);
 		try
 		{
 			var wallet = Global.WalletManager.GetWalletByName(walletName);
-
 			ActiveWallet = wallet;
-			if (ensureLoaded &&!wallet.Loaded)
-			{
-				Global.WalletManager.StartWalletAsync(wallet).ConfigureAwait(false);
-			}
+			return wallet;
 		}
 		catch (InvalidOperationException) // wallet not found
 		{
@@ -624,7 +625,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 		var walletName = parts.Length == 1 ? parts[0] : string.Empty;
 		if (needsWallet && !string.IsNullOrEmpty(walletName))
 		{
-			SelectWallet(walletName);
+			_ = SelectWallet(walletName);
 		}
 		else
 		{


### PR DESCRIPTION
…r RPC command may fail

### Test

```
# Start Wasabi with RPC server on
dotnet run --project WalletWasabi.Fluent.Desktop -f net10.0 -- --JsonRpcServerEnabled=true

# Use this command to load wallet called 'Wallet'
curl -s --data-binary '{"jsonrpc":"2.0","id":"1","method":"loadwallet","params":["Wallet"]}' http://127.0.0.1:37128/Wallet | jq 
```