### PR TITLE
[BIP-77 2 of 5] Recognize BIP 77 pj endpoints and preserve pjos in BIP 21 parsing

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Userfacing/AddressParserTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Userfacing/AddressParserTests.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using WalletWasabi.Payjoin;
 using WalletWasabi.Userfacing;
 using Xunit;
 
@@ -9,6 +10,10 @@ namespace WalletWasabi.Tests.UnitTests.Userfacing;
 /// </summary>
 public class AddressParserTests
 {
+	/// <summary>A realistic BIP 77 <c>pj=</c> value.</summary>
+	/// <seealso cref="Bip77UriParams"/>
+	private const string Bip77PjUrl = "https://payjo.in/TXJCGKTKXLUUZ#EX1WKV8CEC-OH1QYPM59NK2LXXS4890SUAXXYT25Z2VAPHP0X7YEYCJXGWAG6UG9ZU6NQ-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV";
+
 	[Fact]
 	public void TryParse_BitcoinAddressTests()
 	{
@@ -120,5 +125,63 @@ public class AddressParserTests
 		Assert.Equal("sp1qqgste7k9hx0qftg6qmwlkqtwuy6cycyavzmzj85c6qdfhjdpdjtdgqjuexzk6murw56suy3e0rd2cgqvycxttddwsvgxe2usfpxumr70xc9pkqwv", sp.ToWif(Network.Main));
 		Assert.Equal("bolt11_example", result.Label);
 		Assert.Equal(0.02m, result.Amount);
+	}
+
+	/// <summary>
+	/// Inside a BIP 21 URI the whole pj value is percent-encoded. <see cref="AddressParser"/> must hand back the decoded URL and fragment intact.
+	/// </summary>
+	[Fact]
+	public void PreservesBip77PjUrlFragmentParameters()
+	{
+		string encodedPjUrl = Uri.EscapeDataString(Bip77PjUrl);
+		string bip21 = $"bitcoin:tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx?amount=0.00010727&pj={encodedPjUrl}";
+
+		var result = AddressParser.Parse(bip21, Network.TestNet).Value;
+
+		var uri = Assert.IsType<Address.Bip21Uri>(result);
+		Assert.Equal(Bip77PjUrl, uri.PayjoinEndpoint);
+		Assert.Equal(0.00010727m, uri.Amount);
+	}
+
+	/// <summary>
+	/// <c>pjos=0</c> (output substitution disabled) must survive parsing so the sender can rebuild a faithful BIP 21.
+	/// </summary>
+	[Fact]
+	public void PreservesPjosParameter()
+	{
+		string bip21 = $"bitcoin:tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx?amount=1&pj={Uri.EscapeDataString(Bip77PjUrl)}&pjos=0";
+
+		var result = AddressParser.Parse(bip21, Network.TestNet).Value;
+
+		var uri = Assert.IsType<Address.Bip21Uri>(result);
+		Assert.Equal("0", uri.PayjoinOutputSubstitution);
+
+		// And it round-trips through serialization.
+		Assert.Contains("pjos=0", uri.ToWif(Network.TestNet));
+	}
+
+	[Fact]
+	public void Bip77UriParams_DetectsVersionAndExtractsReceiverKey()
+	{
+		Assert.True(Bip77UriParams.IsBip77(Bip77PjUrl));
+		Assert.True(Bip77UriParams.TryGetReceiverKey(Bip77PjUrl, out var receiverKey));
+		Assert.Equal("RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV", receiverKey);
+
+		// A BIP 78 (v1) endpoint has no BIP 77 fragment params.
+		Assert.False(Bip77UriParams.IsBip77("https://btcpay.example/BTC/pj"));
+		Assert.False(Bip77UriParams.TryGetReceiverKey("https://btcpay.example/BTC/pj", out _));
+
+		// A fragment without the receiver key is not BIP 77.
+		Assert.False(Bip77UriParams.IsBip77("https://payjo.in/TXJCGKTKXLUUZ#EX1WKV8CEC"));
+	}
+
+	/// <summary>BIP 21 without a <c>pj</c> parameter yields no payjoin endpoint.</summary>
+	[Fact]
+	public void NoPjParameter_YieldsNullEndpoint()
+	{
+		var result = AddressParser.Parse("bitcoin:tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx?amount=1", Network.TestNet).Value;
+
+		var uri = Assert.IsType<Address.Bip21Uri>(result);
+		Assert.Null(uri.PayjoinEndpoint);
 	}
 }

--- a/WalletWasabi/Payjoin/Bip77UriParams.cs
+++ b/WalletWasabi/Payjoin/Bip77UriParams.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace WalletWasabi.Payjoin;
+
+/// <summary>
+/// Textual helpers for BIP 77 <c>pj=</c> endpoint URLs.
+/// </summary>
+/// <remarks>
+/// An example of a BIP 21 URI carrying a BIP 77 endpoint:
+/// <c>bitcoin:tb1q6q6de88mj8qkg0q5lupmpfexwnqjsr4d2gvx2p?amount=0.00666666&amp;pjos=0&amp;pj=HTTPS://PAYJO.IN/TXJCGKTKXLUUZ%23EX1WKV8CEC-OH1QYPM59NK2LXXS4890SUAXXYT25Z2VAPHP0X7YEYCJXGWAG6UG9ZU6NQ-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV</c>
+/// and the decoded <c>pj</c> parameter is:
+/// <c>HTTPS://PAYJO.IN/TXJCGKTKXLUUZ#EX1WKV8CEC-OH1QYPM59NK2LXXS4890SUAXXYT25Z2VAPHP0X7YEYCJXGWAG6UG9ZU6NQ-RK1Q0DJS3VVDXWQQTLQ8022QGXSX7ML9PHZ6EDSF6AKEWQG758JPS2EV</c>
+/// where the <c>#</c> is followed by the receiver's ephemeral parameters as uppercase bech32,
+/// delimited by <c>-</c> (or <c>+</c> in older senders): <c>RK1…</c> receiver key, <c>OH1…</c>
+/// OHTTP keys, <c>EX1…</c> expiry. The Payjoin package parses and validates the endpoint but
+/// exposes no accessor for the individual parameters, so version dispatch and the session-dedup
+/// key are read off the text here.
+/// </remarks>
+/// <seealso href="https://github.com/bitcoin/bips/blob/master/bip-0077.md"/>
+public static class Bip77UriParams
+{
+	/// <summary>A pj endpoint is BIP 77 when its fragment carries the receiver-key and OHTTP-keys params.</summary>
+	public static bool IsBip77(string pjEndpoint) =>
+		TryGetFragmentParam(pjEndpoint, "RK1", out _) && TryGetFragmentParam(pjEndpoint, "OH1", out _);
+
+	/// <summary>The receiver's ephemeral public key (opaque bech32 string) — the session-dedup key.</summary>
+	public static bool TryGetReceiverKey(string pjEndpoint, [NotNullWhen(true)] out string? receiverKey) =>
+		TryGetFragmentParam(pjEndpoint, "RK1", out receiverKey);
+
+	private static bool TryGetFragmentParam(string pjEndpoint, string prefix, [NotNullWhen(true)] out string? value)
+	{
+		value = null;
+
+		int fragmentStart = pjEndpoint.IndexOf('#', StringComparison.Ordinal);
+		if (fragmentStart < 0 || fragmentStart == pjEndpoint.Length - 1)
+		{
+			return false;
+		}
+
+		// '-' is outside the bech32 character set, so splitting on both delimiters is safe.
+		foreach (string param in pjEndpoint[(fragmentStart + 1)..].Split('+', '-'))
+		{
+			if (param.StartsWith(prefix, StringComparison.Ordinal))
+			{
+				value = param;
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/WalletWasabi/Userfacing/AddressParser.cs
+++ b/WalletWasabi/Userfacing/AddressParser.cs
@@ -1,7 +1,3 @@
-using NBitcoin;
-using System.Collections.Generic;
-using System.Linq;
-using WalletWasabi.Helpers;
 using WalletWasabi.Userfacing.Bip321;
 using WalletWasabi.Wallets.SilentPayment;
 using NBitcoinExtensions = WalletWasabi.Extensions.NBitcoinExtensions;
@@ -12,7 +8,7 @@ using AddressParsingResult = Result<Address, string>;
 
 public abstract record Address
 {
-	public record Bip21Uri(Address Address, decimal? Amount, string? Label, string? PayjoinEndpoint) : Address;
+	public record Bip21Uri(Address Address, decimal? Amount, string? Label, string? PayjoinEndpoint, string? PayjoinOutputSubstitution = null) : Address;
 	public record Bitcoin(BitcoinAddress Address) : Address;
 	public record SilentPayment(SilentPaymentAddress Address) : Address;
 
@@ -40,7 +36,8 @@ public abstract record Address
 		{
 			bip21.Amount is not null ? $"amount={bip21.Amount}" : "",
 			bip21.Label is not null ? $"label={bip21.Label}" : "",
-			bip21.PayjoinEndpoint is not null ? $"pj={bip21.PayjoinEndpoint}" : ""
+			bip21.PayjoinEndpoint is not null ? $"pj={bip21.PayjoinEndpoint}" : "",
+			bip21.PayjoinEndpoint is not null && bip21.PayjoinOutputSubstitution is not null ? $"pjos={bip21.PayjoinOutputSubstitution}" : ""
 		}.Where(x => x != "");
 		var parameterString = string.Join("&", parametersArray);
 
@@ -82,7 +79,8 @@ public static class AddressParser
 				result.Address,
 				result.Amount is null ? null : decimal.Parse(result.Amount.ToString()),
 				result.Label,
-				result.UnknownParameters.GetValueOrDefault("pj")));
+				result.UnknownParameters.GetValueOrDefault("pj"),
+				result.UnknownParameters.GetValueOrDefault("pjos")));
 	}
 
 	public static AddressParsingResult ParseBitcoinAddress(string text, Network expectedNetwork)


### PR DESCRIPTION
2/5 of for Async Payjoin support #13628 

AddressParser now keeps the pjos (output-substitution) parameter alongside the pj endpoint when parsing a BIP 21 URI and re-serializes it, so a faithful BIP 21 can be rebuilt for the payjoin-ffi parser to be introduced later in this series. Bip77UriParams adds textual helpers over the pj endpoint fragment (uppercase bech32 params delimited by '+'/'-'): IsBip77 (version dispatch) and TryGetReceiverKey (the RK1… session dedup key). edit: The Payjoin NuGet package's PjParam exposes no accessor for the individual fragment params, so version dispatch and dedup keys are derived textually here; semantic parsing and validation stay in the package. An accessor is in flight (https://github.com/payjoin/rust-payjoin/pull/1771); Bip77UriParams goes away once it lands.

Pure parsing, no ffi dependency. Tests pin fragment preservation, pjos round-trip, version detection, receiver-key extraction, and the no-pj case.

Disclosure: co-authored by Claude Code assistance