### PR TITLE
FeeRateEstimationUpdater: Report `MiningFeeRatesChanged` only if the new estimations are non-empty

### DIFF
--- a/WalletWasabi/FeeRateEstimation/FeeRateEstimationUpdater.cs
+++ b/WalletWasabi/FeeRateEstimation/FeeRateEstimationUpdater.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
 using WalletWasabi.Services;
 
 namespace WalletWasabi.FeeRateEstimation;
@@ -14,10 +12,18 @@ public static class FeeRateEstimationUpdater
 	private static async Task<FeeRateEstimations> UpdateAsync(UpdateMessage _, FeeRateProvider feeRateProvider, FeeRateEstimations feeRateEstimations, EventBus eventBus, CancellationToken cancellationToken)
 	{
 		var newFeeRateEstimations = await feeRateProvider(cancellationToken).ConfigureAwait(false);
+
 		if (newFeeRateEstimations != feeRateEstimations)
 		{
-			feeRateEstimations = newFeeRateEstimations;
-			eventBus.Publish(new MiningFeeRatesChanged(newFeeRateEstimations));
+			if (newFeeRateEstimations != FeeRateEstimations.Empty)
+			{
+				feeRateEstimations = newFeeRateEstimations;
+				eventBus.Publish(new MiningFeeRatesChanged(newFeeRateEstimations));
+			}
+			else
+			{
+				Logger.LogWarning($"Fee rate provider '{feeRateProvider.GetType().Name}' returned empty fee rate estimations.");
+			}
 		}
 
 		return feeRateEstimations;

--- a/WalletWasabi/FeeRateEstimation/FeeRateEstimations.cs
+++ b/WalletWasabi/FeeRateEstimation/FeeRateEstimations.cs
@@ -1,16 +1,12 @@
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using NBitcoin;
 using WalletWasabi.Blockchain.Transactions;
-using WalletWasabi.Helpers;
 
 namespace WalletWasabi.FeeRateEstimation;
 
 public class FeeRateEstimations : IEquatable<FeeRateEstimations>
 {
 	private static readonly int[] AllConfirmationTargets = Constants.ConfirmationTargets.Prepend(1).ToArray();
-	public static readonly FeeRateEstimations Empty = new(new Dictionary<int, FeeRate>{ {0, FeeRate.Zero} });
+	public static readonly FeeRateEstimations Empty = new(new Dictionary<int, FeeRate> { { 0, FeeRate.Zero } });
 
 	/// <summary>All allowed target confirmation ranges, i.e. 0-2, 2-3, 3-6, 6-18, ..., 432-1008.</summary>
 	private static readonly IEnumerable<(int Start, int End)> TargetRanges = AllConfirmationTargets


### PR DESCRIPTION
This PR should help with issues such as #14597.