### PR TITLE
WabiSabiController: Show recently finished rounds as well

### DIFF
--- a/WalletWasabi.Coordinator/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Coordinator/Controllers/WabiSabiController.cs
@@ -83,7 +83,6 @@ public class WabiSabiController : ControllerBase, IWabiSabiApiRequestHandler
 	public HumanMonitorResponse GetHumanMonitor()
 	{
 		var response = _arena.Rounds
-			.Where(r => r.Phase is not Phase.Ended)
 			.OrderByDescending(x => x.InputCount)
 			.Select(r =>
 				new HumanMonitorRoundResponse(


### PR DESCRIPTION
close #14927

The output of `http://localhost:62276/wabisabi/human-monitor` is not perfect but it's one-line change:

```json
{
  "RoundStates": [
    {
      "RoundId": "c38c6a9c6d169ffdd631860296c438b90278c2a60d5963ddf9ca14bb987a753f",
      "IsBlameRound": false,
      "InputCount": 0,
      "MaxSuggestedAmount": 43000,
      "InputRegistrationRemaining": "0d 0h 0m -10s",
      "Phase": "Ended"
    },
    {
      "RoundId": "eb911439df8f8e6fda85cf4efbc6eb62a1d864d4c8c8839ec12f98935776da03",
      "IsBlameRound": false,
      "InputCount": 0,
      "MaxSuggestedAmount": 43000,
      "InputRegistrationRemaining": "0d 0h 0m 51s",
      "Phase": "InputRegistration"
    },
    {
      "RoundId": "b07ebc23e86d6230207f44dfd996434a73703f83efbcbdf5bb9be7413d39d598",
      "IsBlameRound": false,
      "InputCount": 0,
      "MaxSuggestedAmount": 43000,
      "InputRegistrationRemaining": "0d 0h 1m 51s",
      "Phase": "InputRegistration"
    }
  ]
}
```