### PR TITLE
Track signed payments in coinjoin (#14917)

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/PaymentBatchTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/PaymentBatchTests.cs
@@ -1,0 +1,281 @@
+using System.Linq;
+using NBitcoin;
+using WalletWasabi.Blockchain.Transactions;
+using WalletWasabi.Helpers;
+using WalletWasabi.Models;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Client.Batching;
+using WalletWasabi.WabiSabi.Coordinator;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
+
+/// <summary>
+/// Tests for PaymentBatch focusing on preventing double payments
+/// when coinjoin rounds end with unknown status.
+/// </summary>
+public class PaymentBatchTests
+{
+	/// <summary>
+	/// Verifies that when a payment is moved to uncertain state (due to unknown round ending),
+	/// it is NOT included in subsequent payment selections, preventing double payments.
+	/// </summary>
+	[Fact]
+	public void UncertainPaymentsAreNotSelectedForNewCoinjoins()
+	{
+		var paymentBatch = new PaymentBatch();
+		var roundParameters = WabiSabiFactory.CreateRoundParameters(new WabiSabiConfig());
+		var destination = GetNewSegwitAddress();
+		var amount = Money.Coins(0.1m);
+
+		// Add a payment
+		paymentBatch.AddPayment(destination, amount);
+		Assert.True(paymentBatch.AreTherePendingPayments);
+
+		// Move to in-progress (simulating coinjoin round starting)
+		var roundId = uint256.One;
+		var payments = paymentBatch.GetPayments().ToArray();
+		paymentBatch.MovePaymentsToInProgress(payments, roundId);
+
+		// Move to uncertain (simulating unknown round ending - the critical path for double payments)
+		var signedTxId = CreateTransactionWithOutput(destination.ScriptPubKey, amount).GetHash();
+		paymentBatch.MovePaymentsToSigned(signedTxId);
+
+		// Verify the payment is NOT pending anymore
+		Assert.False(paymentBatch.AreTherePendingPayments);
+		Assert.True(paymentBatch.AreThereUncertainPayments);
+
+		// Verify GetBestPaymentSet returns empty - this is the key assertion!
+		// If this returned the payment, it would be included in another coinjoin = double payment
+		var availableMoney = Money.Coins(1m);
+		var availableVsize = 1000;
+		var bestPaymentSet = paymentBatch.GetBestPaymentSet(availableMoney, availableVsize, roundParameters);
+
+		Assert.Equal(0, bestPaymentSet.PaymentCount);
+	}
+
+	/// <summary>
+	/// Verifies that uncertain payments are resolved when a matching transaction is found.
+	/// </summary>
+	[Fact]
+	public void UncertainPaymentsAreResolvedWhenMatchingTransactionArrives()
+	{
+		var paymentBatch = new PaymentBatch();
+		var destination = GetNewSegwitAddress();
+		var amount = Money.Coins(0.1m);
+
+		// Create the signed transaction first (so we know the txId)
+		var tx = CreateTransactionWithOutput(destination.ScriptPubKey, amount);
+		var signedTxId = tx.GetHash();
+
+		// Add payment and move to uncertain state with the known txId
+		paymentBatch.AddPayment(destination, amount);
+		var payments = paymentBatch.GetPayments().ToArray();
+		paymentBatch.MovePaymentsToInProgress(payments, uint256.One);
+		paymentBatch.MovePaymentsToSigned(signedTxId);
+
+		Assert.True(paymentBatch.AreThereUncertainPayments);
+
+		// Create a SmartTransaction from the same tx (matching txId)
+		var smartTx = new SmartTransaction(tx, Height.Mempool);
+
+		// Try to resolve - should succeed because txId matches
+		var resolved = paymentBatch.TryResolvePaymentsWithTransaction(smartTx);
+
+		Assert.True(resolved);
+		Assert.False(paymentBatch.AreThereUncertainPayments);
+
+		// Verify payment is now finished (not pending, not uncertain)
+		var finishedPayments = paymentBatch.GetPayments().Where(p => p.State is FinishedPayment);
+		Assert.Single(finishedPayments);
+	}
+
+	/// <summary>
+	/// Verifies that uncertain payments are NOT resolved when transaction txId doesn't match.
+	/// </summary>
+	[Fact]
+	public void UncertainPaymentsNotResolvedWhenTransactionIdDoesNotMatch()
+	{
+		var paymentBatch = new PaymentBatch();
+		var destination = GetNewSegwitAddress();
+		var amount = Money.Coins(0.1m);
+
+		// Create the signed transaction and store its txId
+		var signedTx = CreateTransactionWithOutput(destination.ScriptPubKey, amount);
+		var signedTxId = signedTx.GetHash();
+
+		// Add payment and move to uncertain state
+		paymentBatch.AddPayment(destination, amount);
+		var payments = paymentBatch.GetPayments().ToArray();
+		paymentBatch.MovePaymentsToInProgress(payments, uint256.One);
+		paymentBatch.MovePaymentsToSigned(signedTxId);
+
+		// Create a DIFFERENT transaction (different txId)
+		var differentTx = CreateTransactionWithOutput(destination.ScriptPubKey, Money.Coins(0.2m));
+		var smartTx = new SmartTransaction(differentTx, Height.Mempool);
+
+		// Try to resolve - should NOT succeed because txId doesn't match
+		var resolved = paymentBatch.TryResolvePaymentsWithTransaction(smartTx);
+
+		Assert.False(resolved);
+		Assert.True(paymentBatch.AreThereUncertainPayments);
+	}
+
+	/// <summary>
+	/// Verifies that uncertain payments timeout and move back to pending after the timeout period.
+	/// </summary>
+	[Fact]
+	public void UncertainPaymentsTimeoutAfterWaiting()
+	{
+		var paymentBatch = new PaymentBatch();
+		var destination = GetNewSegwitAddress();
+		var amount = Money.Coins(0.1m);
+
+		// Add payment and move to uncertain state
+		paymentBatch.AddPayment(destination, amount);
+		var payments = paymentBatch.GetPayments().ToArray();
+		paymentBatch.MovePaymentsToInProgress(payments, uint256.One);
+		var signedTxId = CreateTransactionWithOutput(destination.ScriptPubKey, amount).GetHash();
+		paymentBatch.MovePaymentsToSigned(signedTxId);
+
+		Assert.True(paymentBatch.AreThereUncertainPayments);
+		Assert.False(paymentBatch.AreTherePendingPayments);
+
+		// Timeout should not move payments back immediately (timeout is 3 minutes)
+		paymentBatch.TimeoutUncertainPayments();
+		Assert.True(paymentBatch.AreThereUncertainPayments);
+
+		// Note: To fully test the timeout, we would need to mock DateTimeOffset.UtcNow
+		// or wait 3 minutes. For now, we verify the method doesn't crash and
+		// doesn't immediately move payments back.
+	}
+
+	/// <summary>
+	/// Verifies that all payments from the same coinjoin are resolved together
+	/// when the matching transaction is found.
+	/// </summary>
+	[Fact]
+	public void AllPaymentsFromSameCoinjoinResolvedTogether()
+	{
+		var paymentBatch = new PaymentBatch();
+		var destination1 = GetNewSegwitAddress();
+		var destination2 = GetNewSegwitAddress();
+		var amount1 = Money.Coins(0.1m);
+		var amount2 = Money.Coins(0.2m);
+
+		// Create the signed coinjoin transaction with both outputs
+		var tx = Transaction.Create(Network.Main);
+		tx.Outputs.Add(new TxOut(amount1, destination1.ScriptPubKey));
+		tx.Outputs.Add(new TxOut(amount2, destination2.ScriptPubKey));
+		var signedTxId = tx.GetHash();
+
+		// Add two payments and move both to uncertain state with same txId
+		paymentBatch.AddPayment(destination1, amount1);
+		paymentBatch.AddPayment(destination2, amount2);
+		var payments = paymentBatch.GetPayments().ToArray();
+		paymentBatch.MovePaymentsToInProgress(payments, uint256.One);
+		paymentBatch.MovePaymentsToSigned(signedTxId);
+
+		Assert.Equal(2, paymentBatch.GetPayments().Count(p => p.State is SignedUnknownPayment));
+
+		// When the transaction arrives, BOTH payments should be resolved
+		var smartTx = new SmartTransaction(tx, Height.Mempool);
+		var resolved = paymentBatch.TryResolvePaymentsWithTransaction(smartTx);
+
+		Assert.True(resolved);
+		// Both should be resolved
+		Assert.Equal(2, paymentBatch.GetPayments().Count(p => p.State is FinishedPayment));
+		Assert.Equal(0, paymentBatch.GetPayments().Count(p => p.State is SignedUnknownPayment));
+	}
+
+	/// <summary>
+	/// Verifies that pending payments are still available while uncertain payments exist.
+	/// This ensures the uncertain state doesn't block other payments.
+	/// </summary>
+	[Fact]
+	public void PendingPaymentsStillAvailableWhileUncertainPaymentsExist()
+	{
+		var paymentBatch = new PaymentBatch();
+		var roundParameters = WabiSabiFactory.CreateRoundParameters(new WabiSabiConfig());
+		var uncertainDestination = GetNewSegwitAddress();
+		var pendingDestination = GetNewSegwitAddress();
+		var amount = Money.Coins(0.1m);
+
+		// Add first payment and move to uncertain
+		paymentBatch.AddPayment(uncertainDestination, amount);
+		var firstPayment = paymentBatch.GetPayments().ToArray();
+		paymentBatch.MovePaymentsToInProgress(firstPayment, uint256.One);
+		var signedTxId = CreateTransactionWithOutput(uncertainDestination.ScriptPubKey, amount).GetHash();
+		paymentBatch.MovePaymentsToSigned(signedTxId);
+
+		// Add a new pending payment
+		paymentBatch.AddPayment(pendingDestination, amount);
+
+		Assert.True(paymentBatch.AreTherePendingPayments);
+		Assert.True(paymentBatch.AreThereUncertainPayments);
+
+		// GetBestPaymentSet should return the pending payment, not the uncertain one
+		var availableMoney = Money.Coins(1m);
+		var availableVsize = 1000;
+		var bestPaymentSet = paymentBatch.GetBestPaymentSet(availableMoney, availableVsize, roundParameters);
+
+		Assert.Equal(1, bestPaymentSet.PaymentCount);
+		Assert.Equal(pendingDestination.ScriptPubKey, bestPaymentSet.Payments.Single().Destination.ScriptPubKey);
+	}
+
+	/// <summary>
+	/// Simulates the exact scenario that caused the double payment bug:
+	/// 1. Payment queued
+	/// 2. First coinjoin starts, payment moves to in-progress
+	/// 3. Round ending is unknown, payment should move to uncertain (not pending!)
+	/// 4. Second coinjoin should NOT include the uncertain payment
+	/// </summary>
+	[Fact]
+	public void DoublePaymentPreventionScenario()
+	{
+		var paymentBatch = new PaymentBatch();
+		var roundParameters = WabiSabiFactory.CreateRoundParameters(new WabiSabiConfig());
+		var destination = GetNewSegwitAddress();
+		var amount = Money.Coins(0.006m); // The exact amount from the bug report
+
+		// Step 1: Queue the payment
+		paymentBatch.AddPayment(destination, amount);
+		Assert.True(paymentBatch.AreTherePendingPayments);
+
+		// Step 2: First coinjoin starts
+		var firstRoundId = uint256.One;
+		var paymentsForFirstRound = paymentBatch.GetPayments().ToArray();
+		paymentBatch.MovePaymentsToInProgress(paymentsForFirstRound, firstRoundId);
+		Assert.False(paymentBatch.AreTherePendingPayments);
+
+		// Step 3: Transaction signed - payments move to signed state immediately
+		// This happens via TransactionSigned event right after signing
+		var signedTxId = CreateTransactionWithOutput(destination.ScriptPubKey, amount).GetHash();
+		paymentBatch.MovePaymentsToSigned(signedTxId);
+
+		// Step 4: Round ending is UNKNOWN - payments stay in signed state
+		// They are NOT moved back to pending to avoid double payments
+		Assert.False(paymentBatch.AreTherePendingPayments, "Payment should NOT be pending after signing");
+		Assert.True(paymentBatch.AreThereUncertainPayments, "Payment should be in signed state awaiting resolution");
+
+		// This is the key check - GetBestPaymentSet should return empty
+		var secondRoundPaymentSet = paymentBatch.GetBestPaymentSet(Money.Coins(1m), 1000, roundParameters);
+		Assert.Equal(0, secondRoundPaymentSet.PaymentCount);
+
+		// The double payment bug would have failed here because the payment
+		// would have been included in the second coinjoin
+	}
+
+	private static BitcoinAddress GetNewSegwitAddress()
+	{
+		using Key key = new();
+		return key.PubKey.GetAddress(ScriptPubKeyType.Segwit, Network.Main);
+	}
+
+	private static Transaction CreateTransactionWithOutput(Script scriptPubKey, Money amount)
+	{
+		var tx = Transaction.Create(Network.Main);
+		tx.Outputs.Add(new TxOut(amount, scriptPubKey));
+		return tx;
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/Batching/Payment.cs
+++ b/WalletWasabi/WabiSabi/Client/Batching/Payment.cs
@@ -14,6 +14,7 @@ public abstract record PaymentState
 
 public record PendingPayment(PaymentState? PreviousState) : PaymentState(PreviousState);
 public record InProgressPayment(PaymentState PreviousState, uint256 RoundId) : PaymentState(PreviousState);
+public record SignedUnknownPayment(PaymentState PreviousState, DateTimeOffset Timestamp, uint256 TransactionId) : PaymentState(PreviousState);
 public record FinishedPayment(PaymentState PreviousState, uint256 TransactionId) : PaymentState(PreviousState);
 
 public record Payment(IDestination Destination, Money Amount)

--- a/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
+++ b/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
@@ -1,7 +1,5 @@
 using System.Collections.ObjectModel;
-using WalletWasabi.Helpers;
-using WalletWasabi.Logging;
-using WalletWasabi.WabiSabi.Coordinator.Rounds;
+using WalletWasabi.Blockchain.Transactions;
 
 namespace WalletWasabi.WabiSabi.Client.Batching;
 
@@ -16,10 +14,15 @@ namespace WalletWasabi.WabiSabi.Client.Batching;
 // payments are moved to finished or back to pending state.
 public class PaymentBatch
 {
+	/// Time to wait before considering an uncertain payment as failed.
+	/// This should be longer than CoinRefrigerator's freeze time
+	private static readonly TimeSpan UncertainPaymentTimeout = TimeSpan.FromMinutes(3);
+
 	private readonly List<Payment> _payments = new();
 	private readonly Lock _syncObj = new();
 	private IEnumerable<Payment> PendingPayments => GetPayments().Where(p => p.State is PendingPayment);
 	private IEnumerable<Payment> InProgressPayments => GetPayments().Where(p => p.State is InProgressPayment);
+	private IEnumerable<Payment> SignedPayments => GetPayments().Where(p => p.State is SignedUnknownPayment);
 
 	public Guid AddPayment(IDestination destination, Money amount)
 	{
@@ -93,10 +96,76 @@ public class PaymentBatch
 	public void MovePaymentsToFinished(uint256 txId) =>
 		MovePaymentsTo(InProgressPayments, payment => payment with { State = new FinishedPayment(payment.State, txId) });
 
-	public void MovePaymentsToPending() =>
+	public void MovePaymentsToPending()
+	{
+		// Move both in-progress and signed payments back to pending.
+		// This handles both: round failure before signing, and round failure after signing.
 		MovePaymentsTo(InProgressPayments, payment => payment with { State = new PendingPayment(payment.State) });
+		MovePaymentsTo(SignedPayments, payment => payment with { State = new PendingPayment(payment.State) });
+	}
+
+	public void MovePaymentsToSigned(uint256 transactionId) =>
+		MovePaymentsTo(InProgressPayments, payment => payment with
+		{
+			State = new SignedUnknownPayment(payment.State, DateTimeOffset.UtcNow, transactionId)
+		});
+
+	public bool TryResolvePaymentsWithTransaction(SmartTransaction transaction)
+	{
+		var uncertainPayments = SignedPayments.ToArray();
+		if (uncertainPayments.Length == 0)
+		{
+			return false;
+		}
+
+		var resolved = false;
+		var txId = transaction.GetHash();
+
+		foreach (var payment in uncertainPayments.Where(p => p.State is SignedUnknownPayment s && s.TransactionId == txId))
+		{
+			Logger.LogInfo($"Payment {payment.Id} resolved as successful - transaction {txId} confirmed.");
+			lock (_syncObj)
+			{
+				_payments.Remove(payment);
+				_payments.Add(payment with { State = new FinishedPayment(payment.State, txId) });
+			}
+			resolved = true;
+		}
+
+		return resolved;
+	}
+
+	/// <summary>
+	/// Moves uncertain payments back to pending state if they have timed out.
+	/// This should be called periodically to handle cases where the coinjoin failed
+	/// but no matching transaction was ever found.
+	/// </summary>
+	public void TimeoutUncertainPayments()
+	{
+		var uncertainPayments = SignedPayments.ToArray();
+		foreach (var payment in uncertainPayments)
+		{
+			if (payment.State is not SignedUnknownPayment uncertainState)
+			{
+				continue;
+			}
+
+			var elapsed = DateTimeOffset.UtcNow - uncertainState.Timestamp;
+			if (elapsed >= UncertainPaymentTimeout)
+			{
+				Logger.LogInfo($"Payment {payment.Id} timed out after {elapsed.TotalSeconds:F0}s - no matching transaction found, moving back to pending.");
+				lock (_syncObj)
+				{
+					_payments.Remove(payment);
+					_payments.Add(payment with { State = new PendingPayment(uncertainState) });
+				}
+			}
+		}
+	}
 
 	public bool AreTherePendingPayments => PendingPayments.Any();
+
+	public bool AreThereUncertainPayments => SignedPayments.Any();
 
 	private void MovePaymentsTo<TOldState, TNewState>(
 		IEnumerable<TOldState> payments,

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -349,6 +349,10 @@ public class CoinJoinClient
 			var outputTxOuts = await ProceedWithOutputRegistrationPhaseAsync(roundId, registeredAliceClients, cancellationToken).ConfigureAwait(false);
 
 			var (unsignedCoinJoin, aliceClientsThatSigned) = await ProceedWithSigningStateAsync(roundId, registeredAliceClients, outputTxOuts, cancellationToken).ConfigureAwait(false);
+
+			// Notify that we've signed the transaction - payments should now be tracked with the txId
+			CoinJoinClientProgress.SafeInvoke(this, new TransactionSigned(unsignedCoinJoin.GetHash()));
+
 			LogCoinJoinSummary(registeredAliceClients, outputTxOuts, roundState);
 
 			_liquidityClueProvider.UpdateLiquidityClue(roundState.CoinjoinState.Parameters.MaxSuggestedAmount, unsignedCoinJoin, outputTxOuts);

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinProgressEvents/TransactionSigned.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinProgressEvents/TransactionSigned.cs
@@ -1,0 +1,6 @@
+namespace WalletWasabi.WabiSabi.Client.CoinJoinProgressEvents;
+
+public class TransactionSigned(uint256 transactionId) : CoinJoinProgressEventArgs
+{
+	public uint256 TransactionId { get; } = transactionId;
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -436,6 +436,13 @@ public class CoinJoinManager : BackgroundService
 			// Updates coinjoin client states.
 			var wallets = await _getWalletsAsync().ConfigureAwait(false);
 
+			// Timeout any uncertain payments that have been waiting too long.
+			// This moves payments back to pending if no matching transaction was found.
+			foreach (var wallet in wallets)
+			{
+				wallet.BatchedPayments.TimeoutUncertainPayments();
+			}
+
 			_state.CoinJoinClientStates = GetCoinJoinClientStates(wallets);
 			_state.CoinsInCriticalPhase = GetCoinsInCriticalPhase(wallets);
 
@@ -495,6 +502,7 @@ public class CoinJoinManager : BackgroundService
 		var batchedPayments = wallet.BatchedPayments;
 		CoinJoinClientException? cjClientException = null;
 		var forceStop = false;
+		var unknownEnding = false;
 		try
 		{
 			var result = await finishedCoinJoin.CoinJoinTask.ConfigureAwait(false);
@@ -512,10 +520,13 @@ public class CoinJoinManager : BackgroundService
 		}
 		catch (UnknownRoundEndingException ex)
 		{
-			// Assuming that the round might be broadcast but our client was not able to get the ending status.
+			// The round ending is unknown - the transaction might have been broadcast.
+			// Payments are already in signed state (moved by TransactionSigned event).
+			// The reconciliation process will later check if the transaction was confirmed.
+			unknownEnding = true;
 			_coinRefrigerator.Freeze(ex.Coins);
 			MarkDestinationsUsed(destinationProvider, ex.OutputScripts);
-			Logger.LogDebug(FormatLog(ex.ToString(), wallet));
+			Logger.LogWarning(FormatLog($"Round ending unknown - payments in signed state awaiting resolution: {ex.Message}", wallet));
 		}
 		catch (CoinJoinClientException clientException)
 		{
@@ -564,7 +575,11 @@ public class CoinJoinManager : BackgroundService
 		}
 		finally
 		{
-			batchedPayments.MovePaymentsToPending();
+			// Only move payments to pending if we know the round failed.
+			if (!unknownEnding)
+			{
+				batchedPayments.MovePaymentsToPending();
+			}
 		}
 
 		// If any coins were marked for banning, store them to file

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTracker.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinTracker.cs
@@ -67,8 +67,21 @@ public class CoinJoinTracker : IDisposable
 				InCriticalCoinJoinState = false;
 				break;
 
+			case TransactionSigned transactionSigned:
+				// We've signed the transaction - move payments to signed state with the txId.
+				// This captures the txId immediately so we can reconcile later if the round
+				// outcome is unknown.
+				Wallet.BatchedPayments.MovePaymentsToSigned(transactionSigned.TransactionId);
+				break;
+
 			case RoundEnded roundEnded:
-				if (roundEnded.LastRoundState.EndRoundState != EndRoundState.TransactionBroadcasted)
+				var endState = roundEnded.LastRoundState.EndRoundState;
+				// Only reset payments if we KNOW the round failed.
+				// When EndRoundState is None (unknown), the transaction might have been
+				// broadcast, so we must NOT move payments back to pending to avoid double payments.
+				// Payments in Signed state will be resolved by reconciliation or timeout.
+				if (endState != EndRoundState.TransactionBroadcasted &&
+					endState != EndRoundState.None)
 				{
 					Wallet.BatchedPayments.MovePaymentsToPending();
 				}

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -319,6 +319,13 @@ public class Wallet : BackgroundService
 			{
 				CpfpInfoProvider.ScheduleRequest(e.Transaction);
 			}
+
+			// Check if this transaction resolves any uncertain payments in coinjoins
+			// If the transaction has outputs matching our pending payments, mark them as finished.
+			if (BatchedPayments.AreThereUncertainPayments && BatchedPayments.TryResolvePaymentsWithTransaction(e.Transaction))
+			{
+				_eventBus.Publish(new PaymentBatchChanged(BatchedPayments.GetPayments()));
+			}
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
Make sure to track payments that are in an unknown state to prevent paying twice by error.