### PR TITLE
Mix to the anonymity score target before handing over to the destination wallet

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinjoinModel.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using ReactiveUI;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Fluent.Infrastructure;
+using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.CoinJoin.Manager;
 using WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
 using WalletWasabi.WabiSabi.Client.StatusChangedEvents;
@@ -88,7 +89,16 @@ public partial class WalletCoinjoinModel : ReactiveObject
 
 	public async Task StartAsync(bool stopWhenAllMixed, bool overridePlebStop)
 	{
-		Wallet outputWallet = _services.GetWallets().First(x => x.WalletId == _settings.OutputWalletId);
+		// Resolved here rather than at construction because wallets load in an arbitrary order.
+		// An unknown or unloaded destination falls back to mixing into self.
+		var wallets = _services.GetWallets().ToList();
+
+		var destinationName = HandoverPolicy.ResolveDestinationWalletName(
+			_wallet.KeyManager.WalletName,
+			_settings.OutputWalletName,
+			wallets.Select(x => x.KeyManager.WalletName).ToList());
+
+		Wallet outputWallet = wallets.FirstOrDefault(x => x.KeyManager.WalletName == destinationName) ?? _wallet;
 
 		_coinJoinManager.RequestCoinJoinStart(_wallet, outputWallet, stopWhenAllMixed, overridePlebStop);
 	}

--- a/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
@@ -1,11 +1,13 @@
 using NBitcoin;
 using ReactiveUI;
+using System.Linq;
 using System.Reactive.Linq;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Fluent.Helpers;
 using WalletWasabi.Fluent.Infrastructure;
 using WalletWasabi.Helpers;
 using WalletWasabi.Models;
+using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.Wallets;
 
 namespace WalletWasabi.Fluent.Models.Wallets;
@@ -25,6 +27,7 @@ public partial class WalletSettingsModel : ReactiveObject
 	[AutoNotify] private bool _nonPrivateCoinIsolation;
 	[AutoNotify] private bool _allowPaymentsRegardlessOfAnonScore;
 	[AutoNotify] private WalletId? _outputWalletId;
+	[AutoNotify] private string? _outputWalletName;
 	[AutoNotify] private ScriptType _defaultReceiveScriptType;
 	[AutoNotify] private PreferredScriptPubKeyType _changeScriptPubKeyType;
 	[AutoNotify] private SendWorkflow _defaultSendWorkflow;
@@ -45,9 +48,11 @@ public partial class WalletSettingsModel : ReactiveObject
 		_nonPrivateCoinIsolation = _keyManager.NonPrivateCoinIsolation;
 		_allowPaymentsRegardlessOfAnonScore = _keyManager.AllowPaymentsRegardlessOfAnonScore;
 
+		_outputWalletName = _keyManager.OutputWalletName;
+
 		if (!isNewWallet)
 		{
-			_outputWalletId = services.GetWalletByName(_keyManager.WalletName).WalletId;
+			_outputWalletId = ResolveOutputWalletId(services, _keyManager);
 		}
 
 		_defaultReceiveScriptType = ScriptType.FromEnum(_keyManager.DefaultReceiveScriptType);
@@ -70,7 +75,8 @@ public partial class WalletSettingsModel : ReactiveObject
 		this.WhenAnyValue(
 				x => x.DefaultSendWorkflow,
 				x => x.DefaultReceiveScriptType,
-				x => x.ChangeScriptPubKeyType)
+				x => x.ChangeScriptPubKeyType,
+				x => x.OutputWalletName)
 			.Do(_ => SetValues())
 			.Subscribe();
 	}
@@ -113,7 +119,27 @@ public partial class WalletSettingsModel : ReactiveObject
 		_keyManager.DefaultSendWorkflow = DefaultSendWorkflow;
 		_keyManager.DefaultReceiveScriptType = ScriptType.ToScriptPubKeyType(DefaultReceiveScriptType);
 		_keyManager.ChangeScriptPubKeyType = ChangeScriptPubKeyType;
+		_keyManager.OutputWalletName = OutputWalletName;
 		_isDirty = true;
+	}
+
+	/// <summary>
+	/// Resolves the persisted destination name to a loaded wallet, falling back to this wallet.
+	/// </summary>
+	/// <remarks>
+	/// Deliberately does not clear <see cref="OutputWalletName"/>, so a destination that is merely not
+	/// loaded yet is not forgotten on the next save.
+	/// </remarks>
+	private static WalletId? ResolveOutputWalletId(IServices services, KeyManager keyManager)
+	{
+		var wallets = services.GetWallets().ToList();
+
+		var destinationName = HandoverPolicy.ResolveDestinationWalletName(
+			keyManager.WalletName,
+			keyManager.OutputWalletName,
+			wallets.Select(x => x.KeyManager.WalletName).ToList());
+
+		return wallets.FirstOrDefault(x => x.KeyManager.WalletName == destinationName)?.WalletId;
 	}
 
 	public void RescanWallet(uint startingHeight = 0)

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletCoinJoinSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletCoinJoinSettingsViewModel.cs
@@ -51,7 +51,9 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 		_nonPrivateCoinIsolation = _wallet.Settings.NonPrivateCoinIsolation;
 		_allowPaymentsRegardlessOfAnonScore = _wallet.Settings.AllowPaymentsRegardlessOfAnonScore;
 
-		_selectedOutputWallet = UiContext.WalletRepository.Wallets.Items.First(x => x.Id == _wallet.Settings.OutputWalletId);
+		_selectedOutputWallet =
+			UiContext.WalletRepository.Wallets.Items.FirstOrDefault(x => x.Id == _wallet.Settings.OutputWalletId)
+			?? UiContext.WalletRepository.Wallets.Items.First(x => x.Id == _wallet.Id);
 
 		SetupCancel(enableCancel: false, enableCancelOnEscape: true, enableCancelOnPressed: true);
 
@@ -123,7 +125,12 @@ public partial class WalletCoinJoinSettingsViewModel : RoutableViewModel
 		this.WhenAnyValue(x => x.SelectedOutputWallet)
 			.Skip(1)
 			.ObserveOn(RxApp.TaskpoolScheduler)
-			.Subscribe(x => _wallet.Settings.OutputWalletId = x.Id);
+			.Subscribe(x =>
+			{
+				_wallet.Settings.OutputWalletId = x.Id;
+				_wallet.Settings.OutputWalletName = x.Name;
+				_wallet.Settings.Save();
+			});
 
 		walletModel.IsCoinjoinStarted
 			.Select(isRunning => !isRunning)

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
@@ -85,7 +85,7 @@
         <ToolTip.Tip>
           <TextBlock>
             - Only loaded wallets can be selected.<LineBreak />
-            - Coins from the coinjoin transaction will be received by this wallet. However, this setting resets after Wasabi restarts.<LineBreak />
+            - Coins are mixed until they reach this wallet's anonymity score target, and are only then handed over to the selected wallet.<LineBreak />
             - The selected wallet cannot be changed when a coinjoin is in progress.
           </TextBlock>
         </ToolTip.Tip>

--- a/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
+++ b/WalletWasabi.Tests/UnitTests/KeyManagementTests.cs
@@ -188,6 +188,34 @@ public class KeyManagementTests
 	}
 
 	[Fact]
+	public void CanSerializeOutputWalletName()
+	{
+		var filePath = "wallet-output-wallet-name.json";
+		var manager = KeyManager.CreateNew(out _, "", Network.Main, filePath);
+		manager.OutputWalletName = "Destination Wallet";
+		manager.ToFile();
+
+		var sameManager = KeyManager.FromFile(filePath);
+		Assert.Equal("Destination Wallet", sameManager.OutputWalletName);
+
+		DeleteFileAndDirectoryIfExists(filePath);
+	}
+
+	[Fact]
+	public void OutputWalletNameIsNullWhenAbsentFromFile()
+	{
+		// Wallet files written before this field existed must keep mixing into themselves.
+		var filePath = "wallet-no-output-wallet-name.json";
+		var manager = KeyManager.CreateNew(out _, "", Network.Main, filePath);
+		manager.ToFile();
+
+		var sameManager = KeyManager.FromFile(filePath);
+		Assert.Null(sameManager.OutputWalletName);
+
+		DeleteFileAndDirectoryIfExists(filePath);
+	}
+
+	[Fact]
 	public void CanGenerateKeys()
 	{
 		string password = "password";

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -18,6 +18,25 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
 public class CoinJoinCoinSelectionTests
 {
 	/// <summary>
+	/// The effective target is raised so that a fully private wallet still has selectable coins,
+	/// which is what lets a handover round register anything at all.
+	/// </summary>
+	[Fact]
+	public void EffectiveAnonScoreTargetIsRaisedWhenSpendingPrivateCoins()
+	{
+		Assert.Equal(int.MaxValue, CoinJoinCoinSelector.GetEffectiveAnonScoreTarget(10, spendPrivateCoins: true));
+	}
+
+	/// <summary>
+	/// Normal rounds keep the wallet's configured target so private coins stay filtered out.
+	/// </summary>
+	[Fact]
+	public void EffectiveAnonScoreTargetIsUnchangedOtherwise()
+	{
+		Assert.Equal(10, CoinJoinCoinSelector.GetEffectiveAnonScoreTarget(10, spendPrivateCoins: false));
+	}
+
+	/// <summary>
 	/// This test is to make sure no coins are selected when there are no coins.
 	/// </summary>
 	[Fact]

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/HandoverPolicyTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/HandoverPolicyTests.cs
@@ -1,0 +1,71 @@
+using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.Wallets;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
+
+/// <summary>
+/// Tests for <see cref="HandoverPolicy"/>.
+/// </summary>
+public class HandoverPolicyTests
+{
+	private static readonly WalletId Source = new(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+	private static readonly WalletId Destination = new(Guid.Parse("22222222-2222-2222-2222-222222222222"));
+
+	[Fact]
+	public void MixingIntoSelfIsNotMixingToOtherWallet()
+	{
+		Assert.False(HandoverPolicy.IsMixingToOtherWallet(Source, Source));
+	}
+
+	[Fact]
+	public void MixingIntoDifferentWalletIsMixingToOtherWallet()
+	{
+		Assert.True(HandoverPolicy.IsMixingToOtherWallet(Source, Destination));
+	}
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public void MixingIntoSelfNeverHandsOver(bool isSourceWalletPrivate)
+	{
+		Assert.False(HandoverPolicy.IsReadyForHandover(Source, Source, isSourceWalletPrivate));
+	}
+
+	[Fact]
+	public void DoesNotHandOverBeforeTheWalletIsPrivate()
+	{
+		Assert.False(HandoverPolicy.IsReadyForHandover(Source, Destination, isSourceWalletPrivate: false));
+	}
+
+	[Fact]
+	public void HandsOverOnceTheWalletIsPrivate()
+	{
+		Assert.True(HandoverPolicy.IsReadyForHandover(Source, Destination, isSourceWalletPrivate: true));
+	}
+
+	[Fact]
+	public void ResolvesAPersistedDestinationThatIsLoaded()
+	{
+		var resolved = HandoverPolicy.ResolveDestinationWalletName("Source", "Destination", ["Source", "Destination"]);
+
+		Assert.Equal("Destination", resolved);
+	}
+
+	[Fact]
+	public void FallsBackToSelfWhenNoDestinationIsPersisted()
+	{
+		var resolved = HandoverPolicy.ResolveDestinationWalletName("Source", null, ["Source", "Destination"]);
+
+		Assert.Equal("Source", resolved);
+	}
+
+	[Fact]
+	public void FallsBackToSelfWhenTheDestinationIsNotLoaded()
+	{
+		// Renamed, deleted, or simply not loaded yet - wallets load in an arbitrary order.
+		var resolved = HandoverPolicy.ResolveDestinationWalletName("Source", "Destination", ["Source"]);
+
+		Assert.Equal("Source", resolved);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -7,8 +7,10 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Crypto.Randomness;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
@@ -173,6 +175,92 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		var broadcastedTx = await transactionCompleted.Task; // wait for the transaction to be broadcasted.
 		Assert.NotNull(broadcastedTx);
 	}
+
+	/// <summary>
+	/// Once a wallet reaches its anonymity score target it hands its coins over to the destination
+	/// wallet. That round registers coins which are already private and pays every output to a
+	/// different wallet, so this asserts the whole handover is possible end to end.
+	/// </summary>
+	[Theory]
+	[InlineData(new long[] { 10_000_000, 20_000_000, 30_000_000, 40_000_000, 100_000_000 })]
+	public async Task HandoverCoinJoinTestAsync(long[] amounts)
+	{
+		const int PrivateAnonymitySet = 100;
+		int inputCount = amounts.Length;
+
+		var transactionCompleted = new TaskCompletionSource<Transaction>();
+
+		KeyManager sourceKeyManager = KeyManager.CreateNew(out _, password: "", Network.Main);
+		KeyManager destinationKeyManager = KeyManager.CreateNew(out _, password: "", Network.Main);
+
+		// Every coin is already private, which is what makes this a handover rather than a mixing round.
+		var coins = sourceKeyManager.GetKeys()
+			.Take(inputCount)
+			.Select((x, i) => BitcoinFactory.CreateSmartCoin(x, Money.Satoshis(amounts[i]), true, PrivateAnonymitySet))
+			.ToArray();
+
+		var httpClient = _apiApplicationFactory.WithWebHostBuilder(builder =>
+			builder.AddMockRpcClient(
+				coins,
+				rpc =>
+					rpc.OnSendRawTransactionAsync = (tx) =>
+					{
+						transactionCompleted.SetResult(tx);
+						return tx.GetHash();
+					})
+			.ConfigureServices(services =>
+			{
+				services.AddSingleton(s => new WabiSabiConfig
+				{
+					MaxInputCountByRound = inputCount - 1,
+					StandardInputRegistrationTimeout = TimeSpan.FromSeconds(20),
+					ConnectionConfirmationTimeout = TimeSpan.FromSeconds(20),
+					OutputRegistrationTimeout = TimeSpan.FromSeconds(20),
+					TransactionSigningTimeout = TimeSpan.FromSeconds(20),
+					MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
+				});
+			})).CreateClient();
+
+		var apiClient = _apiApplicationFactory.CreateWabiSabiHttpApiClient(httpClient);
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(200));
+		cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
+
+		using var roundStateUpdater = RoundStateUpdaterForTesting.Create(apiClient);
+		await using var ticker = new Timer(_ => roundStateUpdater.Update(), 0, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
+		var roundStateProvider = new RoundStateProvider(roundStateUpdater);
+
+		// Spends the source wallet's coins but pays the outputs to the destination wallet, which is
+		// what CoinJoinTrackerFactory wires up once the source wallet is private.
+		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(
+			_ => apiClient,
+			new KeyChain(sourceKeyManager, ""),
+			new OutputProvider(new InternalDestinationProvider(destinationKeyManager), RandomnessProviders.Insecure),
+			roundStateProvider,
+			redCoinIsolation: false);
+
+		var coinjoinResult = await coinJoinClient.StartCoinJoinAsync(() => coins, cts.Token);
+		Assert.True(coinjoinResult is SuccessfulCoinJoinResult);
+
+		var broadcastedTx = await transactionCompleted.Task;
+		Assert.NotNull(broadcastedTx);
+
+		var destinationScripts = ScriptsOf(destinationKeyManager);
+		var sourceScripts = ScriptsOf(sourceKeyManager);
+
+		Assert.NotEmpty(broadcastedTx.Outputs);
+		Assert.All(broadcastedTx.Outputs, output => Assert.Contains(output.ScriptPubKey, destinationScripts));
+		Assert.All(broadcastedTx.Outputs, output => Assert.DoesNotContain(output.ScriptPubKey, sourceScripts));
+	}
+
+	private static HashSet<Script> ScriptsOf(KeyManager keyManager) =>
+		keyManager.GetKeys()
+			.SelectMany(x => new[]
+			{
+				x.PubKey.GetScriptPubKey(ScriptPubKeyType.Segwit),
+				x.PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86)
+			})
+			.ToHashSet();
 
 	[Fact]
 	public async Task FailToRegisterOutputsCoinJoinTestAsync()

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -155,6 +155,12 @@ public class KeyManager
 
 	public string? Icon { get; private set; }
 
+	/// <summary>Name of the wallet that receives this wallet's coinjoin outputs, or <c>null</c> for itself.</summary>
+	/// <remarks>
+	/// Stored as a name rather than a <c>WalletId</c> because that id is regenerated on every load.
+	/// </remarks>
+	public string? OutputWalletName { get; set; }
+
 	public int AnonScoreTarget { get; set; } = PrivacyProfiles.DefaultProfile.AnonScoreTarget;
 
 	public bool NonPrivateCoinIsolation { get; set; } = PrivacyProfiles.DefaultProfile.NonPrivateCoinIsolation;
@@ -723,6 +729,7 @@ public class KeyManager
 			("AutoCoinJoin", Encode.Bool(keyManager.AutoCoinJoin)),
 			("PlebStopThreshold", Encode.MoneyBitcoins(keyManager.PlebStopThreshold)),
 			("Icon", Encode.Optional(keyManager.Icon, Encode.String)),
+			("OutputWalletName", Encode.Optional(keyManager.OutputWalletName, Encode.String)),
 			("AnonScoreTarget", Encode.Int(keyManager.AnonScoreTarget)),
 			("RedCoinIsolation", Encode.Bool(keyManager.NonPrivateCoinIsolation)),
 			("AllowPaymentsRegardlessOfAnonScore", Encode.Bool(keyManager.AllowPaymentsRegardlessOfAnonScore)),
@@ -762,6 +769,7 @@ public class KeyManager
 				AutoCoinJoin = get.Optional("AutoCoinJoin", Decode.Bool, false),
 				PlebStopThreshold = get.Optional("PlebStopThreshold", Decode.MoneyBitcoins) ?? DefaultPlebStopThreshold,
 				Icon = get.Optional("Icon", Decode.String),
+				OutputWalletName = get.Optional("OutputWalletName", Decode.String),
 				AnonScoreTarget = get.Optional("AnonScoreTarget", Decode.Int, 10),
 				NonPrivateCoinIsolation = get.Optional("RedCoinIsolation", Decode.Bool, false),
 				AllowPaymentsRegardlessOfAnonScore = get.Optional("AllowPaymentsRegardlessOfAnonScore", Decode.Bool, false),

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
@@ -31,7 +31,15 @@ public class CoinJoinCoinSelector
 	private RandomnessProvider Rnd => _generator.Rnd;
 	private readonly CoinJoinCoinSelectorRandomnessGenerator _generator;
 
-	public static CoinJoinCoinSelector FromWallet(Wallet wallet)
+	/// <summary>
+	/// A fully private wallet selects nothing, because <see cref="SelectCoinsForRound"/> bails out when
+	/// there are neither semi-private nor red coins. Raising the effective target to
+	/// <see cref="int.MaxValue"/> makes every coin count as non-private so the round can register them.
+	/// </summary>
+	internal static int GetEffectiveAnonScoreTarget(int walletAnonScoreTarget, bool spendPrivateCoins) =>
+		spendPrivateCoins ? int.MaxValue : walletAnonScoreTarget;
+
+	public static CoinJoinCoinSelector FromWallet(Wallet wallet, bool isReadyForHandover = false)
 	{
 		var payWithPrivateCoins = wallet.AllowPaymentsRegardlessOfAnonScore
 			&& wallet.IsWalletPrivate()
@@ -39,7 +47,7 @@ public class CoinJoinCoinSelector
 
 		return new(
 			wallet.ConsolidationMode,
-			payWithPrivateCoins ? int.MaxValue : wallet.AnonScoreTarget,
+			GetEffectiveAnonScoreTarget(wallet.AnonScoreTarget, payWithPrivateCoins || isReadyForHandover),
 			wallet.NonPrivateCoinIsolation ? Constants.SemiPrivateThreshold : 0);
 	}
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -197,8 +197,11 @@ public class CoinJoinManager : BackgroundService
 				throw new CoinJoinClientException(CoinjoinError.NotEnoughUnprivateBalance);
 			}
 
-			// If there are pending payments, ignore already achieved privacy.
-			if (!walletToStart.BatchedPayments.AreTherePendingPayments)
+			// If there are pending payments, ignore already achieved privacy. A wallet mixing into
+			// another wallet must likewise keep going once private, otherwise the coins it just
+			// finished mixing would never be handed over.
+			if (!walletToStart.BatchedPayments.AreTherePendingPayments
+				&& !HandoverPolicy.IsMixingToOtherWallet(walletToStart.WalletId, startCommand.OutputWallet.WalletId))
 			{
 				// If all coins are already private, then don't mix.
 				if (walletToStart.IsWalletPrivate())
@@ -587,7 +590,9 @@ public class CoinJoinManager : BackgroundService
 		{
 			NotifyWalletStoppedCoinJoin(wallet);
 		}
-		else if (wallet.IsWalletPrivate() && !(wallet.AllowPaymentsRegardlessOfAnonScore && wallet.BatchedPayments.AreTherePendingPayments))
+		else if (wallet.IsWalletPrivate()
+			&& !(wallet.AllowPaymentsRegardlessOfAnonScore && wallet.BatchedPayments.AreTherePendingPayments)
+			&& !HandoverPolicy.IsMixingToOtherWallet(wallet.WalletId, finishedCoinJoin.OutputWallet.WalletId))
 		{
 			// A fully private wallet is done mixing, unless it is allowed to fund a pending payment with private coins.
 			NotifyCoinJoinStartError(wallet, CoinjoinError.AllCoinsPrivate);

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -494,7 +494,9 @@ public class CoinJoinManager : BackgroundService
 	private async Task HandleCoinJoinFinalizationAsync(CoinJoinTracker finishedCoinJoin, CancellationToken cancellationToken)
 	{
 		var wallet = finishedCoinJoin.Wallet;
-		var destinationProvider = finishedCoinJoin.OutputWallet.OutputProvider.DestinationProvider;
+		// Marks the scripts this round actually paid to, which is the source wallet itself while it is
+		// still mixing towards its anonymity score target.
+		var destinationProvider = finishedCoinJoin.EffectiveOutputWallet.OutputProvider.DestinationProvider;
 		var batchedPayments = wallet.BatchedPayments;
 		CoinJoinClientException? cjClientException = null;
 		var forceStop = false;

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTracker.cs
@@ -16,6 +16,7 @@ public class CoinJoinTracker : IDisposable
 		bool stopWhenAllMixed,
 		bool overridePlebStop,
 		Wallet outputWallet,
+		Wallet effectiveOutputWallet,
 		CancellationToken cancellationToken)
 	{
 		Wallet = wallet;
@@ -25,6 +26,7 @@ public class CoinJoinTracker : IDisposable
 		StopWhenAllMixed = stopWhenAllMixed;
 		OverridePlebStop = overridePlebStop;
 		OutputWallet = outputWallet;
+		EffectiveOutputWallet = effectiveOutputWallet;
 		_cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 		CoinJoinTask = coinJoinClient.StartCoinJoinAsync(coinCandidatesFunc, _cancellationTokenSource.Token);
 	}
@@ -39,7 +41,19 @@ public class CoinJoinTracker : IDisposable
 	public Task<CoinJoinResult> CoinJoinTask { get; }
 	public bool StopWhenAllMixed { get; set; }
 	public bool OverridePlebStop { get; }
+	/// <summary>Wallet the user selected as the coinjoin destination.</summary>
+	/// <remarks>
+	/// This is the configured destination, not necessarily where this round's outputs went. Use it to
+	/// decide whether a handover is still outstanding.
+	/// </remarks>
 	public Wallet OutputWallet { get; }
+
+	/// <summary>Wallet that actually received this round's outputs.</summary>
+	/// <remarks>
+	/// Equal to <see cref="Wallet"/> while it is still mixing towards its anonymity score target, and
+	/// to <see cref="OutputWallet"/> once it starts handing over.
+	/// </remarks>
+	public Wallet EffectiveOutputWallet { get; }
 
 	public bool IsCompleted => CoinJoinTask.IsCompleted;
 	public bool InCriticalCoinJoinState { get; private set; }

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
@@ -63,6 +63,6 @@ public class CoinJoinTrackerFactory
 			_liquidityClueProvider,
 			doNotRegisterInLastMinuteTimeLimit: TimeSpan.FromMinutes(1));
 
-		return new CoinJoinTracker(wallet, coinJoinClient, coinCandidatesFunc, stopWhenAllMixed, overridePlebStop, outputWallet, _cancellationToken);
+		return new CoinJoinTracker(wallet, coinJoinClient, coinCandidatesFunc, stopWhenAllMixed, overridePlebStop, outputWallet, effectiveOutputWallet, _cancellationToken);
 	}
 }

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTrackerFactory.cs
@@ -39,14 +39,23 @@ public class CoinJoinTrackerFactory
 			throw new NotSupportedException("Wallet has no key chain.");
 		}
 
-		// The only use-case when we set consolidation mode to true, when we are mixing to another wallet.
-		wallet.ConsolidationMode = outputWallet.WalletId != wallet.WalletId;
+		// Outputs stay in the source wallet until it reaches its anonymity score target, and are only
+		// then handed over. Consolidating before that would link the wallet's own coins together,
+		// working against the anonymity the mixing phase exists to build.
+		var isReadyForHandover = HandoverPolicy.IsReadyForHandover(
+			wallet.WalletId,
+			outputWallet.WalletId,
+			wallet.IsWalletPrivate());
 
-		var coinSelector = CoinJoinCoinSelector.FromWallet(wallet);
+		var effectiveOutputWallet = isReadyForHandover ? outputWallet : wallet;
+
+		wallet.ConsolidationMode = isReadyForHandover;
+
+		var coinSelector = CoinJoinCoinSelector.FromWallet(wallet, isReadyForHandover);
 		var coinJoinClient = new CoinJoinClient(
 			ArenaRequestHandlerFactory,
 			wallet.KeyChain,
-			outputWallet.OutputProvider,
+			effectiveOutputWallet.OutputProvider,
 			_roundStatusProvider,
 			coinSelector,
 			_coinJoinConfiguration,

--- a/WalletWasabi/WabiSabi/Client/HandoverPolicy.cs
+++ b/WalletWasabi/WabiSabi/Client/HandoverPolicy.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+using WalletWasabi.Wallets;
+
+namespace WalletWasabi.WabiSabi.Client;
+
+/// <summary>
+/// Decides whether a coinjoin round's outputs stay in the source wallet or are handed over to the
+/// wallet the user selected as the coinjoin destination.
+/// </summary>
+/// <remarks>
+/// A wallet mixing into a different wallet keeps its outputs at home until it reaches its own
+/// anonymity score target, and only then starts delivering them. Handing over sooner means a coin
+/// leaves after a single round, far below the target, and the source wallet can no longer remix it
+/// because it no longer owns it.
+/// </remarks>
+public static class HandoverPolicy
+{
+	/// <summary>Whether the wallet is configured to coinjoin into a different wallet.</summary>
+	public static bool IsMixingToOtherWallet(WalletId source, WalletId destination) =>
+		source != destination;
+
+	/// <summary>Whether this round's outputs should be delivered to the destination wallet.</summary>
+	public static bool IsReadyForHandover(WalletId source, WalletId destination, bool isSourceWalletPrivate) =>
+		IsMixingToOtherWallet(source, destination) && isSourceWalletPrivate;
+
+	/// <summary>
+	/// Resolves the persisted destination name against the wallets currently loaded, falling back to
+	/// the source wallet itself.
+	/// </summary>
+	/// <remarks>
+	/// The destination may have been renamed, deleted, or simply not loaded yet, since wallets load in
+	/// an arbitrary order. Mixing into self is the safe fallback and matches what users already get
+	/// today, when the selection is lost on every restart.
+	/// </remarks>
+	public static string ResolveDestinationWalletName(
+		string sourceWalletName,
+		string? persistedDestinationName,
+		IReadOnlyCollection<string> loadedWalletNames) =>
+		persistedDestinationName is { } name && loadedWalletNames.Contains(name)
+			? name
+			: sourceWalletName;
+}


### PR DESCRIPTION
When a wallet is set to "Coinjoin to this wallet", every round's outputs go to the destination starting with the very first one. `CoinJoinTrackerFactory` passes `outputWallet.OutputProvider` to the client unconditionally and `OutputProvider` holds a single destination provider fixed at construction, so nothing in the output path is aware of anonymity scores. A coin therefore gets exactly one round of mixing and leaves, arriving at the destination far below the source wallet's target, and the source can no longer remix it because it no longer owns it.

Outputs now stay in the source wallet until it reaches its own `AnonScoreTarget`, and only then get delivered to the destination, continuing until the source drains. Since `StartCoinJoinAsync` participates in exactly one round and `CoinJoinManager` builds a fresh tracker for each, deciding this at tracker creation re-evaluates every round without any new state machine — the whole gate is a pure predicate in `HandoverPolicy`.

Most of the work turned out to be unblocking a private wallet rather than routing outputs. Three separate places refuse to coinjoin once every coin is private, and batched payments already threads through all of them, so this reuses that path. The one worth pointing at during review is `CoinJoinCoinSelector`: `SelectCoinsForRound` returns an empty list when there are neither semi-private nor red coins, which is exactly a fully private wallet, so the effective target is raised to `int.MaxValue` the same way `payWithPrivateCoins` already does. Without it the other changes are inert — rounds start and register nothing. Two existing tests pin both sides of that mechanism and are unchanged.

Two things ride along that are worth objecting to separately if you disagree. `ConsolidationMode` was true whenever the destination differed; it now follows the handover instead, because the wallet spends most of its rounds mixing into itself and consolidating there links its own coins together. And the destination is now persisted. It previously reset on every restart, not as an oversight but because `WalletId` is a `Guid.NewGuid()` minted in the `Wallet` constructor on each load, so there was nothing persistable to save — it's stored as a wallet name instead, resolved at use time since wallets load in an arbitrary order. That also replaces two `First()` lookups that would throw once a durable selection can name a renamed or unloaded wallet. The tooltip promising the setting resets is updated.

The honest cost: `StopWhenAllMixed` becomes inert while a handover is outstanding, since it only takes effect inside the `IsWalletPrivate()` branch this now bypasses. Someone with it enabled and a destination set will coinjoin until drained rather than stopping at the target. That follows from the design but it is the change most likely to surprise. There is no opt-in flag — this treats sending immediately as the defect. Happy to put any of these behind a setting, or split the consolidation and persistence changes into their own PRs, if you would rather take them separately.

Thirteen tests added, each watched failing first: the `HandoverPolicy` truth table and name resolution, the effective-target calculation, and `OutputWalletName` round-tripping including a file without the field decoding to null. Unit suite goes 977 to 990 with no new failures, both projects build clean under `TreatWarningsAsErrors`.

Two caveats I would rather state than have you find. First, the three edits in `CoinJoinTrackerFactory` and `CoinJoinManager` are the actual behaviour change and have no automated coverage — `Wallet` has a private constructor reachable only through a nine-service factory and no test in the repo builds one, so I kept the decisions in pure functions and left those three sites uncovered rather than assert against a mock. **They have not yet been exercised on RegTest**, so treat the end-to-end behaviour as unverified. Second, review of my own diff caught that `HandleCoinJoinFinalizationAsync` was marking output scripts through the configured destination rather than the wallet that received them; `TrySetScriptStates` filters by scripts the key manager owns, so it silently matched nothing and would have left the source wallet's locked keys unmarked. The tracker now carries both wallets. I audited the other fifteen `OutputWallet` uses and they all correctly want the configured destination.

Minor note: this touches `KeyManagementTests.cs` at the same place as #14902, so whichever lands second will need a trivial conflict resolution.
