### PR TITLE
SleepInhibitor: Fix sleep inhibition behavior for macOS

### DIFF
--- a/WalletWasabi/Helpers/PowerSaving/BaseInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/BaseInhibitorTask.cs
@@ -1,8 +1,5 @@
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using WalletWasabi.BundledApps;
-using WalletWasabi.Logging;
 
 namespace WalletWasabi.Helpers.PowerSaving;
 
@@ -67,10 +64,10 @@ public class BaseInhibitorTask : IPowerSavingInhibitorTask
 		{
 			if (!_process.HasExited)
 			{
-				// _process cannot stop on its own so we know it is actually running.
+				// Process cannot stop on its own so we know it is actually running.
 				try
 				{
-					_process.Kill(entireProcessTree: true);
+					_process.Kill();
 					Logger.LogTrace("Inhibit task was killed.");
 				}
 				catch (Exception ex)

--- a/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/LinuxInhibitorTask.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using WalletWasabi.BundledApps;
-using WalletWasabi.Logging;
 
 namespace WalletWasabi.Helpers.PowerSaving;
 

--- a/WalletWasabi/Helpers/PowerSaving/MacOsInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/MacOsInhibitorTask.cs
@@ -15,12 +15,9 @@ public class MacOsInhibitorTask : BaseInhibitorTask
 
 	public static MacOsInhibitorTask Create(TimeSpan basePeriod, string reason)
 	{
-		// -w switch makes sure that the caffeinate will stop enforcing "no idle mode" once Wasabi process exits.
-		// If Wasabi is killed, orphaned caffeinate 
-		var innerCommand = $"""caffeinate -i -w {Environment.ProcessId}""";
-
-		var command = $"/bin/bash";
-		var arguments = $"-c \"{innerCommand}\"";
+		// -w switch makes sure that the caffeinate will stop doing its job once Wasabi process exits.
+		var command = "caffeinate";
+		var arguments = $"-i -w {Environment.ProcessId}";
 
 		Logger.LogTrace($"Command to invoke: {command} {arguments}");
 		ProcessStartInfo startInfo = GetProcessStartInfo(command, arguments);

--- a/WalletWasabi/Helpers/PowerSaving/MacOsInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/MacOsInhibitorTask.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using WalletWasabi.BundledApps;
-using WalletWasabi.Logging;
 
 namespace WalletWasabi.Helpers.PowerSaving;
 
@@ -23,7 +22,7 @@ public class MacOsInhibitorTask : BaseInhibitorTask
 		string innerCommand = $$"""
 			caffeinate -i &
 			caffeinatePid=$!;
-			trap \"kill -9 \$caffeinatePid\" 0 SIGINT SIGTERM;
+			trap 'kill -9 $caffeinatePid' EXIT SIGINT SIGTERM;
 			while (ps -p {{Environment.ProcessId}} );
 			do
 				sleep 1;

--- a/WalletWasabi/Helpers/PowerSaving/MacOsInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/MacOsInhibitorTask.cs
@@ -15,22 +15,12 @@ public class MacOsInhibitorTask : BaseInhibitorTask
 
 	public static MacOsInhibitorTask Create(TimeSpan basePeriod, string reason)
 	{
-		// The script is written with newlines but we need to pass the script to
-		// bash -c as a one-liner, so that's why we use the "ReplaceLineEndings" command.
-		//
-		// Note that this script requires dollar signs ($) and quotes (") to be escaped.
-		string innerCommand = $$"""
-			caffeinate -i &
-			caffeinatePid=$!;
-			trap 'kill -9 $caffeinatePid' EXIT SIGINT SIGTERM;
-			while (ps -p {{Environment.ProcessId}} );
-			do
-				sleep 1;
-			done;
-			""".ReplaceLineEndings(replacementText: " ");
+		// -w switch makes sure that the caffeinate will stop enforcing "no idle mode" once Wasabi process exits.
+		// If Wasabi is killed, orphaned caffeinate 
+		var innerCommand = $"""caffeinate -i -w {Environment.ProcessId}""";
 
-		string command = $"/bin/bash";
-		string arguments = $"-c \"{innerCommand}\"";
+		var command = $"/bin/bash";
+		var arguments = $"-c \"{innerCommand}\"";
 
 		Logger.LogTrace($"Command to invoke: {command} {arguments}");
 		ProcessStartInfo startInfo = GetProcessStartInfo(command, arguments);

--- a/WalletWasabi/Helpers/PowerSaving/WindowsPowerAvailabilityTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/WindowsPowerAvailabilityTask.cs
@@ -1,8 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
-using WalletWasabi.Logging;
 
 namespace WalletWasabi.Helpers.PowerSaving;
 

--- a/WalletWasabi/Services/SleepInhibitor.cs
+++ b/WalletWasabi/Services/SleepInhibitor.cs
@@ -1,10 +1,6 @@
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using WalletWasabi.Bases;
-using WalletWasabi.Helpers;
 using WalletWasabi.Helpers.PowerSaving;
-using WalletWasabi.Logging;
 using WalletWasabi.WabiSabi.Client.CoinJoin.Client;
 using WalletWasabi.WabiSabi.Client.CoinJoin.Manager;
 using static WalletWasabi.Helpers.PowerSaving.LinuxInhibitorTask;
@@ -67,7 +63,7 @@ public class SleepInhibitor : PeriodicRunner
 		return new SleepInhibitor(coinJoinManager, taskFactory);
 	}
 
-	protected override async Task ActionAsync(CancellationToken cancel)
+	protected override async Task ActionAsync(CancellationToken cancellationToken)
 	{
 		var highestCoinJoinClientState = _coinJoinManager.HighestCoinJoinClientState;
 		switch (highestCoinJoinClientState)


### PR DESCRIPTION
close #14918

### How to test

Only for linux-based or macOS, Windows is not affected:

1. Start Wasabi
2. Based on your OS
    * macOS: Check that no `caffeinate -i -w <PID>`  is in your list of processes 
    * Linux-based: Check that no `inhibit` (`gnome-session-inhibit` or `mate-session-inhibit` or `systemd-inhibit`) is in your list of processes.
3. Start coinjoin
4.  Based on your OS
    * macOS: Check that a `caffeinate -i -w <PID>`  process appears.
    * Linux-based: Check that an `inhibit` (`gnome-session-inhibit` or `mate-session-inhibit` or `systemd-inhibit`) process appears
5. Stop coinjoin and your inhibit process should be gone
