### PR TITLE
Show awaiting addresses of all script types

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Navigation/FluentNavigate.cs
+++ b/WalletWasabi.Fluent/ViewModels/Navigation/FluentNavigate.cs
@@ -440,9 +440,9 @@ public partial class FluentNavigate
 		return new FluentDialog<bool>(target.NavigateDialogAsync(dialog, navigationMode));
 	}
 
-	public void ReceiveAddresses(IWalletModel wallet, Models.Wallets.ScriptType scriptType, NavigationTarget navigationTarget = NavigationTarget.DialogScreen, NavigationMode navigationMode = NavigationMode.Normal)
+	public void ReceiveAddresses(IWalletModel wallet, NavigationTarget navigationTarget = NavigationTarget.DialogScreen, NavigationMode navigationMode = NavigationMode.Normal)
 	{
-		UiContext.Navigate(navigationTarget).To(new ReceiveAddressesViewModel(UiContext, wallet, scriptType), navigationMode);
+		UiContext.Navigate(navigationTarget).To(new ReceiveAddressesViewModel(UiContext, wallet), navigationMode);
 	}
 
 	public void WalletCoinJoinSettings(IWalletModel walletModel, NavigationTarget navigationTarget = NavigationTarget.DialogScreen, NavigationMode navigationMode = NavigationMode.Normal)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressesViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveAddressesViewModel.cs
@@ -15,14 +15,12 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Receive;
 public partial class ReceiveAddressesViewModel : RoutableViewModel
 {
 	private readonly IWalletModel _wallet;
-	private readonly ScriptType _scriptType;
 
 	[AutoNotify] private FlatTreeDataGridSource<AddressViewModel> _source = new(Enumerable.Empty<AddressViewModel>());
 
-	public ReceiveAddressesViewModel(UiContext uiContext, IWalletModel wallet, WalletWasabi.Fluent.Models.Wallets.ScriptType scriptType) : base(uiContext)
+	public ReceiveAddressesViewModel(UiContext uiContext, IWalletModel wallet) : base(uiContext)
 	{
 		_wallet = wallet;
-		_scriptType = scriptType;
 
 		EnableBack = true;
 		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
@@ -34,7 +32,6 @@ public partial class ReceiveAddressesViewModel : RoutableViewModel
 	{
 		_wallet.Addresses.Unused
 			.ToObservableChangeSet()
-			.Filter(x => x.ScriptType == _scriptType)
 			.Transform(CreateAddressViewModel)
 			.DisposeMany()
 			.Bind(out var unusedAddresses)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Receive/ReceiveViewModel.cs
@@ -58,7 +58,7 @@ public partial class ReceiveViewModel : RoutableViewModel, IDisposable
 
 	public ICommand ShowExistingAddressesCommand { get; }
 
-	public IObservable<bool> HasUnusedAddresses => _wallet.Addresses.Unused.ToObservableChangeSet().Filter(address => address.ScriptType == _scriptType).Count().Select(i => i > 0);
+	public IObservable<bool> HasUnusedAddresses => _wallet.Addresses.Unused.ToObservableChangeSet().Count().Select(i => i > 0);
 
 	protected override void OnNavigatedTo(bool isInHistory, CompositeDisposable disposables)
 	{
@@ -77,7 +77,7 @@ public partial class ReceiveViewModel : RoutableViewModel, IDisposable
 
 	private void OnShowExistingAddresses()
 	{
-		UiContext.Navigate(NavigationTarget.DialogScreen).To().ReceiveAddresses(_wallet, _scriptType);
+		UiContext.Navigate(NavigationTarget.DialogScreen).To().ReceiveAddresses(_wallet);
 	}
 
 	public void Dispose() => _disposables.Dispose();


### PR DESCRIPTION
This is a weird bug (that was put on purpose?) I just discovered when trying to check my awaiting receiving addresses.

If you request a Taproot address, pick a label and give it to someone, and then click to request a Segwit address and click "Addresses Awaiting Payment", you only see your Segwit awaiting addresses. 

This risks a user from mistaking that the Taproot address he initially generated does not belong to the current wallet. 

Why wouldn't it show all script-type addresses? This PR fixes this. 