### PR TITLE
Fix potential crash when `WildEstimations` is empty

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -58,18 +58,19 @@ public static class TransactionFeeHelper
 		}
 
 		var feeRate = new FeeRate(entry.CpfpInfo.EffectiveFeePerVSize);
-		return feeEstimates.EstimateConfirmationTime(feeRate);;
+		_ = feeEstimates.TryEstimateConfirmationTime(feeRate, out estimate);
+		return estimate;
 	}
 
 	public static bool TryEstimateConfirmationTime(Wallet wallet, FeeRate feeRate, [NotNullWhen(true)] out TimeSpan? estimate)
 	{
-		estimate = null;
 		if (TryGetFeeEstimates(wallet, out var feeEstimates))
 		{
-			estimate = feeEstimates.EstimateConfirmationTime(feeRate);
+			return feeEstimates.TryEstimateConfirmationTime(feeRate, out estimate);
 		}
 
-		return estimate is not null;
+		estimate = null;
+		return false;
 	}
 
 	public static bool TryGetFeeEstimates(Wallet wallet, [NotNullWhen(true)] out FeeRateEstimations? estimates)

--- a/WalletWasabi.Tests/UnitTests/FeeRateEstimationsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/FeeRateEstimationsTests.cs
@@ -302,7 +302,7 @@ public class FeeRateEstimationsTests
 	/// the target 6 estimate higher.
 	/// </summary>
 	[Fact]
-	public async Task MempoolDataUsedForNonExactTargetMatches()
+	public async Task MempoolDataUsedForNonExactTargetMatchesAsync()
 	{
 		var mockRpc = new MockRpcClient();
 		mockRpc.Network = Network.Main;

--- a/WalletWasabi.Tests/UnitTests/FeeRateEstimationsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/FeeRateEstimationsTests.cs
@@ -246,19 +246,44 @@ public class FeeRateEstimationsTests
 		Assert.Equal(new FeeRate(5.5m), allFee.WildEstimations[5].feeRate); // 2h
 		Assert.Equal(new FeeRate(1m), allFee.WildEstimations[6].feeRate); // 3h
 
-		Assert.Equal(TimeSpan.FromMinutes(10), allFee.EstimateConfirmationTime(new FeeRate(200m)));
-		Assert.Equal(TimeSpan.FromMinutes(20), allFee.EstimateConfirmationTime(new FeeRate(102.1m)));
-		Assert.Equal(TimeSpan.FromMinutes(20), allFee.EstimateConfirmationTime(new FeeRate(102m)));
-		Assert.Equal(TimeSpan.FromMinutes(30), allFee.EstimateConfirmationTime(new FeeRate(101.9m)));
-		Assert.Equal(TimeSpan.FromMinutes(30), allFee.EstimateConfirmationTime(new FeeRate(50m)));
-		Assert.Equal(TimeSpan.FromMinutes(30), allFee.EstimateConfirmationTime(new FeeRate(20m)));
-		Assert.Equal(TimeSpan.FromMinutes(40), allFee.EstimateConfirmationTime(new FeeRate(19m)));
-		Assert.Equal(TimeSpan.FromMinutes(60), allFee.EstimateConfirmationTime(new FeeRate(11m)));
-		Assert.Equal(TimeSpan.FromMinutes(60), allFee.EstimateConfirmationTime(new FeeRate(10m)));
-		Assert.Equal(TimeSpan.FromHours(2), allFee.EstimateConfirmationTime(new FeeRate(9m)));
-		Assert.Equal(TimeSpan.FromHours(3), allFee.EstimateConfirmationTime(new FeeRate(3m)));
-		Assert.Equal(TimeSpan.FromHours(3), allFee.EstimateConfirmationTime(new FeeRate(1m)));
-		Assert.Equal(TimeSpan.FromHours(3), allFee.EstimateConfirmationTime(new FeeRate(0.1m)));
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(200m), out var confirmationTime));
+		Assert.Equal(TimeSpan.FromMinutes(10), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(102.1m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromMinutes(20), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(102m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromMinutes(20), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(101.9m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromMinutes(30), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(50m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromMinutes(30), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(20m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromMinutes(30), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(19m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromMinutes(40), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(11m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromMinutes(60), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(10m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromMinutes(60), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(9m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromHours(2), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(3m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromHours(3), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(1m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromHours(3), confirmationTime);
+
+		Assert.True(allFee.TryEstimateConfirmationTime(new FeeRate(0.1m), out confirmationTime));
+		Assert.Equal(TimeSpan.FromHours(3), confirmationTime);
 	}
 
 	private static MockRpcClient CreateAndConfigureRpcClient(bool isSynchronized = true, bool hasPeersInfo = false, double memPoolMinFee = 0.00001000)

--- a/WalletWasabi/FeeRateEstimation/FeeRateEstimations.cs
+++ b/WalletWasabi/FeeRateEstimation/FeeRateEstimations.cs
@@ -1,9 +1,5 @@
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using NBitcoin;
 using WalletWasabi.Blockchain.Transactions;
-using WalletWasabi.Helpers;
 
 namespace WalletWasabi.FeeRateEstimation;
 
@@ -40,14 +36,10 @@ public class FeeRateEstimations : IEquatable<FeeRateEstimations>
 		}
 	}
 
-	/// <summary>
-	/// Gets the fee estimations: int: fee target, int: satoshi/vByte
-	/// </summary>
+	/// <summary>Gets the fee estimations: int: fee target, int: satoshi/vByte</summary>
 	public Dictionary<int, FeeRate> Estimations { get; }
 
-	/// <summary>
-	/// Estimations where we try to fill out gaps for all valid time spans.
-	/// </summary>
+	/// <summary>Estimations where we try to fill out gaps for all valid time spans.</summary>
 	public IReadOnlyList<(TimeSpan timeSpan, FeeRate feeRate)> WildEstimations
 	{
 		get

--- a/WalletWasabi/FeeRateEstimation/FeeRateEstimations.cs
+++ b/WalletWasabi/FeeRateEstimation/FeeRateEstimations.cs
@@ -148,23 +148,31 @@ public class FeeRateEstimations : IEquatable<FeeRateEstimations>
 
 		var totalVsize = unconfirmedChain.Sum(x => x.Transaction.GetVirtualSize());
 
-		confirmationTime = EstimateConfirmationTime(new FeeRate(totalFee, totalVsize));
-		return true;
+		return TryEstimateConfirmationTime(new FeeRate(totalFee, totalVsize), out confirmationTime);
 	}
 
-	public TimeSpan EstimateConfirmationTime(FeeRate feeRate)
+	public bool TryEstimateConfirmationTime(FeeRate feeRate, [NotNullWhen(true)] out TimeSpan? confirmationTime)
 	{
 		var wildEstimations = WildEstimations.ToArray();
+		if (wildEstimations.Length == 0)
+		{
+			confirmationTime = null;
+			return false;
+		}
+
 		if (feeRate.SatoshiPerByte >= wildEstimations.First().feeRate.SatoshiPerByte * 1.5m)
 		{
-			return TimeSpan.FromMinutes(10);
+			confirmationTime = TimeSpan.FromMinutes(10);
+			return true;
 		}
 		else if (feeRate <= wildEstimations.Last().feeRate)
 		{
-			return wildEstimations.Last().timeSpan;
+			confirmationTime = wildEstimations.Last().timeSpan;
+			return true;
 		}
 
-		return WildEstimations.FirstOrDefault(x => x.feeRate <= feeRate).timeSpan;
+		confirmationTime = WildEstimations.FirstOrDefault(x => x.feeRate <= feeRate).timeSpan;
+		return true;
 	}
 
 	#region Equality


### PR DESCRIPTION
This PR fixes potential crash. 

I believe it can happen when Internet connection is down, or when data are not fully available before a transaction is to be created in UI.

It was suggested in #14717 that estimation confirmation times should be removed. It was not acked, so I created this bugfix PR.