### PR TITLE
Do not register inputs during the previous round's buffer period

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinClientRegistrationStartTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinClientRegistrationStartTests.cs
@@ -1,0 +1,76 @@
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Client.CoinJoin.Client;
+using WalletWasabi.WabiSabi.Coordinator;
+using WalletWasabi.WabiSabi.Coordinator.Rounds;
+using WalletWasabi.WabiSabi.Models;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Client;
+
+/// <seealso href="https://github.com/WalletWasabi/WalletWasabi/issues/14924"/>
+public class CoinJoinClientRegistrationStartTests
+{
+	private static readonly TimeSpan Buffer = TimeSpan.FromMinutes(1);
+	private static readonly DateTimeOffset Now = new(2026, 8, 14, 12, 0, 0, TimeSpan.Zero);
+
+	private static RoundState CreateRoundState(DateTimeOffset inputRegistrationStart, bool isBlame = false)
+	{
+		WabiSabiConfig cfg = new();
+		Round round = WabiSabiFactory.CreateRound(cfg);
+		if (isBlame)
+		{
+			round = WabiSabiFactory.CreateBlameRound(round, cfg);
+		}
+
+		round.InputRegistrationTimeFrame = new TimeFrame(
+			inputRegistrationStart,
+			round.InputRegistrationTimeFrame.Duration);
+
+		return RoundState.FromRound(round);
+	}
+
+	[Fact]
+	public void DoesNotRegisterWhileThePreviousRoundIsStillInInputRegistration()
+	{
+		// The coordinator creates the successor round when the previous one has one minute of input
+		// registration left, so a round this young overlaps with that still-open round.
+		var roundState = CreateRoundState(Now - TimeSpan.FromSeconds(5));
+
+		var registrationStart = CoinJoinClient.GetRegistrationStart(roundState, Buffer, Now);
+
+		Assert.Equal(Now + TimeSpan.FromSeconds(55), registrationStart);
+	}
+
+	[Fact]
+	public void RegistersImmediatelyOnceTheBufferPeriodHasPassed()
+	{
+		var roundState = CreateRoundState(Now - Buffer - TimeSpan.FromSeconds(1));
+
+		var registrationStart = CoinJoinClient.GetRegistrationStart(roundState, Buffer, Now);
+
+		Assert.Equal(Now, registrationStart);
+	}
+
+	[Fact]
+	public void BlameRoundsAreNotHeldBack()
+	{
+		// A blame round's participants are exactly the failed round's participants, so there is
+		// nothing to hide and its input registration only lasts a few minutes.
+		var roundState = CreateRoundState(Now, isBlame: true);
+
+		var registrationStart = CoinJoinClient.GetRegistrationStart(roundState, Buffer, Now);
+
+		Assert.Equal(Now, registrationStart);
+	}
+
+	[Fact]
+	public void NoTimeLimitMeansNoHoldBack()
+	{
+		// Tests construct the client with TimeSpan.Zero - registration must not be delayed then.
+		var roundState = CreateRoundState(Now);
+
+		var registrationStart = CoinJoinClient.GetRegistrationStart(roundState, TimeSpan.Zero, Now);
+
+		Assert.Equal(Now, registrationStart);
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -519,7 +519,14 @@ public class CoinJoinClient
 		// Decrease the available time, so the clients hurry up.
 		var safetyBuffer = TimeSpan.FromMinutes(1);
 		var remainingTime = roundState.InputRegistrationEnd - safetyBuffer;
-		var scheduledDates = remainingTime.GetScheduledDates(smartCoins.Count());
+
+		var registrationStart = GetRegistrationStart(roundState, _doNotRegisterInLastMinuteTimeLimit, DateTimeOffset.UtcNow);
+		if (registrationStart > DateTimeOffset.UtcNow)
+		{
+			Logger.LogDebug(FormatLog($"Holding the registrations back for {registrationStart - DateTimeOffset.UtcNow:hh\\:mm\\:ss} to not register during the previous round's buffer period.", roundState));
+		}
+
+		var scheduledDates = remainingTime.GetScheduledDates(smartCoins.Count(), registrationStart, TimeSpan.MaxValue);
 
 		// Creates scheduled tasks (tasks that wait until the specified date/time and then perform the real registration)
 		var aliceClients = smartCoins.Zip(
@@ -656,6 +663,17 @@ public class CoinJoinClient
 	internal virtual ImmutableList<DateTimeOffset> GetScheduledDates(int howMany, DateTimeOffset startTime, DateTimeOffset endTime, TimeSpan maximumRequestDelay)
 	{
 		return endTime.GetScheduledDates(howMany, startTime, maximumRequestDelay);
+	}
+
+	internal static DateTimeOffset GetRegistrationStart(RoundState roundState, TimeSpan doNotRegisterInLastMinuteTimeLimit, DateTimeOffset now)
+	{
+		if (roundState.IsBlame)
+		{
+			return now;
+		}
+
+		var bufferEnd = roundState.InputRegistrationStart + doNotRegisterInLastMinuteTimeLimit;
+		return bufferEnd > now ? bufferEnd : now;
 	}
 
 	private void LogCoinJoinSummary(ImmutableArray<AliceClient> registeredAliceClients, IEnumerable<TxOut> myOutputs, RoundState roundState)


### PR DESCRIPTION
Closes #14924.

Clients never register in the last minute of input registration, and the coordinator creates the successor round at exactly the moment the current one enters that last minute. So for 60 seconds two non-blame rounds are open at the same time, and since a wallet only ever coinjoins in one round at a time, anything registered into the new round during that overlap provably belongs to nobody who is registered in the finishing round.

The code was generated using AI. 
