### PR TITLE
RPC startcoinjoin and startcoinjoinsweep: password as last param

### DIFF
--- a/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
@@ -464,7 +464,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("startcoinjoin")]
-	public void StartCoinJoining(string? password = null, bool stopWhenAllMixed = true, bool overridePlebStop = true)
+	public void StartCoinJoining(bool stopWhenAllMixed = true, bool overridePlebStop = true, string? password = null)
 	{
 		var coinJoinManager = GetCoinJoinManager();
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
@@ -475,7 +475,7 @@ public class WasabiJsonRpcService : IJsonRpcService
 	}
 
 	[JsonRpcMethod("startcoinjoinsweep")]
-	public void StartCoinjoinSweeping(string? password = null, string? outputWalletName = null)
+	public void StartCoinjoinSweeping(string? outputWalletName = null, string? password = null)
 	{
 		var activeWallet = Guard.NotNull(nameof(ActiveWallet), ActiveWallet);
 		var coinJoinManager = GetCoinJoinManager();


### PR DESCRIPTION
Each method that requires a password has the password as the last param, except for `startcoinjoin` and `startcoinjoinsweep`.
This PR puts the password/passphrase as the last param at these two methods as well.

breaks "backwards compatibility", I think it's ok.