### PR TITLE
release.sh: Set `amd64` and `arm64` correctly in Debian control file

### DIFF
--- a/Contrib/release.sh
+++ b/Contrib/release.sh
@@ -245,10 +245,12 @@ DEBIAN_BIN=$DEBIAN_USR/local/bin
 
 DEBIAN_ARCH_NAME=""
 DEBIAN_FULL_PLATFORM_NAME="linux-x64"
+DEBIAN_CONTROL_FILE_ARCHITECTURE="amd64"
 
 if [ "$CURRENT_ARCH" = "arm64" ]; then
   DEBIAN_ARCH_NAME="-arm64"
   DEBIAN_FULL_PLATFORM_NAME="linux-arm64"
+  DEBIAN_CONTROL_FILE_ARCHITECTURE="arm64"
 fi
 
 
@@ -277,7 +279,7 @@ Version: ${VERSION}
 Homepage: https://wasabiwallet.io
 Vcs-Git: git://github.com/WalletWasabi/WalletWasabi.git
 Vcs-Browser: https://github.com/WalletWasabi/WalletWasabi
-Architecture: amd64
+Architecture: ${DEBIAN_CONTROL_FILE_ARCHITECTURE}
 License: Open Source (MIT)
 Installed-Size: ${DEBIAN_PACKAGE_SIZE}
 Recommends: policykit-1


### PR DESCRIPTION
Fixes https://github.com/WalletWasabi/WalletWasabi/pull/14792/changes#r3593254055