### PR TITLE
Route coinjoin payment add/cancel through the Wallet backend

### DIFF
--- a/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
@@ -344,7 +344,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	public void CancelPayment(Guid paymentId)
 	{
 		AssertWalletIsLoaded();
-		ActiveWallet!.BatchedPayments.AbortPayment(paymentId);
+		ActiveWallet!.CancelCoinJoinPayment(paymentId);
 	}
 
 	[JsonRpcMethod("send")]

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinPayment/AddCoinJoinPaymentViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinPayment/AddCoinJoinPaymentViewModel.cs
@@ -201,7 +201,7 @@ public partial class AddCoinJoinPaymentViewModel : RoutableViewModel
 
 		try
 		{
-			_wallet.BatchedPayments.AddPayment(destination, amount);
+			_wallet.AddCoinJoinPayment(destination, amount);
 			Navigate().Back();
 		}
 		catch (Exception ex)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinPayment/CoinJoinPaymentsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinPayment/CoinJoinPaymentsViewModel.cs
@@ -68,7 +68,7 @@ public partial class CoinJoinPaymentsViewModel : DialogViewModelBase<Unit>
 	{
 		try
 		{
-			_wallet.BatchedPayments.AbortPayment(payment.Id);
+			_wallet.CancelCoinJoinPayment(payment.Id);
 			RefreshPayments();
 		}
 		catch (InvalidOperationException)

--- a/WalletWasabi/Services/EventBus.cs
+++ b/WalletWasabi/Services/EventBus.cs
@@ -140,4 +140,4 @@ public record NodeTimeoutDownloadingBlock(EndPoint EndPoint, Node Node);
 public record FilterHeadersTipChanged(uint Height);
 public record BlockHeadersTipChanged(uint Height);
 public record BlockDownloaded(uint Height);
-public record PaymentBatchChanged(PaymentBatch PaymentBatch);
+public record PaymentBatchChanged(IReadOnlyList<Payment> Payments);

--- a/WalletWasabi/Services/EventBus.cs
+++ b/WalletWasabi/Services/EventBus.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using NBitcoin.Protocol;
 using WalletWasabi.Blockchain.TransactionProcessing;
 using WalletWasabi.Blockchain.Transactions;
+using WalletWasabi.WabiSabi.Client.Batching;
 
 namespace WalletWasabi.Services;
 using SubscriptionRegistry = Dictionary<Type, List<EventBus.Subscription>>;
@@ -139,3 +140,4 @@ public record NodeTimeoutDownloadingBlock(EndPoint EndPoint, Node Node);
 public record FilterHeadersTipChanged(uint Height);
 public record BlockHeadersTipChanged(uint Height);
 public record BlockDownloaded(uint Height);
+public record PaymentBatchChanged(PaymentBatch PaymentBatch);

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -288,12 +288,14 @@ public class Wallet : BackgroundService
 	public string AddCoinJoinPayment(IDestination destination, Money amount)
 	{
 		var paymentId = BatchedPayments.AddPayment(destination, amount);
+		_eventBus.Publish(new PaymentBatchChanged(BatchedPayments));
 		return paymentId.ToString();
 	}
 
 	public void CancelCoinJoinPayment(Guid paymentId)
 	{
 		BatchedPayments.AbortPayment(paymentId);
+		_eventBus.Publish(new PaymentBatchChanged(BatchedPayments));
 	}
 
 	/// <inheritdoc/>

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -288,14 +288,14 @@ public class Wallet : BackgroundService
 	public string AddCoinJoinPayment(IDestination destination, Money amount)
 	{
 		var paymentId = BatchedPayments.AddPayment(destination, amount);
-		_eventBus.Publish(new PaymentBatchChanged(BatchedPayments));
+		_eventBus.Publish(new PaymentBatchChanged(BatchedPayments.GetPayments()));
 		return paymentId.ToString();
 	}
 
 	public void CancelCoinJoinPayment(Guid paymentId)
 	{
 		BatchedPayments.AbortPayment(paymentId);
-		_eventBus.Publish(new PaymentBatchChanged(BatchedPayments));
+		_eventBus.Publish(new PaymentBatchChanged(BatchedPayments.GetPayments()));
 	}
 
 	/// <inheritdoc/>

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -291,6 +291,11 @@ public class Wallet : BackgroundService
 		return paymentId.ToString();
 	}
 
+	public void CancelCoinJoinPayment(Guid paymentId)
+	{
+		BatchedPayments.AbortPayment(paymentId);
+	}
+
 	/// <inheritdoc/>
 	public override async Task StopAsync(CancellationToken cancel)
 	{


### PR DESCRIPTION
> This is because the OnAddPaymentAsync method manipulates the payment batch directly in the UI instead of doing it using the backend. Refactor that in another PR in order to make this unnecessary.

@lontivero, like this?