### PR TITLE
Keep the wallet height from underflowing and preceding the first filter

### DIFF
--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -2,6 +2,7 @@ using NBitcoin;
 using System.IO;
 using System.Linq;
 using WalletWasabi.Blockchain.Analysis.Clustering;
+using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Models;
 using WalletWasabi.Tests.Helpers;
@@ -154,6 +155,36 @@ public class KeyManagementTests
 		Assert.Equal(new Height.ChainHeight(499_899), sameManager.GetBestHeight());
 
 		DeleteFileAndDirectoryIfExists(filePath);
+	}
+
+	[Fact]
+	public void CanSerializeHeightBelowResyncMargin()
+	{
+		// The resync margin is subtracted when persisting the height. Networks whose first filter
+		// is the genesis block can legitimately sit below that margin, so the subtraction must not
+		// wrap around instead of being floored at zero.
+		var filePath = "wallet-serialization-below-resync-margin.json";
+		var manager = KeyManager.CreateNew(out _, "", Network.RegTest, filePath);
+		manager.SetBestHeight(0);
+		manager.ToFile();
+
+		var sameManager = KeyManager.FromFile(filePath);
+		Assert.Equal(new Height.ChainHeight(0), sameManager.GetBestHeight());
+
+		DeleteFileAndDirectoryIfExists(filePath);
+	}
+
+	[Fact]
+	public void BestHeightNeverPrecedesFirstFilter()
+	{
+		// Filters are only available from the first checkpoint onwards, and the wallet asks for the
+		// filter right after its best height, so a lower height makes that filter unfetchable.
+		var firstFilterHeight = FilterCheckpoints.GetWasabiGenesisFilter(Network.Main).Header.Height;
+		var manager = KeyManager.CreateNew(out _, "", Network.Main);
+
+		manager.SetBestHeight(0);
+
+		Assert.Equal(firstFilterHeight, manager.GetBestHeight());
 	}
 
 	[Fact]

--- a/WalletWasabi/Blockchain/Keys/BlockchainState.cs
+++ b/WalletWasabi/Blockchain/Keys/BlockchainState.cs
@@ -8,13 +8,24 @@ public class BlockchainState
 	public BlockchainState(Network? network = null, ChainHeight? height = null, ChainHeight? birthHeight = null)
 	{
 		Network = network ?? Network.Main;
-		Height = ChainHeight.Max(height ?? ChainHeight.Genesis, FilterCheckpoints.GetWasabiGenesisFilter(Network).Header.Height);
+		Height = height ?? ChainHeight.Genesis;
 		BirthHeight = birthHeight;
 	}
 
 	public Network Network { get; }
 
-	public ChainHeight Height { get; set; }
+	private ChainHeight _height = ChainHeight.Genesis;
+
+	/// <summary>Height of the last processed filter.</summary>
+	/// <remarks>
+	/// Never precedes the first filter we have, otherwise the wallet would ask for the filter right
+	/// after it and that filter cannot be fetched.
+	/// </remarks>
+	public ChainHeight Height
+	{
+		get => _height;
+		set => _height = ChainHeight.Max(value, FilterCheckpoints.GetWasabiGenesisFilter(Network).Header.Height);
+	}
 
 	public ChainHeight? BirthHeight { get; }
 }

--- a/WalletWasabi/Serialization/Client.cs
+++ b/WalletWasabi/Serialization/Client.cs
@@ -65,7 +65,7 @@ public static partial class Encode
 		String(s.ToWif());
 
 	public static JsonNode WalletHeight(ChainHeight height) =>
-		String(Math.Max(0, height.Height - Constants.ResyncHeightMargin).ToString());
+		String(Math.Max(0L, (long)height.Height - Constants.ResyncHeightMargin).ToString());
 
 	public static JsonNode BlockchainState(BlockchainState s) =>
 		Object(s.BirthHeight is not {} nonNullBirthHeight


### PR DESCRIPTION
Importing any wallet file through Add Wallet -> Import Wallet crashes the client:

```
UnreachableException: Block filter for height 1 was not found.
```

`ImportWalletHelper.ImportWalletAsync` ends with `km.SetBestHeight(0)`, and both import branches reach it. `BlockchainState` applies its "not before the first filter we have" floor only in the constructor, so that assignment slips underneath it. The wallet then starts, `WalletFilterProcessor` asks for `GetBestHeight() + 1`, and `BlockFilterIterator` throws because the first filter it has is 481824, not 1.

The same call also corrupts the file on the way out. `Encode.WalletHeight` does `Math.Max(0, height.Height - Constants.ResyncHeightMargin)`, and since `ChainHeight.Height` is a `uint` while `ResyncHeightMargin` is a `const int`, the implicit constant expression conversion binds the subtraction to `uint - uint`. It wraps rather than going negative, so the `Math.Max(0, ...)` floor never fires and a wallet at height 0 writes itself out as `4294967195`. Because the constructor floor only raises the height, reloading cannot recover it — the wallet just sits in the "wait for the index store to catch up" branch forever. Worth noting this half is independent of import: every network except mainnet starts its filters at the genesis block, so heights below the margin are reachable there normally.

I moved the floor from the `BlockchainState` constructor into the `Height` setter so the invariant holds for every assignment rather than only at construction, and forced the margin subtraction to 64-bit so the existing zero floor actually works. That leaves `SetBestHeight(0)` meaning what it seems to intend — rescan from the earliest height we can actually scan — so `ImportWalletHelper` needs no change. Clamping inside the setter does mean `Height` can now silently refuse a lower value; putting the guard in `SetBestHeight` or in `ImportWalletHelper` instead would be a smaller blast radius, and I'm happy to move it if you'd rather keep the setter dumb.

Two tests, both watched failing first: `CanSerializeHeightBelowResyncMargin` (got `4294967195`, wanted `0`) and `BestHeightNeverPrecedesFirstFilter` (got `0`, wanted `481824`). The unit suite is 977 -> 979 with no new failures; `ReleaseDownloaderTests.OfficiallySupportedOSesAsync` and the three `Hwi.DefaultResponseTests.CanEnumerateAsync` cases fail the same way on an unmodified tree here, both for local environment reasons.
