### PR TITLE
Make `dotnet test` output more CI friendly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,8 @@
               --no-build \
               --configuration Release \
               --filter-namespace "*UnitTests*" \
+              --no-progress \
+              --no-ansi \
               --output Detailed
             runHook postCheck
           '';
@@ -77,6 +79,8 @@
             dotnet test --project WalletWasabi.IntegrationTests/WalletWasabi.IntegrationTests.csproj \
               --no-build \
               --configuration Release \
+              --no-progress \
+              --no-ansi \
               --output Detailed
             runHook postCheck
           '';
@@ -91,10 +95,14 @@
               --filter-namespace "*UnitTests*" \
               --no-build \
               --configuration Release \
+              --no-progress \
+              --no-ansi \
               --output Detailed
             dotnet test --project WalletWasabi.IntegrationTests/WalletWasabi.IntegrationTests.csproj \
               --no-build \
               --configuration Release \
+              --no-progress \
+              --no-ansi \
               --output Detailed
             runHook postCheck
           '';


### PR DESCRIPTION
Master

```
WalletWasabi> [✓621/x0/↓0] ...8G(1m 14s)
WalletWasabi> 
WalletWasabi> passed WalletWasabi.Tests.UnitTests.KeyManagementTests.CanCreateNew (1s 728ms)
WalletWasabi>   from WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
WalletWasabi> 
WalletWasabi> [✓622/x0/↓0] ...8G(1m 14s)
WalletWasabi> 
WalletWasabi> passed WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests.RegisterInputFailureTests.InputUnconfirmedAsync (21ms)
WalletWasabi>   from WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
WalletWasabi> 
WalletWasabi> [✓623/x0/↓0] ...8G(1m 14s)
WalletWasabi> 
WalletWasabi> passed WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests.RegisterInputFailureTests.AliceAlreadyRegisteredIntraRoundAsync (31ms)
WalletWasabi>   from WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
WalletWasabi> 
WalletWasabi> [✓624/x0/↓0] ...8G(1m 14s)
WalletWasabi> 
WalletWasabi> passed WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests.RegisterInputFailureTests.InputCantBeNotedAsync (19ms)
WalletWasabi>   from WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
WalletWasabi> 
WalletWasabi> [✓625/x0/↓0] ...8G(1m 14s)
WalletWasabi> 
WalletWasabi> passed WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests.RegisterInputFailureTests.InputBannedAsync (21ms)
WalletWasabi>   from WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
WalletWasabi> 
```

PR

```
WalletWasabi> passed WalletWasabi.Tests.UnitTests.UserInterfaceTest.PocketSelectionTests.NotEnoughSelectedAsync (1s 028ms)
WalletWasabi>   from /build/ly8g2brr324kvpzywalc25w705d6bvx4-source/WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
WalletWasabi> passed WalletWasabi.Tests.UnitTests.UserInterfaceTest.PocketSelectionTests.WhiteListHighlightsAllLabelsInOtherPocketsThatContainTargetLabelExceptThoseAvailableInOtherPocketsAsync (877ms)
WalletWasabi>   from /build/ly8g2brr324kvpzywalc25w705d6bvx4-source/WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
WalletWasabi> passed WalletWasabi.Tests.UnitTests.Transactions.PayjoinTests.DishonestPayjoinServerTest (1s 964ms)
WalletWasabi>   from /build/ly8g2brr324kvpzywalc25w705d6bvx4-source/WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
WalletWasabi> passed WalletWasabi.Tests.UnitTests.Transactions.TransactionFactoryTests.SelectSameScriptPubKeyCoins (1s 996ms)
WalletWasabi>   from /build/ly8g2brr324kvpzywalc25w705d6bvx4-source/WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
WalletWasabi> passed WalletWasabi.Tests.UnitTests.Transactions.TransactionFactoryTests.DoNotSignWatchOnly (43ms)
WalletWasabi>   from /build/ly8g2brr324kvpzywalc25w705d6bvx4-source/WalletWasabi.Tests/bin/Release/net10.0/WalletWasabi.Tests.dll (net10.0|x64)
```

There is no: `[✓623/x0/↓0] ...8G(1m 14s)`