### PR TITLE
[SQLite 9/n] Add `SharedSqliteStorage`

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -85,8 +85,18 @@ public class Global
 		TransactionStore = new AllTransactionStore(networkWorkFolderPath, Network);
 		TransactionStore.DisposeUsing(_disposables);
 
-		FilterStorage = new FilterStorage(Path.Combine(networkWorkFolderPath, "IndexStore"), Network, FilterHeaders, EventBus);
-		FilterStorage.DisposeUsing(_disposables);
+		var blockchainDbFilePath = Path.Combine(networkWorkFolderPath, "IndexStore", "IndexStore.sqlite");
+
+		if (Network == Network.RegTest)
+		{
+			SqliteStorageHelper.DeleteDatabaseFiles(blockchainDbFilePath);
+		}
+
+		var sharedSqliteStorage = SharedSqliteStorage.FromFile(blockchainDbFilePath);
+		sharedSqliteStorage.DisposeUsing(_disposables);
+		var blockFilterSqliteStorage = new BlockFilterSqliteStorage(sharedSqliteStorage.GetConnectionFactory());
+
+		FilterStorage = new FilterStorage(Network, FilterHeaders, blockFilterSqliteStorage, EventBus);
 
 		ExternalSourcesHttpClientFactory = BuildHttpClientFactory();
 

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -32,7 +32,7 @@ using WalletWasabi.Rpc;
 using WalletWasabi.Services;
 using WalletWasabi.Services.NodesManagement;
 using WalletWasabi.Services.Terminate;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 using WalletWasabi.Tor;
 using WalletWasabi.Tor.Control;
 using WalletWasabi.Tor.StatusChecker;
@@ -85,8 +85,8 @@ public class Global
 		TransactionStore = new AllTransactionStore(networkWorkFolderPath, Network);
 		TransactionStore.DisposeUsing(_disposables);
 
-		FilterStore = new FilterStore(Path.Combine(networkWorkFolderPath, "IndexStore"), Network, FilterHeaders, EventBus);
-		FilterStore.DisposeUsing(_disposables);
+		FilterStorage = new FilterStorage(Path.Combine(networkWorkFolderPath, "IndexStore"), Network, FilterHeaders, EventBus);
+		FilterStorage.DisposeUsing(_disposables);
 
 		ExternalSourcesHttpClientFactory = BuildHttpClientFactory();
 
@@ -100,7 +100,7 @@ public class Global
 
 		var walletFactory = Wallet.CreateFactory(
 			Config.Network,
-			FilterStore,
+			FilterStorage,
 			TransactionStore,
 			FilterHeaders,
 			_mempoolService,
@@ -141,7 +141,7 @@ public class Global
 	public TorSettings TorSettings { get; }
 
 	public FilterHeaderChain FilterHeaders { get; }
-	public FilterStore FilterStore { get; }
+	public FilterStorage FilterStorage { get; }
 	public AllTransactionStore TransactionStore { get; }
 	public IHttpClientFactory ExternalSourcesHttpClientFactory { get; }
 	public Config Config { get; }
@@ -408,7 +408,7 @@ public class Global
 				rpcProvider => rpcProvider,
 				_ =>
 				{
-					var tip = FilterStore.GetTip()!.Header;
+					var tip = FilterStorage.GetTip()!.Header;
 					var synchronizationState = new CompactFilterBehavior.FilterSynchronizationState(_blockHeaders, FilterHeaders, tip.Height, EventBus);
 					_p2pConnectionManager.AddBehavior(new CompactFilterBehavior(synchronizationState, _blockHeaders, EventBus));
 
@@ -417,7 +417,7 @@ public class Global
 
 
 		var (pause, resume, serviceLoop) =
-			Continuously(Synchronizer.CreateFilterGenerator(filtersProvider, FilterStore, FilterHeaders, EventBus));
+			Continuously(Synchronizer.CreateFilterGenerator(filtersProvider, FilterStorage, FilterHeaders, EventBus));
 
 		if (supportsBlockFiltersResult.IsOk)
 		{
@@ -551,7 +551,7 @@ public class Global
 		try
 		{
 			await TransactionStore.InitializeAsync(cancellationToken).ConfigureAwait(false);
-			await FilterStore.InitializeAsync(CalculateSafestHeight(), cancellationToken).ConfigureAwait(false);
+			await FilterStorage.InitializeAsync(CalculateSafestHeight(), cancellationToken).ConfigureAwait(false);
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
 		{

--- a/WalletWasabi.Fluent/Services.cs
+++ b/WalletWasabi.Fluent/Services.cs
@@ -14,7 +14,7 @@ using WalletWasabi.Client.Configuration;
 using WalletWasabi.Helpers;
 using WalletWasabi.Services;
 using WalletWasabi.Services.Terminate;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 using WalletWasabi.Tor;
 using WalletWasabi.Wallets;
 
@@ -27,7 +27,7 @@ public class Services : IServices
 
 	private readonly Global _global;
 	private readonly TorSettings _torSettings;
-	private readonly FilterStore _filterStore;
+	private readonly FilterStorage _filterStorage;
 	private readonly FilterHeaderChain _filterHeaders;
 	private readonly AllTransactionStore _transactionStore;
 	private readonly IHttpClientFactory _httpClientFactory;
@@ -40,7 +40,7 @@ public class Services : IServices
 	{
 		Guard.NotNull(nameof(global.DataDir), global.DataDir);
 		Guard.NotNull(nameof(global.TorSettings), global.TorSettings);
-		Guard.NotNull(nameof(global.FilterStore), global.FilterStore);
+		Guard.NotNull(nameof(global.FilterStorage), global.FilterStorage);
 		Guard.NotNull(nameof(global.FilterHeaders), global.FilterHeaders);
 		Guard.NotNull(nameof(global.TransactionStore), global.TransactionStore);
 		Guard.NotNull(nameof(global.ExternalSourcesHttpClientFactory), global.ExternalSourcesHttpClientFactory);
@@ -53,7 +53,7 @@ public class Services : IServices
 
 		_global = global;
 		_torSettings = global.TorSettings;
-		_filterStore = global.FilterStore;
+		_filterStorage = global.FilterStorage;
 		_filterHeaders = global.FilterHeaders;
 		_transactionStore = global.TransactionStore;
 		_httpClientFactory = global.ExternalSourcesHttpClientFactory;
@@ -88,7 +88,7 @@ public class Services : IServices
 	public int GetPeerCount() => _global.GetPeerCount();
 
 	// Filters info
-	public uint? GetMinimumBlockHeight() => _filterStore.GetMinimumBlockHeight();
+	public uint? GetMinimumBlockHeight() => _filterStorage.GetMinimumBlockHeight();
 
 	// Transactions info
 	public IEnumerable<LabelsArray> GetTransactionLabels() => _transactionStore.GetLabels();

--- a/WalletWasabi.IntegrationTests/BitcoinCore/Tests/P2pBasedTests.cs
+++ b/WalletWasabi.IntegrationTests/BitcoinCore/Tests/P2pBasedTests.cs
@@ -40,7 +40,10 @@ public class P2pBasedTests
 			using var transactionStore = new AllTransactionStore(Path.Combine(dir, "transactionStore"), network);
 			await transactionStore.InitializeAsync(CancellationToken.None);
 
-			using var filterStorage = new FilterStorage(Path.Combine(dir, "indexStore"), network, filterHeaderChain, TestNodeBuilder.EventBus);
+			var sharedSqliteStorage = SharedSqliteStorage.FromFile(Path.Combine(dir, "Shared.sqlite"));
+			var blockFilterSqliteStorage = new BlockFilterSqliteStorage(sharedSqliteStorage.GetConnectionFactory());
+
+			var filterStorage = new FilterStorage(network, filterHeaderChain, blockFilterSqliteStorage, TestNodeBuilder.EventBus);
 			await filterStorage.InitializeAsync(new Height.ChainHeight(0u), CancellationToken.None);
 
 			var mempoolService = coreNode.MempoolService;

--- a/WalletWasabi.IntegrationTests/BitcoinCore/Tests/P2pBasedTests.cs
+++ b/WalletWasabi.IntegrationTests/BitcoinCore/Tests/P2pBasedTests.cs
@@ -12,9 +12,9 @@ using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
-using WalletWasabi.Stores;
 using WalletWasabi.IntegrationTests.Infrastructure;
 using Xunit;
+using WalletWasabi.Storages;
 
 namespace WalletWasabi.IntegrationTests.BitcoinCore.Tests;
 
@@ -40,8 +40,8 @@ public class P2pBasedTests
 			using var transactionStore = new AllTransactionStore(Path.Combine(dir, "transactionStore"), network);
 			await transactionStore.InitializeAsync(CancellationToken.None);
 
-			using var filterStore = new FilterStore(Path.Combine(dir, "indexStore"), network, filterHeaderChain, TestNodeBuilder.EventBus);
-			await filterStore.InitializeAsync(new Height.ChainHeight(0u), CancellationToken.None);
+			using var filterStorage = new FilterStorage(Path.Combine(dir, "indexStore"), network, filterHeaderChain, TestNodeBuilder.EventBus);
+			await filterStorage.InitializeAsync(new Height.ChainHeight(0u), CancellationToken.None);
 
 			var mempoolService = coreNode.MempoolService;
 

--- a/WalletWasabi.IntegrationTests/Infrastructure/RegTestEnvironment.cs
+++ b/WalletWasabi.IntegrationTests/Infrastructure/RegTestEnvironment.cs
@@ -6,11 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
-using NBitcoin.Protocol;
-using NBitcoin.Protocol.Behaviors;
-using WalletWasabi.Backend.Models;
 using WalletWasabi.BitcoinP2p;
-using WalletWasabi.Extensions;
 using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Blockchain.Keys;
@@ -19,10 +15,10 @@ using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
-using WalletWasabi.Stores;
 using WalletWasabi.IntegrationTests.BitcoinCore;
 using WalletWasabi.Wallets;
 using ChainHeight = WalletWasabi.Models.Height.ChainHeight;
+using WalletWasabi.Storages;
 
 namespace WalletWasabi.IntegrationTests.Infrastructure;
 
@@ -36,7 +32,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 		IntegrationTestFixture fixture,
 		string workDir,
 		EventBus eventBus,
-		FilterStore filterStore,
+		FilterStorage filterStorage,
 		AllTransactionStore transactionStore,
 		FilterHeaderChain filterHeaderChain,
 		CpfpInfoProvider cpfpInfoProvider)
@@ -44,7 +40,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 		Fixture = fixture;
 		WorkDir = workDir;
 		EventBus = eventBus;
-		FilterStore = filterStore;
+		FilterStorage = filterStorage;
 		TransactionStore = transactionStore;
 		FilterHeaderChain = filterHeaderChain;
 		CpfpInfoProvider = cpfpInfoProvider;
@@ -54,7 +50,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 	public IntegrationTestFixture Fixture { get; }
 	public string WorkDir { get; }
 	public EventBus EventBus { get; }
-	public FilterStore FilterStore { get; }
+	public FilterStorage FilterStorage { get; }
 	public AllTransactionStore TransactionStore { get; }
 	public FilterHeaderChain FilterHeaderChain { get; }
 	public CpfpInfoProvider CpfpInfoProvider { get; }
@@ -90,12 +86,12 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 		var eventBus = new EventBus();
 		var filterHeaderChain = new FilterHeaderChain();
 
-		var filterStore = new FilterStore(
+		var filterStorage = new FilterStorage(
 			Path.Combine(workDir, "filters"),
 			fixture.BitcoinCoreNode.Network,
 			filterHeaderChain,
 			eventBus);
-		await filterStore.InitializeAsync(new ChainHeight(0u), CancellationToken.None).ConfigureAwait(false);
+		await filterStorage.InitializeAsync(new ChainHeight(0u), CancellationToken.None).ConfigureAwait(false);
 
 		var transactionStore = new AllTransactionStore(
 			Path.Combine(workDir, "transactions"),
@@ -111,7 +107,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 			fixture,
 			workDir,
 			eventBus,
-			filterStore,
+			filterStorage,
 			transactionStore,
 			filterHeaderChain,
 			cpfpInfoProvider);
@@ -132,7 +128,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 	{
 		var factory = Wallet.CreateFactory(
 			Network,
-			FilterStore,
+			FilterStorage,
 			TransactionStore,
 			FilterHeaderChain,
 			MempoolService,
@@ -161,7 +157,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 		var blockHeaderChain = new ConcurrentChain(Network);
 		var filterProvider = FilterProviders.CreateBitcoinRpcFilterProvider(RpcClient, blockHeaderChain);
 
-		var tip = FilterStore.GetTip();
+		var tip = FilterStorage.GetTip();
 		uint fromHeight = (uint)(tip?.Header.Height ?? ChainHeight.Genesis);
 		uint256 fromHash = tip?.Header.BlockHash ?? await RpcClient.GetBlockHashAsync(0, cancellationToken).ConfigureAwait(false);
 
@@ -173,7 +169,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 
 			if (result is {IsOk: true, Value: FiltersResponse.NewFiltersAvailable newFilters})
 			{
-				await FilterStore.AddNewFiltersAsync(newFilters.Filters).ConfigureAwait(false);
+				await FilterStorage.AddNewFiltersAsync(newFilters.Filters).ConfigureAwait(false);
 
 				var lastFilter = newFilters.Filters.LastOrDefault();
 				if (lastFilter is not null)
@@ -203,7 +199,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 		var blockHeaderChain = new ConcurrentChain(Network);
 
 		// Create the filter synchronization state
-		var tip = FilterStore.GetTip();
+		var tip = FilterStorage.GetTip();
 		var tipHeight = tip?.Header.Height ?? ChainHeight.Genesis;
 		var synchronizationState = new CompactFilterBehavior.FilterSynchronizationState(
 			blockHeaderChain,
@@ -262,7 +258,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 
 			if (result is {IsOk: true, Value: FiltersResponse.NewFiltersAvailable newFilters})
 			{
-				await FilterStore.AddNewFiltersAsync(newFilters.Filters).ConfigureAwait(false);
+				await FilterStorage.AddNewFiltersAsync(newFilters.Filters).ConfigureAwait(false);
 
 				var lastFilter = newFilters.Filters.LastOrDefault();
 				if (lastFilter is not null)
@@ -370,7 +366,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 
 	public ValueTask DisposeAsync()
 	{
-		FilterStore.Dispose();
+		FilterStorage.Dispose();
 		TransactionStore.Dispose();
 		return ValueTask.CompletedTask;
 	}

--- a/WalletWasabi.IntegrationTests/Infrastructure/RegTestEnvironment.cs
+++ b/WalletWasabi.IntegrationTests/Infrastructure/RegTestEnvironment.cs
@@ -32,6 +32,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 		IntegrationTestFixture fixture,
 		string workDir,
 		EventBus eventBus,
+		SharedSqliteStorage sharedSqliteStorage,
 		FilterStorage filterStorage,
 		AllTransactionStore transactionStore,
 		FilterHeaderChain filterHeaderChain,
@@ -40,6 +41,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 		Fixture = fixture;
 		WorkDir = workDir;
 		EventBus = eventBus;
+		SharedSqliteStorage = sharedSqliteStorage;
 		FilterStorage = filterStorage;
 		TransactionStore = transactionStore;
 		FilterHeaderChain = filterHeaderChain;
@@ -50,6 +52,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 	public IntegrationTestFixture Fixture { get; }
 	public string WorkDir { get; }
 	public EventBus EventBus { get; }
+	public SharedSqliteStorage SharedSqliteStorage { get; }
 	public FilterStorage FilterStorage { get; }
 	public AllTransactionStore TransactionStore { get; }
 	public FilterHeaderChain FilterHeaderChain { get; }
@@ -86,10 +89,13 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 		var eventBus = new EventBus();
 		var filterHeaderChain = new FilterHeaderChain();
 
+		var sharedSqliteStorage = SharedSqliteStorage.FromFile(Path.Combine(workDir, "Shared.sqlite"));
+		var blockFilterSqliteStorage = new BlockFilterSqliteStorage(sharedSqliteStorage.GetConnectionFactory());
+
 		var filterStorage = new FilterStorage(
-			Path.Combine(workDir, "filters"),
 			fixture.BitcoinCoreNode.Network,
 			filterHeaderChain,
+			blockFilterSqliteStorage,
 			eventBus);
 		await filterStorage.InitializeAsync(new ChainHeight(0u), CancellationToken.None).ConfigureAwait(false);
 
@@ -107,6 +113,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 			fixture,
 			workDir,
 			eventBus,
+			sharedSqliteStorage,
 			filterStorage,
 			transactionStore,
 			filterHeaderChain,
@@ -366,7 +373,7 @@ public sealed class RegTestEnvironment : IAsyncDisposable
 
 	public ValueTask DisposeAsync()
 	{
-		FilterStorage.Dispose();
+		SharedSqliteStorage.Dispose();
 		TransactionStore.Dispose();
 		return ValueTask.CompletedTask;
 	}

--- a/WalletWasabi.IntegrationTests/SyncTests/FilterSyncTests.cs
+++ b/WalletWasabi.IntegrationTests/SyncTests/FilterSyncTests.cs
@@ -33,7 +33,7 @@ public class FilterSyncTests
 		await env.SyncFiltersAsync();
 
 		// Assert - Filter store should have filters up to tip
-		var filterTip = env.FilterStore.GetTip();
+		var filterTip = env.FilterStorage.GetTip();
 		Assert.NotNull(filterTip);
 		Assert.Equal((uint)tipHeight, (uint)filterTip.Header.Height);
 	}
@@ -46,7 +46,7 @@ public class FilterSyncTests
 
 		// Initial sync
 		await env.SyncFiltersAsync();
-		var initialTip = env.FilterStore.GetTip();
+		var initialTip = env.FilterStorage.GetTip();
 		Assert.NotNull(initialTip);
 
 		var initialHeight = (uint)initialTip.Header.Height;
@@ -58,7 +58,7 @@ public class FilterSyncTests
 		await env.SyncFiltersAsync();
 
 		// Assert - Filter tip should advance by 1
-		var newTip = env.FilterStore.GetTip();
+		var newTip = env.FilterStorage.GetTip();
 		Assert.NotNull(newTip);
 		Assert.Equal(initialHeight + 1, (uint)newTip.Header.Height);
 	}
@@ -70,7 +70,7 @@ public class FilterSyncTests
 		await using var env = await RegTestEnvironment.CreateAsync(_fixture);
 
 		await env.SyncFiltersAsync();
-		var initialTip = env.FilterStore.GetTip();
+		var initialTip = env.FilterStorage.GetTip();
 		Assert.NotNull(initialTip);
 
 		var initialHeight = (uint)initialTip.Header.Height;
@@ -82,7 +82,7 @@ public class FilterSyncTests
 		await env.SyncFiltersAsync();
 
 		// Assert
-		var newTip = env.FilterStore.GetTip();
+		var newTip = env.FilterStorage.GetTip();
 		Assert.NotNull(newTip);
 		Assert.Equal(initialHeight + blocksToMine, (uint)newTip.Header.Height);
 	}
@@ -97,7 +97,7 @@ public class FilterSyncTests
 		await env.SyncFiltersAsync();
 
 		// Assert - FilterHeaderChain should be in sync
-		var filterTip = env.FilterStore.GetTip();
+		var filterTip = env.FilterStorage.GetTip();
 		Assert.NotNull(filterTip);
 
 		var chainTipHeight = env.FilterHeaderChain.TipHeight;
@@ -111,7 +111,7 @@ public class FilterSyncTests
 		await using var env = await RegTestEnvironment.CreateAsync(_fixture);
 
 		// The filter store is initialized with checkpoint at height 0 for regtest
-		var tip = env.FilterStore.GetTip();
+		var tip = env.FilterStorage.GetTip();
 
 		// For regtest, we expect to have at least the genesis filter
 		Assert.NotNull(tip);
@@ -120,7 +120,7 @@ public class FilterSyncTests
 		// Now sync and verify we catch up
 		await env.SyncFiltersAsync();
 
-		var syncedTip = env.FilterStore.GetTip();
+		var syncedTip = env.FilterStorage.GetTip();
 		Assert.NotNull(syncedTip);
 
 		var blockchainTip = await env.RpcClient.GetBlockCountAsync();

--- a/WalletWasabi.IntegrationTests/SyncTests/P2pFilterSyncTests.cs
+++ b/WalletWasabi.IntegrationTests/SyncTests/P2pFilterSyncTests.cs
@@ -31,7 +31,7 @@ public class P2pFilterSyncTests
 		await env.SyncFiltersP2pAsync();
 
 		// Assert - Filter store should have filters up to tip
-		var filterTip = env.FilterStore.GetTip();
+		var filterTip = env.FilterStorage.GetTip();
 		Assert.NotNull(filterTip);
 		Assert.Equal((uint)tipHeight, (uint)filterTip.Header.Height);
 	}
@@ -44,7 +44,7 @@ public class P2pFilterSyncTests
 
 		// Initial sync via P2P
 		await env.SyncFiltersP2pAsync();
-		var initialTip = env.FilterStore.GetTip();
+		var initialTip = env.FilterStorage.GetTip();
 		Assert.NotNull(initialTip);
 
 		var initialHeight = (uint)initialTip.Header.Height;
@@ -56,7 +56,7 @@ public class P2pFilterSyncTests
 		await env.SyncFiltersP2pAsync();
 
 		// Assert - Filter tip should advance by 1
-		var newTip = env.FilterStore.GetTip();
+		var newTip = env.FilterStorage.GetTip();
 		Assert.NotNull(newTip);
 		Assert.Equal(initialHeight + 1, (uint)newTip.Header.Height);
 	}
@@ -68,7 +68,7 @@ public class P2pFilterSyncTests
 		await using var env = await RegTestEnvironment.CreateAsync(_fixture);
 
 		await env.SyncFiltersP2pAsync();
-		var initialTip = env.FilterStore.GetTip();
+		var initialTip = env.FilterStorage.GetTip();
 		Assert.NotNull(initialTip);
 
 		var initialHeight = (uint)initialTip.Header.Height;
@@ -80,7 +80,7 @@ public class P2pFilterSyncTests
 		await env.SyncFiltersP2pAsync();
 
 		// Assert
-		var newTip = env.FilterStore.GetTip();
+		var newTip = env.FilterStorage.GetTip();
 		Assert.NotNull(newTip);
 		Assert.Equal(initialHeight + blocksToMine, (uint)newTip.Header.Height);
 	}
@@ -95,7 +95,7 @@ public class P2pFilterSyncTests
 		await env.SyncFiltersP2pAsync();
 
 		// Assert - FilterHeaderChain should be in sync
-		var filterTip = env.FilterStore.GetTip();
+		var filterTip = env.FilterStorage.GetTip();
 		Assert.NotNull(filterTip);
 
 		var chainTipHeight = env.FilterHeaderChain.TipHeight;
@@ -109,7 +109,7 @@ public class P2pFilterSyncTests
 		await using var env = await RegTestEnvironment.CreateAsync(_fixture);
 
 		// The filter store is initialized with checkpoint at height 0 for regtest
-		var tip = env.FilterStore.GetTip();
+		var tip = env.FilterStorage.GetTip();
 
 		// For regtest, we expect to have at least the genesis filter
 		Assert.NotNull(tip);
@@ -118,7 +118,7 @@ public class P2pFilterSyncTests
 		// Now sync via P2P and verify we catch up
 		await env.SyncFiltersP2pAsync();
 
-		var syncedTip = env.FilterStore.GetTip();
+		var syncedTip = env.FilterStorage.GetTip();
 		Assert.NotNull(syncedTip);
 
 		var blockchainTip = await env.RpcClient.GetBlockCountAsync();
@@ -139,7 +139,7 @@ public class P2pFilterSyncTests
 		await env.SyncFiltersP2pAsync();
 
 		// Assert
-		var filterTip = env.FilterStore.GetTip();
+		var filterTip = env.FilterStorage.GetTip();
 		Assert.NotNull(filterTip);
 
 		var blockchainTip = await env.RpcClient.GetBlockCountAsync();

--- a/WalletWasabi.IntegrationTests/SyncTests/ReorgTests.cs
+++ b/WalletWasabi.IntegrationTests/SyncTests/ReorgTests.cs
@@ -32,7 +32,7 @@ public class ReorgTests
 		await env.RpcClient.GenerateAsync(5);
 		await env.SyncFiltersAsync();
 
-		var preTip = env.FilterStore.GetTip();
+		var preTip = env.FilterStorage.GetTip();
 		Assert.NotNull(preTip);
 		var preHeight = (uint)preTip.Header.Height;
 		var preBlockHash = preTip.Header.BlockHash;
@@ -47,7 +47,7 @@ public class ReorgTests
 		await env.SyncFiltersAsync();
 
 		// Assert
-		var postTip = env.FilterStore.GetTip();
+		var postTip = env.FilterStorage.GetTip();
 		Assert.NotNull(postTip);
 
 		// The new tip should be at the same or higher height
@@ -121,7 +121,7 @@ public class ReorgTests
 		await env.RpcClient.GenerateAsync(10);
 		await env.SyncFiltersAsync();
 
-		var initialTip = env.FilterStore.GetTip();
+		var initialTip = env.FilterStorage.GetTip();
 		Assert.NotNull(initialTip);
 
 		// Get a block 5 blocks back to invalidate
@@ -139,7 +139,7 @@ public class ReorgTests
 		await env.SyncFiltersAsync();
 
 		// Assert
-		var newTip = env.FilterStore.GetTip();
+		var newTip = env.FilterStorage.GetTip();
 		Assert.NotNull(newTip);
 
 		// The new chain should be longer

--- a/WalletWasabi.Tests/UnitTests/Mocks/TestableFilterStorage.cs
+++ b/WalletWasabi.Tests/UnitTests/Mocks/TestableFilterStorage.cs
@@ -1,11 +1,11 @@
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 
 namespace WalletWasabi.Tests.UnitTests.Mocks;
 
-class TestableFilterStore : IFilterStore
+class TestableFilterStorage : IFilterStorage
 {
 	public required Func<uint, int, CancellationToken, Task<FilterModel[]>> OnFetchBatchAsync { get; init; }
 	public Task<FilterModel[]> FetchBatchAsync(uint fromHeight, int batchSize, CancellationToken cancellationToken) =>

--- a/WalletWasabi.Tests/UnitTests/Storages/BlockFilterSqliteStorageTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Storages/BlockFilterSqliteStorageTests.cs
@@ -4,11 +4,11 @@ using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
 
-namespace WalletWasabi.Tests.UnitTests.Stores;
+namespace WalletWasabi.Tests.UnitTests.Storages;
 
 /// <summary>
 /// Tests for <see cref="BlockFilterSqliteStorage"/>.

--- a/WalletWasabi.Tests/UnitTests/Storages/BlockFilterSqliteStorageTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Storages/BlockFilterSqliteStorageTests.cs
@@ -25,16 +25,17 @@ public class BlockFilterSqliteStorageTests
 		FilterModel filter0 = CreateFilterModel(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, headerOrPrevBlockHash: uint256.Zero, blockTime: 1231006505);
 		FilterModel filter1 = CreateFilterModel(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, headerOrPrevBlockHash: uint256.One, blockTime: 1231006506);
 
-		using BlockFilterSqliteStorage indexStorage = BlockFilterSqliteStorage.FromFile(Path.Combine(workDir, "Filters.sqlite"));
+		var sharedSqliteStorage = SharedSqliteStorage.FromFile(Path.Combine(workDir, "Shared.sqlite"));
+		var filterStorage = new BlockFilterSqliteStorage(sharedSqliteStorage.GetConnectionFactory());
 
-		bool added = indexStorage.TryAppend(filter0);
+		bool added = filterStorage.TryAppend(filter0);
 		Assert.True(added);
 
-		added = indexStorage.TryAppend(filter1);
+		added = filterStorage.TryAppend(filter1);
 		Assert.True(added);
 
 		// The filter with the same block height is already present.
-		added = indexStorage.TryAppend(filter1);
+		added = filterStorage.TryAppend(filter1);
 		Assert.False(added);
 	}
 
@@ -45,15 +46,16 @@ public class BlockFilterSqliteStorageTests
 
 		FilterModel startingFilter = FilterCheckpoints.GetWasabiGenesisFilter(Network.Main);
 
-		using BlockFilterSqliteStorage indexStorage = BlockFilterSqliteStorage.FromFile(Path.Combine(workDir, "Filters.sqlite"));
-		indexStorage.TryAppend(startingFilter);
+		var sharedSqliteStorage = SharedSqliteStorage.FromFile(Path.Combine(workDir, "Shared.sqlite"));
+		var filterStorage = new BlockFilterSqliteStorage(sharedSqliteStorage.GetConnectionFactory());
+		filterStorage.TryAppend(startingFilter);
 
-		bool result = indexStorage.TryRemoveLast(out FilterModel? filter1);
+		bool result = filterStorage.TryRemoveLast(out FilterModel? filter1);
 		Assert.True(result);
 		Assert.NotNull(filter1);
 		Assert.NotSame(startingFilter, filter1); // The filter was stored in the database and removed from the database, so no reference equality.
 
-		result = indexStorage.TryRemoveLast(out FilterModel? filter2);
+		result = filterStorage.TryRemoveLast(out FilterModel? filter2);
 		Assert.False(result);
 		Assert.Null(filter2);
 	}
@@ -66,13 +68,14 @@ public class BlockFilterSqliteStorageTests
 		FilterModel filter0 = CreateFilterModel(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, headerOrPrevBlockHash: uint256.Zero, blockTime: 1231006505);
 		FilterModel filter1 = CreateFilterModel(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, headerOrPrevBlockHash: uint256.One, blockTime: 1231006506);
 
-		using BlockFilterSqliteStorage indexStorage = BlockFilterSqliteStorage.FromFile(Path.Combine(workDir, "Filters.sqlite"));
-		indexStorage.TryAppend(filter0);
+		var sharedSqliteStorage = SharedSqliteStorage.FromFile(Path.Combine(workDir, "Shared.sqlite"));
+		var filterStorage = new BlockFilterSqliteStorage(sharedSqliteStorage.GetConnectionFactory());
+		filterStorage.TryAppend(filter0);
 
-		bool added = indexStorage.TryAppend(filter1);
+		bool added = filterStorage.TryAppend(filter1);
 		Assert.True(added);
 
-		bool result = indexStorage.TryRemoveLast(out FilterModel? filterLast);
+		bool result = filterStorage.TryRemoveLast(out FilterModel? filterLast);
 		Assert.True(result);
 		Assert.NotNull(filterLast);
 		Assert.NotSame(filter1, filterLast);
@@ -82,7 +85,7 @@ public class BlockFilterSqliteStorageTests
 		Assert.Equal(1231006506, filterLast.Header.EpochBlockTime);
 		Assert.Equal(DummyFilterData, filterLast.Filter.ToBytes());
 
-		result = indexStorage.TryRemoveLast(out filterLast);
+		result = filterStorage.TryRemoveLast(out filterLast);
 		Assert.True(result);
 		Assert.NotNull(filterLast);
 		Assert.Equal(0u, filterLast.Header.Height.Height);
@@ -102,29 +105,30 @@ public class BlockFilterSqliteStorageTests
 		FilterModel filter2 = CreateFilterModel(blockHeight: 2, blockHash: new uint256(3), filterData: DummyFilterData, headerOrPrevBlockHash: new uint256(2), blockTime: 1231006507);
 		FilterModel filter3 = CreateFilterModel(blockHeight: 3, blockHash: new uint256(4), filterData: DummyFilterData, headerOrPrevBlockHash: new uint256(3), blockTime: 1231006508);
 
-		using BlockFilterSqliteStorage indexStorage = BlockFilterSqliteStorage.FromFile(Path.Combine(workDir, "Filters.sqlite"));
+		var sharedSqliteStorage = SharedSqliteStorage.FromFile(Path.Combine(workDir, "Shared.sqlite"));
+		var filterStorage = new BlockFilterSqliteStorage(sharedSqliteStorage.GetConnectionFactory());
 
-		Assert.True(indexStorage.TryAppend(filter0));
-		Assert.True(indexStorage.TryAppend(filter1));
-		Assert.True(indexStorage.TryAppend(filter2));
-		Assert.True(indexStorage.TryAppend(filter3));
+		Assert.True(filterStorage.TryAppend(filter0));
+		Assert.True(filterStorage.TryAppend(filter1));
+		Assert.True(filterStorage.TryAppend(filter2));
+		Assert.True(filterStorage.TryAppend(filter3));
 
-		bool result = indexStorage.TryRemoveLastIfNewerThan(height: 0, out FilterModel? filterLast);
+		bool result = filterStorage.TryRemoveLastIfNewerThan(height: 0, out FilterModel? filterLast);
 		Assert.True(result);
 		Assert.NotNull(filterLast);
 		Assert.Equal(3u, filterLast.Header.Height.Height);
 
-		result = indexStorage.TryRemoveLastIfNewerThan(height: 0, out filterLast);
+		result = filterStorage.TryRemoveLastIfNewerThan(height: 0, out filterLast);
 		Assert.True(result);
 		Assert.NotNull(filterLast);
 		Assert.Equal(2u, filterLast.Header.Height.Height);
 
-		result = indexStorage.TryRemoveLastIfNewerThan(height: 0, out filterLast);
+		result = filterStorage.TryRemoveLastIfNewerThan(height: 0, out filterLast);
 		Assert.True(result);
 		Assert.NotNull(filterLast);
 		Assert.Equal(1u, filterLast.Header.Height.Height);
 
-		result = indexStorage.TryRemoveLastIfNewerThan(height: 0, out filterLast);
+		result = filterStorage.TryRemoveLastIfNewerThan(height: 0, out filterLast);
 		Assert.False(result);
 		Assert.Null(filterLast);
 	}
@@ -137,24 +141,26 @@ public class BlockFilterSqliteStorageTests
 		FilterModel filter0 = CreateFilterModel(blockHeight: 0, blockHash: uint256.One, filterData: DummyFilterData, headerOrPrevBlockHash: uint256.Zero, blockTime: 1231006505);
 		FilterModel filter1 = CreateFilterModel(blockHeight: 1, blockHash: new uint256(2), filterData: DummyFilterData, headerOrPrevBlockHash: uint256.One, blockTime: 1231006506);
 
-		using BlockFilterSqliteStorage indexStorage = BlockFilterSqliteStorage.FromFile(Path.Combine(workDir, "Filters.sqlite"));
-		bool result = indexStorage.TryAppend(filter0);
+		var sharedSqliteStorage = SharedSqliteStorage.FromFile(Path.Combine(workDir, "Shared.sqlite"));
+		var filterStorage = new BlockFilterSqliteStorage(sharedSqliteStorage.GetConnectionFactory());
+
+		bool result = filterStorage.TryAppend(filter0);
 
 		// Now the storage contains 2 rows.
-		result = indexStorage.TryAppend(filter1);
+		result = filterStorage.TryAppend(filter1);
 		Assert.True(result);
 
 		// Now we believe that the storage is empty.
-		bool removedRows = indexStorage.Clear();
+		bool removedRows = filterStorage.Clear();
 		Assert.True(removedRows);
 
 		// Now the storage is empty.
-		removedRows = indexStorage.Clear();
+		removedRows = filterStorage.Clear();
 		Assert.False(removedRows);
 	}
 
 	private static FilterModel CreateFilterModel(uint blockHeight, uint256 blockHash, byte[] filterData, uint256 headerOrPrevBlockHash, long blockTime) =>
-		new (
+		new(
 			new SmartHeader(blockHash, headerOrPrevBlockHash, blockHeight, blockTime),
 			new GolombRiceFilter(filterData, 20, 1 << 20));
 }

--- a/WalletWasabi.Tests/UnitTests/Storages/FilterStorageTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Storages/FilterStorageTests.cs
@@ -7,19 +7,19 @@ using WalletWasabi.Backend.Models;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Services;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
 
-namespace WalletWasabi.Tests.UnitTests.Stores;
+namespace WalletWasabi.Tests.UnitTests.Storages;
 
 /// <summary>
-/// Tests for <see cref="FilterStore"/>.
+/// Tests for <see cref="FilterStorage"/>.
 /// </summary>
-public class FilterStoreTests
+public class FilterStorageTests
 {
 	[Fact]
-	public async Task FilterStoreTestsAsync()
+	public async Task FilterStorageTestsAsync()
 	{
 		using CancellationTokenSource testCts = new(TimeSpan.FromMinutes(1));
 
@@ -27,15 +27,15 @@ public class FilterStoreTests
 		await IoHelpers.TryDeleteDirectoryAsync(directory);
 		IoHelpers.EnsureContainingDirectoryExists(directory);
 
-		using var filterStore = new FilterStore(directory, Network.Main, new FilterHeaderChain(), new EventBus());
-		await filterStore.InitializeAsync(0, testCts.Token);
+		using var filterStorage = new FilterStorage(directory, Network.Main, new FilterHeaderChain(), new EventBus());
+		await filterStorage.InitializeAsync(0, testCts.Token);
 
 		// Remove starting filter.
-		FilterModel? filterModel = await filterStore.TryRemoveLastFilterAsync();
+		FilterModel? filterModel = await filterStorage.TryRemoveLastFilterAsync();
 		Assert.NotNull(filterModel);
 
 		// No filter to remove.
-		filterModel = await filterStore.TryRemoveLastFilterAsync();
+		filterModel = await filterStorage.TryRemoveLastFilterAsync();
 		Assert.Null(filterModel);
 	}
 

--- a/WalletWasabi.Tests/UnitTests/Storages/FilterStorageTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Storages/FilterStorageTests.cs
@@ -27,7 +27,10 @@ public class FilterStorageTests
 		await IoHelpers.TryDeleteDirectoryAsync(directory);
 		IoHelpers.EnsureContainingDirectoryExists(directory);
 
-		using var filterStorage = new FilterStorage(directory, Network.Main, new FilterHeaderChain(), new EventBus());
+		var sharedSqliteStorage = SharedSqliteStorage.FromFile(Path.Combine(directory, "Shared.sqlite"));
+		var blockFilterSqliteStorage = new BlockFilterSqliteStorage(sharedSqliteStorage.GetConnectionFactory());
+
+		var filterStorage = new FilterStorage(Network.Main, new FilterHeaderChain(), blockFilterSqliteStorage, new EventBus());
 		await filterStorage.InitializeAsync(0, testCts.Token);
 
 		// Remove starting filter.

--- a/WalletWasabi.Tests/UnitTests/Transactions/AllTransactionStoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/AllTransactionStoreTests.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Extensions;
 using WalletWasabi.Models;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 using WalletWasabi.Tests.Helpers;
 using Xunit;
 

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionSqliteStorageTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionSqliteStorageTests.cs
@@ -1,6 +1,6 @@
 using NBitcoin;
 using WalletWasabi.Blockchain.Transactions;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.Transactions;

--- a/WalletWasabi.Tests/UnitTests/Wallet/FilterProcessor/BlockFilterIteratorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/FilterProcessor/BlockFilterIteratorTests.cs
@@ -31,7 +31,7 @@ public class BlockFilterIteratorTests
 		FilterModel filter4 = CreateFilterModel(blockHeight: 610_004, blockHash: new uint256(4), filterData: DummyFilterData, headerOrPrevBlockHash: new uint256(3), blockTime: 1231006506);
 
 		var fetchCallCount = 0;
-		var filterStore = new TestableFilterStore
+		var filterStorage = new TestableFilterStorage
 		{
 			OnFetchBatchAsync = (fromHeight, count, _) =>
 			{
@@ -45,7 +45,7 @@ public class BlockFilterIteratorTests
 			}
 		};
 
-		BlockFilterIterator filterIterator = new(filterStore, maxNumberFiltersInMemory: 3);
+		BlockFilterIterator filterIterator = new(filterStorage, maxNumberFiltersInMemory: 3);
 
 		// Iterator needs to do a database lookup.
 		{

--- a/WalletWasabi/Blockchain/Transactions/AllTransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/AllTransactionStore.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 
 namespace WalletWasabi.Blockchain.Transactions;
 

--- a/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionStore.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 
 namespace WalletWasabi.Blockchain.Transactions;
 

--- a/WalletWasabi/Services/Synchronizer.cs
+++ b/WalletWasabi/Services/Synchronizer.cs
@@ -12,7 +12,7 @@ using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 
 namespace WalletWasabi.Services;
 
@@ -196,10 +196,10 @@ public static class FilterProviders
 
 public static class Synchronizer
 {
-	public static MessageHandler<Unit> CreateFilterGenerator(FilterProvider filtersProvider, FilterStore filterStore, FilterHeaderChain filterHeaderChain, EventBus eventBus) =>
-		(_, cancellationToken) => GenerateCompactFiltersAsync(filtersProvider, filterStore, filterHeaderChain, eventBus, cancellationToken);
+	public static MessageHandler<Unit> CreateFilterGenerator(FilterProvider filtersProvider, FilterStorage filterStorage, FilterHeaderChain filterHeaderChain, EventBus eventBus) =>
+		(_, cancellationToken) => GenerateCompactFiltersAsync(filtersProvider, filterStorage, filterHeaderChain, eventBus, cancellationToken);
 
-	private static async Task<Unit> GenerateCompactFiltersAsync(FilterProvider filtersProvider, FilterStore filterStore, FilterHeaderChain filterHeaderChain, EventBus eventBus, CancellationToken cancellationToken)
+	private static async Task<Unit> GenerateCompactFiltersAsync(FilterProvider filtersProvider, FilterStorage filterStorage, FilterHeaderChain filterHeaderChain, EventBus eventBus, CancellationToken cancellationToken)
 	{
 		// Don't attempt synchronization without a valid tip hash
 		if (filterHeaderChain.TipHash is null)
@@ -208,7 +208,7 @@ public static class Synchronizer
 			return Unit.Instance;
 		}
 
-		if (filterStore.GetTip() is not { } storedTip)
+		if (filterStorage.GetTip() is not { } storedTip)
 		{
 			return Unit.Instance;
 		}
@@ -218,7 +218,7 @@ public static class Synchronizer
 
 		if (response.IsOk)
 		{
-			var isSynchronized = await ProcessFiltersAsync(response.Value, filterStore, filterHeaderChain, eventBus).ConfigureAwait(false);
+			var isSynchronized = await ProcessFiltersAsync(response.Value, filterStorage, filterHeaderChain, eventBus).ConfigureAwait(false);
 			if (isSynchronized)
 			{
 				await Task.Delay(TimeSpan.FromSeconds(20), cancellationToken).ConfigureAwait(false);
@@ -232,7 +232,7 @@ public static class Synchronizer
 		return Unit.Instance;
 	}
 
-	private static async Task<bool> ProcessFiltersAsync(FiltersResponse response, FilterStore filterStore, FilterHeaderChain filterHeaderChain, EventBus eventBus)
+	private static async Task<bool> ProcessFiltersAsync(FiltersResponse response, FilterStorage filterStorage, FilterHeaderChain filterHeaderChain, EventBus eventBus)
 	{
 		switch (response)
 		{
@@ -244,13 +244,13 @@ public static class Synchronizer
 				return true;
 			case FiltersResponse.BestBlockUnknown:
 				// Reorg happened. Rollback the latest index.
-				FilterModel reorgedFilter = await filterStore.TryRemoveLastFilterAsync().ConfigureAwait(false)
+				FilterModel reorgedFilter = await filterStorage.TryRemoveLastFilterAsync().ConfigureAwait(false)
 					?? throw new InvalidOperationException("Fatal error: Failed to remove the reorged filter.");
 
 				Logger.LogInfo($"REORG Invalid Block: {reorgedFilter.Header.BlockHash}  Height {reorgedFilter.Header.Height}.");
 				break;
 			case FiltersResponse.NewFiltersAvailable newFiltersAvailable:
-				var localTipHeight = filterStore.GetTip()?.Header.Height ?? 0;
+				var localTipHeight = filterStorage.GetTip()?.Header.Height ?? 0;
 
 				filterHeaderChain.SetServerTipHeight(newFiltersAvailable.BestHeight);
 				eventBus.Publish(new NetworkTipHeightChanged(newFiltersAvailable.BestHeight));
@@ -272,11 +272,11 @@ public static class Synchronizer
 					string details = FormatInconsistencyDetails(filterHeaderChain, firstNewFilter);
 					Logger.LogError($"Inconsistent index state detected.{Environment.NewLine}{details}");
 
-					await filterStore.RemoveAllNewerThanAsync(localTipHeight).ConfigureAwait(false);
+					await filterStorage.RemoveAllNewerThanAsync(localTipHeight).ConfigureAwait(false);
 				}
 				else
 				{
-					await filterStore.AddNewFiltersAsync(newFilters).ConfigureAwait(false);
+					await filterStorage.AddNewFiltersAsync(newFilters).ConfigureAwait(false);
 
 					Logger.LogInfo(newFilters.Length == 1
 						? $"Downloaded filter for block {firstNewFilter.Header.Height}."

--- a/WalletWasabi/Storages/BlockFilterSqliteStorage.cs
+++ b/WalletWasabi/Storages/BlockFilterSqliteStorage.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using WalletWasabi.Backend.Models;
 
-namespace WalletWasabi.Stores;
+namespace WalletWasabi.Storages;
 
 /// <summary>
 /// SQLite-based storage for block filters.

--- a/WalletWasabi/Storages/BlockFilterSqliteStorage.cs
+++ b/WalletWasabi/Storages/BlockFilterSqliteStorage.cs
@@ -1,6 +1,4 @@
 using Microsoft.Data.Sqlite;
-using NBitcoin;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using WalletWasabi.Backend.Models;
 
@@ -10,75 +8,20 @@ namespace WalletWasabi.Storages;
 /// SQLite-based storage for block filters.
 /// </summary>
 /// <remarks>The implementation is thread-safe because <see cref="SqliteConnection"/> are created per operation. The connection pool is used for efficiency.</remarks>
-/// <seealso href="https://learn.microsoft.com/en-gb/dotnet/standard/data/sqlite/async">
-/// Async is not supported at the moment, so no async methods were used in this implementation.
-/// </seealso>
-public class BlockFilterSqliteStorage : IDisposable
+public class BlockFilterSqliteStorage
 {
-	private readonly string _connectionString;
-	private bool _disposedValue;
+	private readonly SqliteConnectionFactory _connectionFactory;
 
-	private BlockFilterSqliteStorage(string connectionString)
+	public BlockFilterSqliteStorage(SqliteConnectionFactory connectionFactory)
 	{
-		_connectionString = connectionString;
-	}
-
-	/// <summary>
-	/// Opens a new SQLite connection to the given database file.
-	/// </summary>
-	/// <param name="filePath">Path to the SQLite database file.</param>
-	/// <param name="startingFilter">Starting filter to put into the filter table if the table needs to be created.</param>
-	/// <exception cref="InvalidOperationException">If there is an unrecoverable error.</exception>
-	/// <seealso href="https://dev.to/lefebvre/speed-up-sqlite-with-write-ahead-logging-wal-do">Write-ahead logging explained.</seealso>
-	public static BlockFilterSqliteStorage FromFile(string filePath)
-	{
-		SqliteConnectionStringBuilder builder = new();
-		builder.DataSource = filePath;
-		builder.Pooling = true;
-
-		string connectionString = builder.ConnectionString;
-
-		using var connection = new SqliteConnection(connectionString);
-		connection.Open();
-
-		using (var createCommand = connection.CreateCommand())
-		{
-			createCommand.CommandText = """
-				CREATE TABLE IF NOT EXISTS filter (
-				    block_height INTEGER NOT NULL PRIMARY KEY,
-				    block_hash BLOB NOT NULL,
-				    filter_data BLOB NOT NULL,
-				    previous_block_hash BLOB NOT NULL,
-				    epoch_block_time INTEGER NOT NULL
-				);
-				CREATE INDEX IF NOT EXISTS idx_blocks_height ON filter(block_height);
-				CREATE INDEX IF NOT EXISTS idx_blocks_hash ON filter(block_hash);
-				""";
-			createCommand.ExecuteNonQuery();
-		}
-
-		// Enable write-ahead logging.
-		using (var walCommand = connection.CreateCommand())
-		{
-			walCommand.CommandText = """
-				PRAGMA journal_mode = 'wal';
-				PRAGMA synchronous  = 'NORMAL';
-				""";
-			walCommand.ExecuteNonQuery();
-		}
-
-		return new(connectionString);
+		_connectionFactory = connectionFactory;
 	}
 
 	/// <summary>
 	/// Creates and opens a new pooled connection.
 	/// </summary>
 	public SqliteConnection CreateConnection()
-	{
-		var connection = new SqliteConnection(_connectionString);
-		connection.Open();
-		return connection;
-	}
+		=> _connectionFactory();
 
 	/// <summary>
 	/// Returns all filters with height ≥ than the given one.
@@ -86,7 +29,7 @@ public class BlockFilterSqliteStorage : IDisposable
 	/// <param name="limit">If a maximum number is specified, the number of returned records is limited to this value.</param>
 	public IEnumerable<FilterModel> Fetch(uint fromHeight, int limit = -1)
 	{
-		using var connection = CreateConnection();
+		using var connection = _connectionFactory();
 		using var command = connection.CreateCommand();
 
 		command.CommandText = "SELECT * FROM filter WHERE block_height >= $block_height ORDER BY block_height LIMIT $limit";
@@ -107,7 +50,7 @@ public class BlockFilterSqliteStorage : IDisposable
 	/// </summary>
 	public IEnumerable<FilterModel> FetchLast(int n)
 	{
-		using var connection = CreateConnection();
+		using var connection = _connectionFactory();
 		using var command = connection.CreateCommand();
 		command.CommandText = "SELECT * FROM filter WHERE block_height > (SELECT MAX(block_height) - $n FROM filter) ORDER BY block_height";
 		command.Parameters.AddWithValue("$n", n);
@@ -126,7 +69,7 @@ public class BlockFilterSqliteStorage : IDisposable
 	/// </summary>
 	public bool TryRemoveLast([NotNullWhen(true)] out FilterModel? filter)
 	{
-		using var connection = CreateConnection();
+		using var connection = _connectionFactory();
 		using var command = connection.CreateCommand();
 		command.CommandText = "DELETE FROM filter WHERE block_height = (SELECT MAX(block_height) FROM filter) returning *";
 
@@ -149,7 +92,7 @@ public class BlockFilterSqliteStorage : IDisposable
 	/// <param name="height">Minimum block height of the last block to remove (exclusive).</param>
 	public bool TryRemoveLastIfNewerThan(uint height, [NotNullWhen(true)] out FilterModel? filter)
 	{
-		using var connection = CreateConnection();
+		using var connection = _connectionFactory();
 		using var command = connection.CreateCommand();
 		command.CommandText = "DELETE FROM filter WHERE block_height > $block_height AND block_height = (SELECT MAX(block_height) FROM filter) returning *";
 		command.Parameters.AddWithValue("$block_height", height);
@@ -173,7 +116,7 @@ public class BlockFilterSqliteStorage : IDisposable
 	/// <param name="height">Minimum block height of the last block to remove (exclusive).</param>
 	public IEnumerable<FilterModel> RemoveNewerThan(uint height)
 	{
-		using var connection = CreateConnection();
+		using var connection = _connectionFactory();
 		using var command = connection.CreateCommand();
 		command.CommandText = "DELETE FROM filter WHERE block_height > $block_height RETURNING *";
 		command.Parameters.AddWithValue("$block_height", height);
@@ -209,7 +152,7 @@ public class BlockFilterSqliteStorage : IDisposable
 	{
 		try
 		{
-			using var connection = CreateConnection();
+			using var connection = _connectionFactory();
 			return TryAppend(connection, filter);
 		}
 		catch (SqliteException)
@@ -244,7 +187,7 @@ public class BlockFilterSqliteStorage : IDisposable
 
 	public void SetPragmaUserVersion(int newUserVersion)
 	{
-		using var connection = CreateConnection();
+		using var connection = _connectionFactory();
 		using var command = connection.CreateCommand();
 		command.CommandText = $"PRAGMA user_version = {newUserVersion};";
 		command.ExecuteNonQuery();
@@ -252,7 +195,7 @@ public class BlockFilterSqliteStorage : IDisposable
 
 	public int GetPragmaUserVersion()
 	{
-		using var connection = CreateConnection();
+		using var connection = _connectionFactory();
 		using var command = connection.CreateCommand();
 		command.CommandText = "PRAGMA user_version";
 		var tmp = Convert.ToInt32(command.ExecuteScalar());
@@ -261,7 +204,7 @@ public class BlockFilterSqliteStorage : IDisposable
 
 	public uint? GetMinimumBlockHeight()
 	{
-		using var connection = CreateConnection();
+		using var connection = _connectionFactory();
 		using var command = connection.CreateCommand();
 		command.CommandText = "SELECT MIN(block_height) FROM filter";
 
@@ -275,32 +218,11 @@ public class BlockFilterSqliteStorage : IDisposable
 	/// <returns><c>true</c> if at least one row was deleted, <c>false</c> otherwise.</returns>
 	public bool Clear()
 	{
-		using var connection = CreateConnection();
+		using var connection = _connectionFactory();
 		using var createCommand = connection.CreateCommand();
 		createCommand.CommandText = "DELETE FROM filter";
 		int affectedLines = createCommand.ExecuteNonQuery();
 
 		return affectedLines > 0;
-	}
-
-	protected virtual void Dispose(bool disposing)
-	{
-		if (!_disposedValue)
-		{
-			if (disposing)
-			{
-				// Empty the connection pool to release all connections and make sure the database is no longer in use.
-				SqliteConnection.ClearAllPools();
-			}
-
-			_disposedValue = true;
-		}
-	}
-
-	/// <inheritdoc/>
-	public void Dispose()
-	{
-		Dispose(disposing: true);
-		GC.SuppressFinalize(this);
 	}
 }

--- a/WalletWasabi/Storages/FilterStorage.cs
+++ b/WalletWasabi/Storages/FilterStorage.cs
@@ -6,14 +6,14 @@ using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Services;
 
-namespace WalletWasabi.Stores;
+namespace WalletWasabi.Storages;
 
 /// <summary>
 /// Manages to store the filters safely.
 /// </summary>
-public class FilterStore : IFilterStore, IDisposable
+public class FilterStorage : IFilterStorage, IDisposable
 {
-	public FilterStore(string workFolderPath, Network network, FilterHeaderChain filterHeaderChain, EventBus eventBus)
+	public FilterStorage(string workFolderPath, Network network, FilterHeaderChain filterHeaderChain, EventBus eventBus)
 	{
 		_network = network;
 		_filterHeaderChain = filterHeaderChain;

--- a/WalletWasabi/Storages/FilterStorage.cs
+++ b/WalletWasabi/Storages/FilterStorage.cs
@@ -1,6 +1,4 @@
-using Microsoft.Data.Sqlite;
 using Nito.AsyncEx;
-using System.IO;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
@@ -11,54 +9,15 @@ namespace WalletWasabi.Storages;
 /// <summary>
 /// Manages to store the filters safely.
 /// </summary>
-public class FilterStorage : IFilterStorage, IDisposable
+public class FilterStorage : IFilterStorage
 {
-	public FilterStorage(string workFolderPath, Network network, FilterHeaderChain filterHeaderChain, EventBus eventBus)
+	public FilterStorage(Network network, FilterHeaderChain filterHeaderChain, BlockFilterSqliteStorage blockFilterSqliteStorage, EventBus eventBus)
 	{
 		_network = network;
 		_filterHeaderChain = filterHeaderChain;
 		_eventBus = eventBus;
-		_storageFilePath = Path.Combine(workFolderPath, "IndexStore.sqlite");
-
-		IoHelpers.EnsureDirectoryExists(workFolderPath);
-
-		if (network == Network.RegTest)
-		{
-			SqliteStorageHelper.DeleteDatabaseFiles(_storageFilePath);
-		}
-
-		IndexStorage = CreateBlockFilterSqliteStorage();
+		IndexStorage = blockFilterSqliteStorage;
 	}
-
-	private BlockFilterSqliteStorage CreateBlockFilterSqliteStorage()
-	{
-		try
-		{
-			var storage = BlockFilterSqliteStorage.FromFile(_storageFilePath);
-			if (storage.GetPragmaUserVersion() < 2)
-			{
-				storage.Dispose();
-				Logger.LogInfo("Migrating from old Indexer filters to Bitcoin Core RPC filters.");
-				SqliteStorageHelper.DeleteDatabaseFiles(_storageFilePath);
-				storage = BlockFilterSqliteStorage.FromFile(_storageFilePath);
-				storage.SetPragmaUserVersion(2);
-			}
-
-			return storage;
-		}
-		catch (SqliteException ex) when (ex.SqliteExtendedErrorCode == 11) // 11 ~ SQLITE_CORRUPT error code
-		{
-			Logger.LogError($"Failed to open SQLite storage file because it's corrupted. Deleting the storage file '{_storageFilePath}'.");
-
-			SqliteStorageHelper.DeleteDatabaseFiles(_storageFilePath);
-			var storage = BlockFilterSqliteStorage.FromFile(_storageFilePath);
-			storage.SetPragmaUserVersion(2);
-			return storage;
-		}
-	}
-
-	/// <summary>SQLite file path for migration purposes.</summary>
-	private readonly string _storageFilePath;
 
 	private readonly Network _network;
 	private readonly FilterHeaderChain _filterHeaderChain;
@@ -261,10 +220,5 @@ public class FilterStorage : IFilterStorage, IDisposable
 				break;
 			}
 		}
-	}
-
-	public void Dispose()
-	{
-		IndexStorage.Dispose();
 	}
 }

--- a/WalletWasabi/Storages/IFilterStorage.cs
+++ b/WalletWasabi/Storages/IFilterStorage.cs
@@ -2,9 +2,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 
-namespace WalletWasabi.Stores;
+namespace WalletWasabi.Storages;
 
-public interface IFilterStore
+public interface IFilterStorage
 {
 	Task<FilterModel[]> FetchBatchAsync(uint fromHeight, int batchSize, CancellationToken cancellationToken);
 }

--- a/WalletWasabi/Storages/SharedSqliteStorage.cs
+++ b/WalletWasabi/Storages/SharedSqliteStorage.cs
@@ -1,0 +1,99 @@
+using Microsoft.Data.Sqlite;
+
+namespace WalletWasabi.Storages;
+
+public delegate SqliteConnection SqliteConnectionFactory();
+
+/// <summary>
+/// SQLite-based storage for public data such Bitcoin block filters, P2P seed data, etc. which are not related to any particular wallet.
+/// </summary>
+public class SharedSqliteStorage : IDisposable
+{
+	private readonly string _connectionString;
+	private bool _disposedValue;
+
+	private SharedSqliteStorage(string connectionString)
+	{
+		_connectionString = connectionString;
+	}
+
+	public SqliteConnectionFactory GetConnectionFactory() => CreateConnection;
+
+	/// <summary>
+	/// Opens a new SQLite connection to the given database file.
+	/// </summary>
+	/// <param name="filePath">Path to the SQLite database file.</param>
+	/// <param name="startingFilter">Starting filter to put into the filter table if the table needs to be created.</param>
+	/// <exception cref="InvalidOperationException">If there is an unrecoverable error.</exception>
+	/// <seealso href="https://dev.to/lefebvre/speed-up-sqlite-with-write-ahead-logging-wal-do">Write-ahead logging explained.</seealso>
+	public static SharedSqliteStorage FromFile(string filePath)
+	{
+		SqliteConnectionStringBuilder builder = new();
+		builder.DataSource = filePath;
+		builder.Pooling = true;
+
+		string connectionString = builder.ConnectionString;
+
+		using var connection = new SqliteConnection(connectionString);
+		connection.Open();
+
+		using (var createCommand = connection.CreateCommand())
+		{
+			createCommand.CommandText = """
+				CREATE TABLE IF NOT EXISTS filter (
+				    block_height INTEGER NOT NULL PRIMARY KEY,
+				    block_hash BLOB NOT NULL,
+				    filter_data BLOB NOT NULL,
+				    previous_block_hash BLOB NOT NULL,
+				    epoch_block_time INTEGER NOT NULL
+				);
+				CREATE INDEX IF NOT EXISTS idx_blocks_height ON filter(block_height);
+				CREATE INDEX IF NOT EXISTS idx_blocks_hash ON filter(block_hash);
+				""";
+			createCommand.ExecuteNonQuery();
+		}
+
+		// Enable write-ahead logging.
+		using (var walCommand = connection.CreateCommand())
+		{
+			walCommand.CommandText = """
+				PRAGMA journal_mode = 'wal';
+				PRAGMA synchronous  = 'NORMAL';
+				""";
+			walCommand.ExecuteNonQuery();
+		}
+
+		return new(connectionString);
+	}
+
+	/// <summary>
+	/// Creates and opens a new pooled connection.
+	/// </summary>
+	private SqliteConnection CreateConnection()
+	{
+		var connection = new SqliteConnection(_connectionString);
+		connection.Open();
+		return connection;
+	}
+
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!_disposedValue)
+		{
+			if (disposing)
+			{
+				// Empty the connection pool to release all connections and make sure the database is no longer in use.
+				SqliteConnection.ClearAllPools();
+			}
+
+			_disposedValue = true;
+		}
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+}

--- a/WalletWasabi/Storages/SqliteStorageHelper.cs
+++ b/WalletWasabi/Storages/SqliteStorageHelper.cs
@@ -1,6 +1,6 @@
 using System.IO;
 
-namespace WalletWasabi.Stores;
+namespace WalletWasabi.Storages;
 
 public static class SqliteStorageHelper
 {

--- a/WalletWasabi/Storages/TransactionSqliteStorage.cs
+++ b/WalletWasabi/Storages/TransactionSqliteStorage.cs
@@ -9,7 +9,7 @@ using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
 
-namespace WalletWasabi.Stores;
+namespace WalletWasabi.Storages;
 
 public class TransactionSqliteStorage : IDisposable
 {

--- a/WalletWasabi/Stores/FilterStore.cs
+++ b/WalletWasabi/Stores/FilterStore.cs
@@ -1,16 +1,9 @@
 using Microsoft.Data.Sqlite;
-using NBitcoin;
 using Nito.AsyncEx;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
-using WalletWasabi.Helpers;
-using WalletWasabi.Logging;
 using WalletWasabi.Services;
 
 namespace WalletWasabi.Stores;
@@ -31,7 +24,7 @@ public class FilterStore : IFilterStore, IDisposable
 
 		if (network == Network.RegTest)
 		{
-			DeleteIndex(_storageFilePath);
+			SqliteStorageHelper.DeleteDatabaseFiles(_storageFilePath);
 		}
 
 		IndexStorage = CreateBlockFilterSqliteStorage();
@@ -46,7 +39,7 @@ public class FilterStore : IFilterStore, IDisposable
 			{
 				storage.Dispose();
 				Logger.LogInfo("Migrating from old Indexer filters to Bitcoin Core RPC filters.");
-				DeleteIndex(_storageFilePath);
+				SqliteStorageHelper.DeleteDatabaseFiles(_storageFilePath);
 				storage = BlockFilterSqliteStorage.FromFile(_storageFilePath);
 				storage.SetPragmaUserVersion(2);
 			}
@@ -57,7 +50,7 @@ public class FilterStore : IFilterStore, IDisposable
 		{
 			Logger.LogError($"Failed to open SQLite storage file because it's corrupted. Deleting the storage file '{_storageFilePath}'.");
 
-			DeleteIndex(_storageFilePath);
+			SqliteStorageHelper.DeleteDatabaseFiles(_storageFilePath);
 			var storage = BlockFilterSqliteStorage.FromFile(_storageFilePath);
 			storage.SetPragmaUserVersion(2);
 			return storage;
@@ -267,24 +260,6 @@ public class FilterStore : IFilterStore, IDisposable
 			{
 				break;
 			}
-		}
-	}
-
-	private void DeleteIndex(string indexPath)
-	{
-		if (File.Exists(indexPath))
-		{
-			File.Delete(indexPath);
-		}
-
-		if (File.Exists($"{indexPath}-shm"))
-		{
-			File.Delete($"{indexPath}-shm");
-		}
-
-		if (File.Exists($"{indexPath}-wal"))
-		{
-			File.Delete($"{indexPath}-wal");
 		}
 	}
 

--- a/WalletWasabi/Stores/SqliteStorageHelper.cs
+++ b/WalletWasabi/Stores/SqliteStorageHelper.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace WalletWasabi.Stores;
 
 public static class SqliteStorageHelper
@@ -5,4 +7,22 @@ public static class SqliteStorageHelper
 	/// <remarks>Useful for testing purposes to create a non-persistent SQLite database in memory.</remarks>
 	/// <seealso href="https://learn.microsoft.com/en-us/dotnet/standard/data/sqlite/in-memory-databases"/>
 	public const string InMemoryDatabase = ":memory:";
+
+	public static void DeleteDatabaseFiles(string mainFilePath)
+	{
+		if (File.Exists(mainFilePath))
+		{
+			File.Delete(mainFilePath);
+		}
+
+		if (File.Exists($"{mainFilePath}-shm"))
+		{
+			File.Delete($"{mainFilePath}-shm");
+		}
+
+		if (File.Exists($"{mainFilePath}-wal"))
+		{
+			File.Delete($"{mainFilePath}-wal");
+		}
+	}
 }

--- a/WalletWasabi/Wallets/FilterProcessor/BlockFilterIterator.cs
+++ b/WalletWasabi/Wallets/FilterProcessor/BlockFilterIterator.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Models;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 
 namespace WalletWasabi.Wallets.FilterProcessor;
 
-public class BlockFilterIterator(IFilterStore filterStore, int maxNumberFiltersInMemory = 1000)
+public class BlockFilterIterator(IFilterStorage filterStorage, int maxNumberFiltersInMemory = 1000)
 {
 	private readonly Dictionary<uint, FilterModel> _cache = new();
 	private readonly int _maxNumberFiltersInMemory = maxNumberFiltersInMemory > 0
@@ -29,7 +29,7 @@ public class BlockFilterIterator(IFilterStore filterStore, int maxNumberFiltersI
 		// We don't have the next filter to process, so fetch another batch of filters from the database.
 		_cache.Clear();
 
-		var filtersBatch = await filterStore.FetchBatchAsync(height, _maxNumberFiltersInMemory, cancellationToken).ConfigureAwait(false);
+		var filtersBatch = await filterStorage.FetchBatchAsync(height, _maxNumberFiltersInMemory, cancellationToken).ConfigureAwait(false);
 
 		if (filtersBatch.Length == 0)
 		{

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -19,7 +19,7 @@ using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Services;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 using WalletWasabi.Userfacing;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.Batching;
@@ -34,15 +34,15 @@ public class Wallet : BackgroundService
 	private readonly ComposedDisposable _disposables = new();
 
 	public static WalletFactory CreateFactory(
-		Network network, FilterStore filterStore, AllTransactionStore transactionStore, FilterHeaderChain filterHeaderChain,
+		Network network, FilterStorage filterStorage, AllTransactionStore transactionStore, FilterHeaderChain filterHeaderChain,
 		MempoolService mempoolService, ServiceConfiguration serviceConfiguration, BlockProvider blockProvider,
 		EventBus eventBus, CpfpInfoProvider cpfpInfoProvider) =>
-		keyManager => new Wallet(network, keyManager, filterStore, transactionStore, filterHeaderChain, blockProvider, mempoolService, serviceConfiguration, cpfpInfoProvider, eventBus);
+		keyManager => new Wallet(network, keyManager, filterStorage, transactionStore, filterHeaderChain, blockProvider, mempoolService, serviceConfiguration, cpfpInfoProvider, eventBus);
 
 	private Wallet(
 		Network network,
 		KeyManager keyManager,
-		FilterStore filterStore,
+		FilterStorage filterStorage,
 		AllTransactionStore transactionStore,
 		FilterHeaderChain filterHeaderChain,
 		BlockProvider blockProvider,
@@ -57,12 +57,12 @@ public class Wallet : BackgroundService
 		ServiceConfiguration = serviceConfiguration;
 		CpfpInfoProvider = cpfpInfoProvider;
 		DestinationProvider = new InternalDestinationProvider(KeyManager);
-		_filterStore = filterStore;
+		_filterStorage = filterStorage;
 		TransactionStore = transactionStore;
 		FilterHeaderChain = filterHeaderChain;
 
 		TransactionProcessor = new TransactionProcessor(TransactionStore, mempoolService, keyManager, ServiceConfiguration.DustThreshold, eventBus);
-		WalletFilterProcessor = new WalletFilterProcessor(keyManager, TransactionStore, _filterStore, FilterHeaderChain, TransactionProcessor, blockProvider, eventBus);
+		WalletFilterProcessor = new WalletFilterProcessor(keyManager, TransactionStore, _filterStorage, FilterHeaderChain, TransactionProcessor, blockProvider, eventBus);
 		Coins = TransactionProcessor.Coins;
 		BatchedPayments = new PaymentBatch();
 		OutputProvider = new PaymentAwareOutputProvider(DestinationProvider, BatchedPayments, RandomnessProviders.Secure);
@@ -86,7 +86,7 @@ public class Wallet : BackgroundService
 	}
 
 	private readonly EventBus _eventBus;
-	private readonly FilterStore _filterStore;
+	private readonly FilterStorage _filterStorage;
 	private ChainHeight _lastFilterProcess = 0;
 	public AllTransactionStore TransactionStore { get; }
 	public FilterHeaderChain FilterHeaderChain { get; }

--- a/WalletWasabi/Wallets/WalletFilterProcessor.cs
+++ b/WalletWasabi/Wallets/WalletFilterProcessor.cs
@@ -12,7 +12,7 @@ using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Logging;
 using WalletWasabi.Services;
 using WalletWasabi.Services.Terminate;
-using WalletWasabi.Stores;
+using WalletWasabi.Storages;
 using WalletWasabi.Wallets.FilterProcessor;
 
 namespace WalletWasabi.Wallets;
@@ -22,7 +22,7 @@ public class WalletFilterProcessor : BackgroundService
 	public WalletFilterProcessor(
 		KeyManager keyManager,
 		AllTransactionStore transactionStore,
-		FilterStore filterStore,
+		FilterStorage filterStorage,
 		FilterHeaderChain filterHeaderChain,
 		TransactionProcessor transactionProcessor,
 		BlockProvider blockProvider,
@@ -34,7 +34,7 @@ public class WalletFilterProcessor : BackgroundService
 		_transactionProcessor = transactionProcessor;
 		_blockProvider = blockProvider;
 		_eventBus = eventBus;
-		_blockFilterIterator = new(filterStore);
+		_blockFilterIterator = new(filterStorage);
 		_initialSynchronizationFinished = new TaskCompletionSource();
 	}
 


### PR DESCRIPTION
Stacked on top of #14862
Original PR was #14674

## Motivation

@lontivero [mentioned](https://github.com/WalletWasabi/WalletWasabi/pull/14586#discussion_r3227853565) that his the long term goal is to have two SQLite databases:

1. one for "public Bitcoin network data" like compact filters, P2P seed data, etc.
2. one for transactions representing "private data for users' wallets".

Currently, there are two classes that handles this `BlockFilterSqliteStorage` (the first group), `TransactionSqliteStorage` in Wasabi. The goal of this PR is to unblock storing more public data and provide reasonable API for working with it.

General API design points:

* In general, I believe Wasabi should store data on disk either to JSON configuration files or to SQLite files. This minimizes risk of situations like storing files safely to disk without risking file corruption. Moreover, JSON and SQLite are mature formats that are well supported and well understood. SQLite offers a great query language (SQL) and is uniquely suited for quick lookups from database when needed to decrease memory use.
* `BlockFilterSqliteStorage` and `TransactionSqliteStorage` were originally designed so that each have one single SQLite connection. #14684 modified `BlockFilterSqliteStorage` so that connection polling is used. `TransactionSqliteStorage` is still open for the duration of the app's whole lifecycle. This PR paves the way for SQLite tables in `Index.sqlite` not to block one another.


## This PR

The idea of this PR is that `SharedSqliteStorage` is the class that handles database connections and its initialization for "public Bitcoin network data".

* `BlockFilterSqliteStorage` is class that works with `filter` SQLite table _exclusively_. `BlockFilterSqliteStorage`[^2] depends on `SharedSqliteStorage`. 
* A step forward is to add a new class that again depends on `SharedSqliteStorage` and adds a new table with custom data (P2P seed data, already discovered P2P nodes, or any other stuff to store to `Index.sqlite`[^1]). This is to be done in a follow-up PR.


[^1]: This name is not great but I don't want to complicate stuff further.
[^2]: A better name would be `BlockFilterSqliteStorage` -> `BlockFilterSqliteRepository`. The naming would somewhat align to Entity Framework in .NET.