### PR TITLE
WabiSabiConfig: Change `LoadFile` to `TryLoadFile`

### DIFF
--- a/WalletWasabi.Coordinator/Startup.cs
+++ b/WalletWasabi.Coordinator/Startup.cs
@@ -56,7 +56,10 @@ public class Startup(IConfiguration configuration)
 
 		services.AddControllers();
 
-		WabiSabiConfig config = WabiSabiConfig.LoadFile(Path.Combine(dataDir, "Config.json"));
+		var configFilePath = Path.Combine(dataDir, "Config.json");
+		var config = WabiSabiConfig.TryLoadFile(configFilePath) ??
+			throw new InvalidDataException($"Failed to load '{configFilePath}' config.");
+
 		services.AddSingleton(config);
 
 		var torSetting = new TorSettings(dataDir,

--- a/WalletWasabi/WabiSabi/Coordinator/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Coordinator/WabiSabiConfig.cs
@@ -169,7 +169,7 @@ public class WabiSabiConfig : ConfigBase
 		return scriptTypes.ToImmutableSortedSet();
 	}
 
-	public static WabiSabiConfig LoadFile(string filePath)
+	public static WabiSabiConfig? TryLoadFile(string filePath)
 	{
 		try
 		{
@@ -180,11 +180,16 @@ public class WabiSabiConfig : ConfigBase
 		}
 		catch (Exception ex)
 		{
-			var config = new WabiSabiConfig(filePath);
-			config.ToFile();
-			Logger.LogInfo($"{nameof(WabiSabiConfig)} file has been deleted because it was corrupted. Recreated default version at path: `{filePath}`.");
+			Logger.LogInfo($"Failed to load '{filePath}' config file is corrupted.");
 			Logger.LogWarning(ex);
-			return config;
+
+			var defaultFilePath = $"{filePath}.default";
+			var defaultConfig = new WabiSabiConfig(defaultFilePath);
+			defaultConfig.ToFile();
+
+			Logger.LogInfo($"Default config was stored to '{defaultFilePath}'. Use the config to start fresh.");
+
+			return null;
 		}
 	}
 


### PR DESCRIPTION
## How to test

* Start coordinator with a Config.json containing some invalid JSON -> Should crash and create a _new_ default config file 
* Start coordinator with a valid Config.json -> Should normally start