### PR TITLE
Global: Start P2P after bitcoin data is initialized from SQLite

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -542,7 +542,7 @@ public class Global
 		return new CpfpInfoProvider(cpfpUpdater);
 	}
 
-	private async Task InitializeBlockchainDataFromSqliteAsync(CancellationToken cancellationToken)
+	private async Task InitializeBitcoinStoreAsync(CancellationToken cancellationToken)
 	{
 		try
 		{
@@ -583,7 +583,7 @@ public class Global
 
 			await Task.WhenAll(
 				StartTorProcessManagerAsync(linkedCtsToken),
-				InitializeBlockchainDataFromSqliteAsync(linkedCtsToken))
+				InitializeBitcoinStoreAsync(linkedCtsToken))
 				.ConfigureAwait(false);
 
 			// Bitcoin P2P network can be started after filters are initialized.

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -301,11 +301,6 @@ public class Global
 		return manager;
 	}
 
-	private void ConfigureBitcoinNetwork(CancellationToken cancellationToken)
-	{
-		_p2pConnectionManager.Start(cancellationToken);
-	}
-
 	private RpcClientBase? ConfigureBitcoinRpcClient()
 	{
 		var credentialString = Config.BitcoinRpcCredentialString;
@@ -547,7 +542,7 @@ public class Global
 		return new CpfpInfoProvider(cpfpUpdater);
 	}
 
-	private async Task InitializeBitcoinStoreAsync(CancellationToken cancellationToken)
+	private async Task InitializeBlockchainDataFromSqliteAsync(CancellationToken cancellationToken)
 	{
 		try
 		{
@@ -576,7 +571,6 @@ public class Global
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _stoppingCts.Token);
 		CancellationToken linkedCtsToken = linkedCts.Token;
 
-		ConfigureBitcoinNetwork(linkedCtsToken);
 		ConfigureWasabiUpdater(linkedCtsToken);
 		ConfigureExchangeRateUpdater(linkedCtsToken);
 		ConfigureRpcMonitor(linkedCtsToken);
@@ -589,8 +583,11 @@ public class Global
 
 			await Task.WhenAll(
 				StartTorProcessManagerAsync(linkedCtsToken),
-				InitializeBitcoinStoreAsync(linkedCtsToken))
+				InitializeBlockchainDataFromSqliteAsync(linkedCtsToken))
 				.ConfigureAwait(false);
+
+			// Bitcoin P2P network can be started after filters are initialized.
+			_p2pConnectionManager.Start(linkedCtsToken);
 
 			await ConfigureSynchronizerAsync(linkedCtsToken).ConfigureAwait(false);
 

--- a/WalletWasabi/Blockchain/Blocks/FilterHeaderChain.cs
+++ b/WalletWasabi/Blockchain/Blocks/FilterHeaderChain.cs
@@ -1,8 +1,3 @@
-using NBitcoin;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-
 namespace WalletWasabi.Blockchain.Blocks;
 
 /// <summary>


### PR DESCRIPTION
This PR fixes an unlikely race when a P2P node can provide a filter (header) before blockchain data is initialized from SQLite. If it would occur, it would likely result in some data corruption in memory.