### PR TITLE
release.sh: Add `--root-owner-group` to avoid using local user being …

### DIFF
--- a/Contrib/release.sh
+++ b/Contrib/release.sh
@@ -350,7 +350,7 @@ if [[ "$PACKAGE_COORDINATOR" == "yes" ]]; then
 fi
 
 # Build the .deb package
-dpkg-deb -Zxz --build "${DEBIAN_PACKAGE_DIR}" "$PACKAGES_DIR/${PACKAGE_FILE_NAME_PREFIX}${DEBIAN_ARCH_NAME}.deb"
+dpkg-deb -Zxz --root-owner-group --build "${DEBIAN_PACKAGE_DIR}" "$PACKAGES_DIR/${PACKAGE_FILE_NAME_PREFIX}${DEBIAN_ARCH_NAME}.deb"
 
 done
 fi


### PR DESCRIPTION
…involved

Related to #14791

This PR fixes the following warning 

```
dpkg-deb: warning: root directory /home/USER/WalletWasabi/build/Wasabi-2.8.1-linux-x64.zip/deb has unusual owner or group 1000:1000
dpkg-deb: hint: you might need to pass --root-owner-group, see <https://wiki.debian.org/Teams/Dpkg/RootlessBuilds> for further details
dpkg-deb: warning: ignoring 1 warning about the control file(s)
```

when `./Contrib/release.sh debian` is executed.

## How to test

```bash
./Contrib/release.sh debian
cd packages
dpkg-deb -c Wasabi-2.8.1.deb
```

On `master`, you get files owned by your `USER`:

```
drwxr-xr-x USER/USER         0 2026-08-18 02:01 ./
drwxr-xr-x USER/USER         0 2026-08-18 02:01 ./usr/
drwxr-xr-x USER/USER         0 2026-08-18 02:01 ./usr/local/
drwxr-xr-x USER/USER         0 2026-08-18 02:01 ./usr/local/bin/
drwxr-xr-x USER/USER         0 2026-08-18 02:01 ./usr/local/bin/wasabiwallet/
drwxr-xr-x USER/USER         0 2026-08-18 02:01 ./usr/local/bin/wasabiwallet/Announcements/
-rw-r--r-- USER/USER      1298 2026-08-18 02:01 ./usr/local/bin/wasabiwallet/Announcements/ReleaseHighlights.md
-rw-r--r-- USER/USER   2127360 2026-04-13 20:21 ./usr/local/bin/wasabiwallet/Avalonia.Base.dll
-rw-r--r-- USER/USER    481280 2026-04-13 20:21 ./usr/local/bin/wasabiwallet/Avalonia.Controls.ColorPicker.dll
etc etc.
```

With this PR, you get:

```
drwxr-xr-x root/root         0 2026-08-18 02:01 ./
drwxr-xr-x root/root         0 2026-08-18 02:01 ./usr/
drwxr-xr-x root/root         0 2026-08-18 02:01 ./usr/local/
drwxr-xr-x root/root         0 2026-08-18 02:01 ./usr/local/bin/
drwxr-xr-x root/root         0 2026-08-18 02:01 ./usr/local/bin/wasabiwallet/
drwxr-xr-x root/root         0 2026-08-18 02:01 ./usr/local/bin/wasabiwallet/Announcements/
-rw-r--r-- root/root      1298 2026-08-18 02:01 ./usr/local/bin/wasabiwallet/Announcements/ReleaseHighlights.md
-rw-r--r-- root/root   2127360 2026-04-13 20:21 ./usr/local/bin/wasabiwallet/Avalonia.Base.dll
-rw-r--r-- root/root    481280 2026-04-13 20:21 ./usr/local/bin/wasabiwallet/Avalonia.Controls.ColorPicker.dll
etc etc.
```

The important part being `root/root`.

These two website pages 

* https://askubuntu.com/questions/735883/what-user-file-owner-to-use-when-creating-debian-packages
* https://unix.stackexchange.com/questions/254245/what-is-an-appropriate-uid-and-gid-for-a-debian-package-file-owner/254266#254266

explain the topic a bit.

cc @xrviv