### PR TITLE
Verify other participant's inputs

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -38,6 +38,7 @@ using WalletWasabi.Tor.Control;
 using WalletWasabi.Tor.StatusChecker;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.Banning;
+using WalletWasabi.WabiSabi.Client.CoinJoin.Client;
 using WalletWasabi.WabiSabi.Client.CoinJoin.Manager;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Models;
@@ -735,7 +736,7 @@ public class Global
 
 		Func<string, WabiSabiHttpApiClient> wabiSabiHttpClientFactory = (identity) => new WabiSabiHttpApiClient(identity, coordinatorHttpClientFactory);
 		var coinJoinConfiguration = new CoinJoinConfiguration(Config.CoordinatorIdentifier, Config.MaxCoinjoinMiningFeeRate, Config.AbsoluteMinInputCount, AllowSoloCoinjoining: false);
-		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager.GetWalletsAsync, new RoundStateProvider(roundUpdater), wabiSabiHttpClientFactory, coinJoinConfiguration, _coinPrison, EventBus), "CoinJoin Manager");
+		HostedServices.Register<CoinJoinManager>(() => new CoinJoinManager(WalletManager.GetWalletsAsync, new RoundStateProvider(roundUpdater), wabiSabiHttpClientFactory, coinJoinConfiguration, _coinPrison, CreateInputVerifier(), EventBus), "CoinJoin Manager");
 	}
 
 	private List<IBroadcaster> CreateBroadcasters(P2pNodeListProvider p2PNodeListProvider, MempoolService mempoolService)
@@ -758,6 +759,17 @@ public class Global
 		}
 
 		return result;
+	}
+
+	private InputVerifier CreateInputVerifier()
+	{
+		if (_bitcoinRpcClient is not null)
+		{
+			Logger.LogInfo("Using Bitcoin RPC for coinjoin input verification (10% sample).");
+			return InputVerifiers.CreateRpcVerifier(_bitcoinRpcClient);
+		}
+
+		return InputVerifiers.NoVerification();
 	}
 
 	public ImmutableArray<Node> GetNodes() => _p2pConnectionManager.Nodes;

--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -342,6 +342,7 @@ public static class WabiSabiFactory
 			roundStateProvider,
 			coinSelector,
 			new CoinJoinConfiguration("CoinJoinCoordinatorIdentifier", 150.0m, 1, AllowSoloCoinjoining: true),
+			InputVerifiers.NoVerification(),
 			new LiquidityClueProvider(),
 			TimeSpan.Zero);
 
@@ -396,6 +397,7 @@ public class TestableCoinJoinClient(
 	RoundStateProvider roundStatusProvider,
 	CoinJoinCoinSelector coinJoinCoinSelector,
 	CoinJoinConfiguration coinJoinConfiguration,
+	InputVerifier inputVerifier,
 	LiquidityClueProvider liquidityClueProvider,
 	TimeSpan doNotRegisterInLastMinuteTimeLimit = default)
 	: CoinJoinClient(arenaRequestHandlerFactory,
@@ -404,6 +406,7 @@ public class TestableCoinJoinClient(
 		roundStatusProvider,
 		coinJoinCoinSelector,
 		coinJoinConfiguration,
+		inputVerifier,
 		liquidityClueProvider,
 		doNotRegisterInLastMinuteTimeLimit)
 {

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -28,6 +28,7 @@ public class CoinJoinClient
 		RoundStateProvider roundStatusProvider,
 		CoinJoinCoinSelector coinJoinCoinSelector,
 		CoinJoinConfiguration coinJoinConfiguration,
+		InputVerifier verifyInputsExistance,
 		LiquidityClueProvider liquidityClueProvider,
 		TimeSpan doNotRegisterInLastMinuteTimeLimit = default)
 	{
@@ -37,6 +38,7 @@ public class CoinJoinClient
 		_roundStatusProvider = roundStatusProvider;
 		_liquidityClueProvider = liquidityClueProvider;
 		_coinJoinConfiguration = coinJoinConfiguration;
+		_verifyInputsExistance = verifyInputsExistance;
 		_coinJoinCoinSelector = coinJoinCoinSelector;
 		_secureRandom = SecureRandom.Instance;
 		_doNotRegisterInLastMinuteTimeLimit = doNotRegisterInLastMinuteTimeLimit;
@@ -53,6 +55,7 @@ public class CoinJoinClient
 	private readonly RoundStateProvider _roundStatusProvider;
 	private readonly LiquidityClueProvider _liquidityClueProvider;
 	private readonly CoinJoinConfiguration _coinJoinConfiguration;
+	private readonly InputVerifier _verifyInputsExistance;
 	private readonly CoinJoinCoinSelector _coinJoinCoinSelector;
 	private readonly TimeSpan _doNotRegisterInLastMinuteTimeLimit;
 	private readonly TimeSpan _maxWaitingTimeForRound = TimeSpan.FromMinutes(10);
@@ -718,6 +721,9 @@ public class CoinJoinClient
 		{
 			throw new CoinJoinClientException(CoinjoinError.CoordinatorLiedAboutInputs, "Coordinator lied about registered inputs. It probably tries to be malicious.");
 		}
+
+		// Verify other participants' inputs to detect a malicious coordinator.
+		await _verifyInputsExistance(theirCoins.ToArray(), cancellationToken).ConfigureAwait(false);
 
 		var outputTxOuts = _outputProvider.GetOutputs(roundId, roundParameters, registeredCoinEffectiveValues, theirCoinEffectiveValues, (int)availableVsizes.Sum()).ToArray();
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/InputVerifiers.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/InputVerifiers.cs
@@ -1,0 +1,65 @@
+using WalletWasabi.BitcoinRpc;
+using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
+
+namespace WalletWasabi.WabiSabi.Client.CoinJoin.Client;
+
+public delegate Task InputVerifier(Coin[] coins, CancellationToken cancellationToken);
+
+public static class InputVerifiers
+{
+	public static InputVerifier NoVerification()  =>
+		(_, _) => Task.CompletedTask;
+
+	public static InputVerifier CreateRpcVerifier(IRPCClient rpcClient, double samplePercentage = 0.10) =>
+		async (coins, cancellationToken) =>
+		{
+			if (coins.Length == 0)
+			{
+				return;
+			}
+
+			var sampleSize = Math.Max(1, (int)(coins.Length * samplePercentage));
+			var sample = coins
+				.OrderBy(_ => Random.Shared.Next())
+				.Take(sampleSize)
+				.ToList();
+
+			Logger.LogDebug($"Verifying {sample.Count} of {coins.Length} other participants' inputs via RPC.");
+
+			var batchedRpc = rpcClient.PrepareBatch();
+			var verifyTasks = sample.Select(coin => (
+				Coin: coin,
+				Task: batchedRpc.GetTxOutAsync(coin.Outpoint.Hash, (int)coin.Outpoint.N, includeMempool: true, cancellationToken)
+			)).ToList();
+
+			await batchedRpc.SendBatchAsync(cancellationToken).ConfigureAwait(false);
+
+			foreach (var (coinToVerify, getTxOutTask) in verifyTasks)
+			{
+				var getTxOutResponse = await getTxOutTask.ConfigureAwait(false);
+
+				if (getTxOutResponse is null)
+				{
+					throw new CoinJoinClientException(
+						CoinjoinError.CoordinatorLiedAboutInputs,
+						$"UTXO {coinToVerify.Outpoint} does not exist or is already spent. The coordinator may be malicious.");
+				}
+
+				if (getTxOutResponse.TxOut.ScriptPubKey != coinToVerify.TxOut.ScriptPubKey)
+				{
+					throw new CoinJoinClientException(
+						CoinjoinError.CoordinatorLiedAboutInputs,
+						$"ScriptPubKey mismatch for {coinToVerify.Outpoint}. Expected {coinToVerify.TxOut.ScriptPubKey}, got {getTxOutResponse.TxOut.ScriptPubKey}. The coordinator may be malicious.");
+				}
+
+				if (getTxOutResponse.TxOut.Value != coinToVerify.Amount)
+				{
+					throw new CoinJoinClientException(
+						CoinjoinError.CoordinatorLiedAboutInputs,
+						$"Amount mismatch for {coinToVerify.Outpoint}. Expected {coinToVerify.Amount}, got {getTxOutResponse.TxOut.Value}. The coordinator may be malicious.");
+				}
+			}
+
+			Logger.LogDebug($"Successfully verified {sample.Count} inputs via RPC.");
+		};
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -22,6 +22,7 @@ public class CoinJoinManager : BackgroundService
 		Func<string, IWabiSabiApiRequestHandler> arenaRequestHandlerFactory,
 		CoinJoinConfiguration coinJoinConfiguration,
 		CoinPrison coinPrison,
+		InputVerifier inputVerifier,
 		EventBus eventBus)
 	{
 		_state = new();
@@ -30,6 +31,7 @@ public class CoinJoinManager : BackgroundService
 		_roundStatusProvider = roundStatusProvider;
 		_coinJoinConfiguration = coinJoinConfiguration;
 		_coinPrison = coinPrison;
+		_inputVerifier = inputVerifier;
 		_serverTipHeightChangeSubscription = eventBus.Subscribe<NetworkTipHeightChanged>(h => _serverTipHeight = h.Height);
 		_mailboxProcessor = new MailboxProcessor<CoinJoinCommand>(nameof(CoinJoinManager), HandleCoinJoinCommandsAsync, cancellationToken: _stopCts.Token);
 	}
@@ -42,6 +44,7 @@ public class CoinJoinManager : BackgroundService
 	private Func<string, IWabiSabiApiRequestHandler> ArenaRequestHandlerFactory { get; }
 	private readonly RoundStateProvider _roundStatusProvider;
 	private readonly CoinPrison _coinPrison;
+	private readonly InputVerifier _inputVerifier;
 	private readonly CoinRefrigerator _coinRefrigerator = new();
 	private readonly CoinJoinConfiguration _coinJoinConfiguration;
 	private uint _serverTipHeight;
@@ -111,7 +114,7 @@ public class CoinJoinManager : BackgroundService
 
 	private async Task HandleCoinJoinCommandsAsync(Mailbox<CoinJoinCommand> mailbox, CancellationToken cancellationToken)
 	{
-		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(ArenaRequestHandlerFactory, _roundStatusProvider, _coinJoinConfiguration, cancellationToken);
+		var coinJoinTrackerFactory = new CoinJoinTrackerFactory(ArenaRequestHandlerFactory, _roundStatusProvider, _coinJoinConfiguration, _inputVerifier, cancellationToken);
 
 		// TODO: Use Workers.EventDriven once we get state ready for it.
 		while (!cancellationToken.IsCancellationRequested)

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
@@ -12,11 +12,13 @@ public class CoinJoinTrackerFactory
 		Func<string, IWabiSabiApiRequestHandler> arenaRequestHandlerFactory,
 		RoundStateProvider roundStatusProvider,
 		CoinJoinConfiguration coinJoinConfiguration,
+		InputVerifier inputVerifier,
 		CancellationToken cancellationToken)
 	{
 		ArenaRequestHandlerFactory = arenaRequestHandlerFactory;
 		_roundStatusProvider = roundStatusProvider;
 		_coinJoinConfiguration = coinJoinConfiguration;
+		_inputVerifier = inputVerifier;
 		_cancellationToken = cancellationToken;
 		_liquidityClueProvider = new LiquidityClueProvider();
 	}
@@ -24,6 +26,7 @@ public class CoinJoinTrackerFactory
 	private Func<string, IWabiSabiApiRequestHandler> ArenaRequestHandlerFactory { get; }
 	private readonly RoundStateProvider _roundStatusProvider;
 	private readonly CoinJoinConfiguration _coinJoinConfiguration;
+	private readonly InputVerifier _inputVerifier;
 	private readonly CancellationToken _cancellationToken;
 	private readonly LiquidityClueProvider _liquidityClueProvider;
 
@@ -47,6 +50,7 @@ public class CoinJoinTrackerFactory
 			_roundStatusProvider,
 			coinSelector,
 			_coinJoinConfiguration,
+			_inputVerifier,
 			_liquidityClueProvider,
 			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1));
 


### PR DESCRIPTION
Closes https://github.com/WalletWasabi/WalletWasabi/issues/5533

Validate that the other coinjoin participants' inputs really exist, their scriptPubKey and value are correct. This means that the coins are not fake coins created by the coordinator. Given that verifying all the inputs could be costly in terms of time, each client verifies a randomly selected subset (currently 10% of all registered inputs)