### PR TITLE
Run unit tests across supported platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches: [ "*" ]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,3 +23,42 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build --print-build-logs .#all
       - run: echo OK
+
+  unit-tests:
+    name: Unit tests (${{ matrix.runtime }})
+    runs-on: ${{ matrix.os }}
+    env:
+      AVALONIA_TELEMETRY_OPTOUT: '1'
+      DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+      DOTNET_NOLOGO: '1'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            runtime: linux-x64
+          - os: windows-latest
+            runtime: win-x64
+          - os: macos-15-intel
+            runtime: osx-x64
+          - os: macos-15
+            runtime: osx-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-${{ matrix.runtime }}-nuget-${{ hashFiles('Directory.Packages.props', 'NuGet.Config', 'global.json', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.runtime }}-nuget-
+            ${{ runner.os }}-nuget-
+      - name: Restore
+        run: dotnet restore WalletWasabi.Tests/WalletWasabi.Tests.csproj
+      - name: Build
+        run: dotnet build WalletWasabi.Tests/WalletWasabi.Tests.csproj --no-restore --configuration Release
+      - name: Test
+        run: dotnet test --project WalletWasabi.Tests/WalletWasabi.Tests.csproj --no-build --configuration Release --filter-namespace "*UnitTests*" --no-progress --no-ansi --output Normal

--- a/WalletWasabi.Tests/UnitTests/Services/ReleaseDownloaderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/ReleaseDownloaderTests.cs
@@ -1,7 +1,9 @@
 using System.Collections.Immutable;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Helpers;
 using WalletWasabi.Services;
 using WalletWasabi.Tests.UnitTests.Mocks;
 using WalletWasabi.WebClients;
@@ -12,9 +14,14 @@ namespace WalletWasabi.Tests.UnitTests.Services;
 public class ReleaseDownloaderTests
 {
 	[Fact]
-	public async Task OfficiallySupportedOSesAsync()
+	public async Task DownloadsAndVerifiesInstallerAsync()
 	{
-		var (sha256sums, sha256sumsAsc, sha256sumsWasabiSig)  = CreateSha256SumsFiles();
+		var version = Version.Parse("2.5.1");
+		var installerFileName = $"Wasabi-{version}-linux-x64.tar.gz";
+		var installDirectory = Path.Combine(Path.GetTempPath(), $"wasabi-installer-{version}");
+		Assert.True(await IoHelpers.TryDeleteDirectoryAsync(installDirectory));
+
+		var (sha256sums, sha256sumsAsc, sha256sumsWasabiSig) = CreateSha256SumsFiles();
 
 		// Setup HTTP responses for mocked handler
 		var httpClientFactory = MockHttpClientFactory.Create([
@@ -25,26 +32,52 @@ public class ReleaseDownloaderTests
 		]);
 
 		var eventBus = new EventBus();
-		var asyncDownloader = ReleaseDownloader.ForOfficiallySupportedOSes(httpClientFactory, eventBus);
+		var asyncDownloader = ReleaseDownloader.ForOfficiallySupportedOSes(
+			httpClientFactory,
+			eventBus,
+			_ => installerFileName);
 		(string, Uri)[] assets =
 		[
 			("SHA256SUMS", new Uri("https://myserver.com/SHA256SUMS")),
 			("SHA256SUMS.asc", new Uri("https://myserver.com/SHA256SUMS.asc")),
 			("SHA256SUMS.wasabisig", new Uri("https://myserver.com/SHA256SUMS.wasabisig")),
-			("Wasabi-2.5.1-linux-x64.tar.gz", new Uri("https://myserver.com/Wasabi-2.5.1-linux-x64.tar.gz")),
-			("Wasabi-2.5.1.msi", new Uri("https://myserver.com/Wasabi-2.5.1.msi")),
+			(installerFileName, new Uri($"https://myserver.com/{installerFileName}")),
 		];
 
-		var installerObstainedTask = new TaskCompletionSource<string>();
-		using var _ = eventBus.Subscribe<NewSoftwareVersionInstallerAvailable>(e => installerObstainedTask.TrySetResult(e.InstallerPath));
+		var installerObtainedTask = new TaskCompletionSource<string>();
+		using var _ = eventBus.Subscribe<NewSoftwareVersionInstallerAvailable>(e => installerObtainedTask.TrySetResult(e.InstallerPath));
 
-		var releaseInfo = new ReleaseInfo(Version.Parse("2.5.1"), assets.ToImmutableDictionary(x => x.Item1, x => x.Item2));
-		await asyncDownloader(releaseInfo, CancellationToken.None);
+		try
+		{
+			var releaseInfo = new ReleaseInfo(version, assets.ToImmutableDictionary(x => x.Item1, x => x.Item2));
+			await asyncDownloader(releaseInfo, CancellationToken.None);
 
-		// Wait for the installer. Throws TimeoutException in case the installer is not found
-		var installerPath = await installerObstainedTask.Task.WaitAsync(TimeSpan.FromMilliseconds(100));
-		var installerContent = File.ReadAllText(installerPath);
-		Assert.Equal("binary file", installerContent);
+			Assert.True(installerObtainedTask.Task.IsCompletedSuccessfully);
+			var installerPath = await installerObtainedTask.Task;
+			var installerContent = File.ReadAllText(installerPath);
+			Assert.Equal("binary file", installerContent);
+		}
+		finally
+		{
+			await IoHelpers.TryDeleteDirectoryAsync(installDirectory);
+		}
+	}
+
+	[Theory]
+	[InlineData(OS.Windows, Architecture.X64, false, "Wasabi-2.5.1.msi")]
+	[InlineData(OS.OSX, Architecture.X64, false, "Wasabi-2.5.1.dmg")]
+	[InlineData(OS.OSX, Architecture.Arm64, false, "Wasabi-2.5.1-arm64.dmg")]
+	[InlineData(OS.Linux, Architecture.X64, true, "Wasabi-2.5.1.deb")]
+	[InlineData(OS.Linux, Architecture.X64, false, "Wasabi-2.5.1-linux-x64.tar.gz")]
+	public void SelectsInstallerName(OS platform, Architecture architecture, bool isDebianBased, string expected)
+	{
+		var result = ReleaseDownloader.GetInstallerName(
+			Version.Parse("2.5.1"),
+			platform,
+			architecture,
+			isDebianBased);
+
+		Assert.Equal(expected, result);
 	}
 
 	private static (string, string, string)  CreateSha256SumsFiles()

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -102,7 +102,18 @@ public static class ReleaseDownloader
 	private static readonly UserAgentPicker UserAgentGetter = UserAgent.GenerateUserAgentPicker(false);
 
 	public static AsyncReleaseDownloader ForOfficiallySupportedOSes(IHttpClientFactory httpClientFactory, EventBus eventBus) =>
-		(releaseInfo, cancellationToken) => DownloadNewWasabiReleaseVersionAsync(httpClientFactory, eventBus, releaseInfo, cancellationToken);
+		ForOfficiallySupportedOSes(httpClientFactory, eventBus, GetInstallerName);
+
+	internal static AsyncReleaseDownloader ForOfficiallySupportedOSes(
+		IHttpClientFactory httpClientFactory,
+		EventBus eventBus,
+		Func<Version, string> getInstallerName) =>
+		(releaseInfo, cancellationToken) => DownloadNewWasabiReleaseVersionAsync(
+			httpClientFactory,
+			eventBus,
+			releaseInfo,
+			getInstallerName(releaseInfo.Version),
+			cancellationToken);
 
 	public static AsyncReleaseDownloader ForUnsupportedLinuxDistributions() =>
 		(_, _) =>
@@ -119,7 +130,12 @@ public static class ReleaseDownloader
 		};
 
 	// Downloads and verifies a new Wasabi release version
-	private static async Task DownloadNewWasabiReleaseVersionAsync(IHttpClientFactory httpClientFactory, EventBus eventBus, ReleaseInfo releaseInfo, CancellationToken cancellationToken)
+	private static async Task DownloadNewWasabiReleaseVersionAsync(
+		IHttpClientFactory httpClientFactory,
+		EventBus eventBus,
+		ReleaseInfo releaseInfo,
+		string installerFileName,
+		CancellationToken cancellationToken)
 	{
 		var installDirectory = GetInstallDirectory(releaseInfo);
 
@@ -135,7 +151,6 @@ public static class ReleaseDownloader
 		Logger.LogInfo("Trying to download new version.");
 
 		// Find appropriate installer for current platform
-		var installerFileName = GetInstallerName(releaseInfo.Version);
 		var installerUriResult = GetInstallerUri(installerFileName);
 		if (!installerUriResult.IsOk)
 		{
@@ -251,13 +266,20 @@ public static class ReleaseDownloader
 	}
 
 	private static string GetInstallerName(Version version) =>
-		(PlatformInformation.GetOsPlatform(), RuntimeInformation.ProcessArchitecture) switch
+		GetInstallerName(
+			version,
+			PlatformInformation.GetOsPlatform(),
+			RuntimeInformation.ProcessArchitecture,
+			PlatformInformation.IsDebianBasedOS());
+
+	internal static string GetInstallerName(Version version, OS platform, Architecture architecture, bool isDebianBased) =>
+		(platform, architecture, isDebianBased) switch
 		{
-			(OS.Windows, _) => $"Wasabi-{version}.msi",
-			(OS.OSX, Architecture.Arm64) => $"Wasabi-{version}-arm64.dmg",
-			(OS.OSX, _) => $"Wasabi-{version}.dmg",
-			(OS.Linux, _) when PlatformInformation.IsDebianBasedOS() => $"Wasabi-{version}.deb",
-			(OS.Linux, Architecture.X64) => $"Wasabi-{version}-linux-x64.tar.gz",
+			(OS.Windows, _, _) => $"Wasabi-{version}.msi",
+			(OS.OSX, Architecture.Arm64, _) => $"Wasabi-{version}-arm64.dmg",
+			(OS.OSX, _, _) => $"Wasabi-{version}.dmg",
+			(OS.Linux, _, true) => $"Wasabi-{version}.deb",
+			(OS.Linux, Architecture.X64, false) => $"Wasabi-{version}-linux-x64.tar.gz",
 			_ => throw new NotSupportedException($"Unsupported platform: '{RuntimeInformation.OSDescription}'.")
 		};
 


### PR DESCRIPTION
## Summary

- keep the existing Nix build and full test job unchanged
- add a Release unit-test matrix for Linux x64, Windows x64, macOS Intel, and macOS ARM64
- cache NuGet packages, build once per runner, and test with no rebuild
- cancel superseded runs while allowing every matrix leg to report independently
- make the mocked ReleaseDownloader flow platform-neutral and test installer-name selection deterministically for every supported runner case

## Motivation

PR #14887 exposed a macOS ARM64 path that the Linux-only test job could not exercise. This restores platform coverage at the unit-test layer.

The first matrix run also showed that ReleaseDownloaderTests.OfficiallySupportedOSesAsync depended on the host platform although its fixture was valid only for the generic Linux x64 tarball. Ubuntu and both Macs could not find their selected fixture asset; Windows selected an MSI whose signed checksum did not match the mocked content.

The fix separates those concerns: production still derives the installer from the real environment, the mocked download/verification flow injects its known-valid installer fixture, and a theory covers Windows x64, macOS Intel, macOS ARM64, Debian Linux, and generic Linux selection on every runner.

The runner layout follows the useful parts of [GingerWallet's unit-test workflow](https://github.com/GingerPrivacy/GingerWallet/blob/master/.github/workflows/UnitTests.yml), adapted to Wasabi's project and dependency manifests. GitHub's current labels make macos-15-intel x64 and macos-15 ARM64.

## Scope

- `.github/workflows/build.yml`: four-runner unit-test matrix; existing Nix job unchanged
- `WalletWasabi/Services/UpdateManager.cs`: internal dependency seam and pure installer-name selector; public production behavior unchanged
- `WalletWasabi.Tests/UnitTests/Services/ReleaseDownloaderTests.cs`: deterministic flow fixture, explicit platform mapping theory, and temp-directory cleanup

Base: current upstream/master at b0b931ffbe2cfe0555f846988fa3febda9a0915c.

## Validation

Local Windows x64:

- workflow YAML parsed successfully and contains all four matrix entries
- git diff --check passed
- Release build succeeded with 0 warnings and 0 errors
- focused ReleaseDownloader tests: 6 passed, 0 failed
- complete Release unit suite: 1,004 passed, 0 failed in 6m37s

One earlier full-suite attempt was interrupted after 539 passing tests by an unrelated background UiConfig serialization null-reference; the unchanged rerun completed successfully.

Refreshed GitHub Actions run after the deterministic fixture fix:

- unchanged Nix build: passed
- Linux x64: 1,004 tests passed
- Windows x64: 1,004 tests passed
- macOS ARM64: 1,004 tests passed
- macOS Intel: ReleaseDownloader tests passed; 1,003/1,004 overall, with only the unrelated CpfpInfoProviderTests.ScheduleRequest_PostsPreFetchMessage_AndProcessesItAsync assertion failing

GitHub does not allow the fork contributor to rerun the single failed upstream job without repository-admin rights. The matrix confirms the ReleaseDownloader fixture fix on every target runner while separately surfacing a pre-existing Intel-macOS test issue.