### PR TITLE
TreeDataGrid: Work around missing row-action cells on Linux

### DIFF
--- a/WalletWasabi.Fluent/Behaviors/TreeDataGridMissingCellsWorkaroundBehavior.cs
+++ b/WalletWasabi.Fluent/Behaviors/TreeDataGridMissingCellsWorkaroundBehavior.cs
@@ -1,0 +1,125 @@
+using System.Reactive.Disposables;
+using Avalonia;
+using Avalonia.Threading;
+using Avalonia.Xaml.Interactions.Custom;
+
+namespace WalletWasabi.Fluent.Behaviors;
+
+/// <summary>
+/// Works around an Avalonia.Controls.TreeDataGrid layout bug (fixed upstream only in the commercially-licensed
+/// 11.3.1 release, so the fix is unavailable to the pinned 11.1.1 package): when a star-sized column gets its
+/// width committed before the trailing Auto columns have ever been measured, the committed column widths fill
+/// the viewport exactly and the trailing cells begin precisely at the viewport's right edge. The horizontal
+/// virtualization loop only realizes cells that start strictly inside the viewport, so those cells are never
+/// created or measured - the column keeps an estimated width, the grid reports phantom horizontal overflow
+/// and the right-side buttons stay invisible until the user drags the horizontal scrollbar.
+/// See https://github.com/WalletWasabi/WalletWasabi/issues/14632.
+/// When this behavior detects a never-measured column together with horizontal overflow, it briefly reports
+/// a slightly narrower viewport to the columns: the star column shrinks, the missing cells start inside the
+/// real viewport and finally get realized and measured. Once the layout settles the real viewport width is
+/// restored, which lets the columns settle to their correct sizes and the phantom overflow disappear. If a
+/// nudge brings no progress the content genuinely overflows, so the behavior stops interfering.
+/// </summary>
+public class TreeDataGridMissingCellsWorkaroundBehavior : AttachedToVisualTreeBehavior<Avalonia.Controls.TreeDataGrid>
+{
+	private const int MaxAttempts = 3;
+
+	private int _attempts;
+	private bool _nudgePending;
+	private int _unmeasuredCountAtNudge;
+
+	protected override IDisposable OnAttachedToVisualTreeOverride()
+	{
+		if (AssociatedObject is not { } grid)
+		{
+			return Disposable.Empty;
+		}
+
+		grid.LayoutUpdated += OnLayoutUpdated;
+
+		var sourceChanged = grid
+			.GetObservable(Avalonia.Controls.TreeDataGrid.SourceProperty)
+			.Subscribe(_ =>
+			{
+				_attempts = 0;
+				_nudgePending = false;
+			});
+
+		return Disposable.Create(() =>
+		{
+			grid.LayoutUpdated -= OnLayoutUpdated;
+			sourceChanged.Dispose();
+		});
+	}
+
+	private void OnLayoutUpdated(object? sender, EventArgs e)
+	{
+		if (_nudgePending || _attempts >= MaxAttempts)
+		{
+			return;
+		}
+
+		var unmeasuredCount = CountUnmeasuredColumns();
+
+		if (unmeasuredCount == 0 || AssociatedObject is not { Scroll: { } scroll, Source.Columns: { } columns })
+		{
+			return;
+		}
+
+		if (scroll.Viewport.Width <= 0 || scroll.Extent.Width <= scroll.Viewport.Width)
+		{
+			// Empty grid or everything fits: the unmeasured columns are not caused by the bug.
+			return;
+		}
+
+		_attempts++;
+		_nudgePending = true;
+		_unmeasuredCountAtNudge = unmeasuredCount;
+
+		// Pretend the viewport is slightly narrower: the star column shrinks, which makes the trailing
+		// cells start inside the real viewport, so the virtualization finally realizes and measures them.
+		columns.ViewportChanged(new Rect(0, 0, scroll.Viewport.Width - 2, scroll.Viewport.Height));
+
+		// Restore the real width only after the layout triggered by the shrink has fully settled.
+		Dispatcher.UIThread.Post(OnAfterNudge, DispatcherPriority.Background);
+	}
+
+	private void OnAfterNudge()
+	{
+		_nudgePending = false;
+
+		if (AssociatedObject is not { Scroll: { } scroll, Source.Columns: { } columns })
+		{
+			return;
+		}
+
+		// Restore the real viewport width; with the previously missing cells now measured the columns
+		// settle to their correct sizes. If nothing was gained the content genuinely overflows, so stop.
+		columns.ViewportChanged(new Rect(0, 0, scroll.Viewport.Width, scroll.Viewport.Height));
+
+		var unmeasuredCount = CountUnmeasuredColumns();
+		if (unmeasuredCount >= _unmeasuredCountAtNudge)
+		{
+			_attempts = MaxAttempts;
+		}
+	}
+
+	private int CountUnmeasuredColumns()
+	{
+		if (AssociatedObject is not { Source.Columns: { Count: > 0 } columns })
+		{
+			return 0;
+		}
+
+		var unmeasuredCount = 0;
+		for (var i = 0; i < columns.Count; i++)
+		{
+			if (double.IsNaN(columns[i].ActualWidth))
+			{
+				unmeasuredCount++;
+			}
+		}
+
+		return unmeasuredCount;
+	}
+}

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/HistoryTable.axaml
@@ -154,6 +154,7 @@
           <ScrollToSelectedItemBehavior />
           <HistoryItemTypeClassBehavior />
           <SetLastChildBehavior />
+          <TreeDataGridMissingCellsWorkaroundBehavior />
         </Interaction.Behaviors>
         <TreeDataGrid.ElementFactory>
           <treeDataGrid:PrivacyElementFactory />

--- a/WalletWasabi.Fluent/Views/Wallets/Receive/ReceiveAddressesView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Receive/ReceiveAddressesView.axaml
@@ -25,6 +25,9 @@
     <TreeDataGrid Source="{Binding Source}"
                   VerticalAlignment="Stretch"
                   Margin="0 20 0 0">
+      <Interaction.Behaviors>
+        <TreeDataGridMissingCellsWorkaroundBehavior />
+      </Interaction.Behaviors>
       <TreeDataGrid.Styles>
         <Style Selector="TreeDataGridRow">
           <Setter Property="Theme" Value="{StaticResource ReceiveAddressesViewTreeDataGridRow}" />


### PR DESCRIPTION
## Summary
Closes #14632

The transaction history and "Addresses Awaiting Payment" rows sometimes render without their right-side action buttons, alongside a phantom horizontal scrollbar, until the user drags it.

## Root cause
Avalonia.Controls.TreeDataGrid 11.1.1 (pinned 11.2+ is a commercial AvaloniaUI product) can commit a star column's width before a trailing Auto column has been measured. The measured columns then exactly fill the viewport, so the trailing cell (the row action buttons) starts precisely at the viewport's right edge. TreeDataGrid's horizontal virtualization only realizes cells that start inside the viewport, so that cell is never created. The grid over-estimates the extent, and you get a scrollbar with nothing to
actually scroll to. Dragging the scrollbar shifts the viewport just enough for the cell to finally realize, which is why that "fixes" it.

## Fix
`TreeDataGridMissingCellsWorkaroundBehavior`, attached to `HistoryTable` and `ReceiveAddressesView` (the only two grids with a trailing Auto column after a star column).

## Disclaimer

Code is entirely AI generated. 