### PR TITLE
Bundle a universal (x86_64 + arm64) macOS HWI binary

### DIFF
--- a/Contrib/BundledApps/upgrade-hwi.sh
+++ b/Contrib/BundledApps/upgrade-hwi.sh
@@ -82,11 +82,15 @@ declare -A FILES
 FILES[linux-arm64]="hwi-${VERSION}-linux-aarch64.tar.gz"
 FILES[linux-x64]="hwi-${VERSION}-linux-x86_64.tar.gz"
 FILES[osx64]="hwi-${VERSION}-mac-x86_64.tar.gz"
+FILES[osx64-arm64]="hwi-${VERSION}-mac-arm64.tar.gz"
 FILES[win-x64]="hwi-${VERSION}-windows-x86_64.zip"
 
 CHECKSUM_FILE="SHA256SUMS.txt.asc"
 
 SUPPORTED_PLATFORMS=("linux-arm64" "linux-x64" "osx64" "win-x64")
+# The osx64 folder ships in both the x86_64 and the arm64 dmg (see Contrib/release.sh),
+# so its hwi is a universal binary fused from these two downloads.
+DOWNLOAD_PLATFORMS=("${SUPPORTED_PLATFORMS[@]}" "osx64-arm64")
 
 SEVEN_ZIP="7zz"
 
@@ -188,7 +192,7 @@ section "Downloading HWI packages"
 downloadChecksumsFile=true
 
 # Download platform binaries only if missing or forced
-for platform in "${SUPPORTED_PLATFORMS[@]}"; do
+for platform in "${DOWNLOAD_PLATFORMS[@]}"; do
     fname="${FILES[$platform]}"
     url="${DIST_URI}/${fname}"
 
@@ -241,6 +245,12 @@ if [[ "$SKIP_EXTRACT" != true ]]; then
     "$SEVEN_ZIP" x -y "hwi-${VERSION}-mac-x86_64.tar.gz" >/dev/null
     "$SEVEN_ZIP" x -y -oHWI/osx64 "hwi-${VERSION}-mac-x86_64.tar" >/dev/null
 
+    # macOS arm64 (fused into a universal osx64/hwi at replace time)
+    info "Extracting macOS arm64 (hwi-${VERSION}-mac-arm64.tar.gz)"
+    mkdir -p HWI/osx64-arm64
+    "$SEVEN_ZIP" x -y "hwi-${VERSION}-mac-arm64.tar.gz" >/dev/null
+    "$SEVEN_ZIP" x -y -oHWI/osx64-arm64 "hwi-${VERSION}-mac-arm64.tar" >/dev/null
+
     # Windows
     info "Extracting Windows (hwi-${VERSION}-windows-x86_64.zip)"
     mkdir -p HWI/win-x64
@@ -265,6 +275,14 @@ if [[ "$SKIP_REPLACE" != true ]]; then
         cp -a "${TEMP_DIR}/HWI/${platform}/"* "${BINARIES_DIR}/${target_dir}/"
         info "Updated ${target_dir}"
     done
+
+    # Fuse the two macOS builds into one universal binary: the osx64 folder ships in
+    # both the x86_64 and the arm64 dmg, and Apple Silicon without Rosetta 2 cannot
+    # run an x86_64-only hwi at all ("bad CPU type in executable").
+    LIPO=$(command -v lipo || command -v llvm-lipo || true)
+    [[ -n "$LIPO" ]] || error "lipo (macOS) or llvm-lipo is required to build the universal macOS hwi"
+    "$LIPO" -create "${TEMP_DIR}/HWI/osx64/hwi" "${TEMP_DIR}/HWI/osx64-arm64/hwi" -output "osx64/hwi"
+    info "Created universal macOS hwi (x86_64 + arm64)"
 else
     section "Skipping HWI binary replacement"
 fi


### PR DESCRIPTION
## Problem

The `osx64` bundled-apps folder ships in **both** macOS dmgs (`Contrib/release.sh` builds `osx-x64` and `osx-arm64` from the same folder), but the bundled `hwi` is x86_64-only (thin Mach-O, byte-identical to the official HWI 3.2.0 `mac-x86_64` build). On Apple Silicon **without Rosetta 2** it fails with `bad CPU type in executable`, so hardware wallet detection silently finds nothing. Most users don't notice because Rosetta is usually installed; on a clean M-series Mac the failure is silent. The bundled Tor is already a universal binary — that's why everything else works natively.

## Change

- Replace `osx64/hwi` with a **universal binary** (x86_64 + arm64) fused with `lipo` from the two official HWI 3.2.0 release archives. Same HWI version as before — the old binary is byte-identical to the official `mac-x86_64` build, so this only adds the arm64 slice.
- `upgrade-hwi.sh` now downloads both mac archives (both SHA256-verified against the signed `SHA256SUMS.txt.asc`) and fuses them the same way (`lipo` on macOS, `llvm-lipo` elsewhere).

## Verification

- Both source archives and both embedded `hwi` slice hashes verified against the release's signed manifest (`b3764a53…` x86_64, `87a89918…` arm64).
- `lipo -archs` reports `x86_64 arm64`; binary is 22 MB (was 10.7 MB).
- Tested natively on an M-series Mac without Rosetta 2: `hwi enumerate` finds a Trezor Model T, and a full watch-only wallet import through the Wasabi GUI works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)