### PR TITLE
Global: `ConfigureBitcoinRpcClient` – report more user-friendly exception when `Config.BitcoinRpcUri` is invalid

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -327,7 +327,7 @@ public class Global
 
 		if (!Uri.TryCreate(Config.BitcoinRpcUri, UriKind.Absolute, out var bitcoinRpcUri))
 		{
-			throw new ArgumentException($"Config property '{nameof(Config.BitcoinRpcUri)}' was set to an invalid URI value: {Config.BitcoinRpcUri}");
+			throw new UriFormatException($"Config property '{nameof(Config.BitcoinRpcUri)}' was set to an invalid URI value: {Config.BitcoinRpcUri}");
 		}
 
 		RPCClient internalRpcClient;

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -325,7 +325,11 @@ public class Global
 			return null;
 		}
 
-		var bitcoinRpcUri = Config.BitcoinRpcUri;
+		if (!Uri.TryCreate(Config.BitcoinRpcUri, UriKind.Absolute, out var bitcoinRpcUri))
+		{
+			throw new ArgumentException($"Config property '{nameof(Config.BitcoinRpcUri)}' was set to an invalid URI value: {Config.BitcoinRpcUri}");
+		}
+
 		RPCClient internalRpcClient;
 
 		try
@@ -338,7 +342,7 @@ public class Global
 		}
 
 		// Use Tor only if the address ends with .onion. Especially, do not use Tor for loopback (i.e. `localhost`).
-		if (new Uri(bitcoinRpcUri).DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase))
+		if (bitcoinRpcUri.DnsSafeHost.EndsWith(".onion", StringComparison.OrdinalIgnoreCase))
 		{
 			internalRpcClient.HttpClient = ExternalSourcesHttpClientFactory.CreateClient("long-live-rpc-connection");
 		}


### PR DESCRIPTION
close #14955

When I set in my `Config.json`:

```
"BitcoinRpcEndPoint": "http://localhost:-1234", // Set an invalid port (negative) on purpose here
```

### master

On master, I get an exception like this

```
2026-08-22 13:50:25.781 [ 2] CRT | Program.cs:102 | System.FormatException: The input string '//localhost:-1234' was not in a correct format.
   at System.Number.ThrowFormatException[TChar](ReadOnlySpan`1 value)
   at System.Int32.Parse(String s)
   at NBitcoin.RPC.RPCClient.BuildUri(String hostOrUri, String connectionString, Int32 port)
   at NBitcoin.RPC.RPCClient..ctor(RPCCredentialString credentials, String host, Network network)
   at WalletWasabi.Client.Global.ConfigureBitcoinRpcClient() in WalletWasabi.Client/Global.cs:line 333
   at WalletWasabi.Client.Global..ctor(String dataDir, Config config) in WalletWasabi.Client/Global.cs:line 98
   at WalletWasabi.Client.WasabiApplication..ctor(WasabiAppBuilder wasabiAppBuilder) in WalletWasabi.Client/WasabiApplication.cs:line 34
   at WalletWasabi.Client.WasabiAppBuilder.Build() in WalletWasabi.Client/WasabiAppBuilder.cs:line 31
   at WalletWasabi.Fluent.Desktop.Program.Main(String[] args)
```

So the users get this message: `The input string '//localhost:-1234' was not in a correct format.`

### PR

With this PR, the following exception is reported:

```
2026-08-22 19:54:02.865 [ 2] CRT | Program.cs:102 | System.ArgumentException: Config property 'BitcoinRpcUri' was set to an invalid URI value: http://localhost:-1234
   at WalletWasabi.Client.Global.ConfigureBitcoinRpcClient() in WalletWasabi.Client/Global.cs:line 330
   at WalletWasabi.Client.Global..ctor(String dataDir, Config config) in WalletWasabi.Client/Global.cs:line 98
   at WalletWasabi.Client.WasabiApplication..ctor(WasabiAppBuilder wasabiAppBuilder) in WalletWasabi.Client/WasabiApplication.cs:line 34
   at WalletWasabi.Client.WasabiAppBuilder.Build() in WalletWasabi.Client/WasabiAppBuilder.cs:line 31
   at WalletWasabi.Fluent.Desktop.Program.Main(String[] args)
```

So the users get this message: `System.ArgumentException: Config property 'BitcoinRpcUri' was set to an invalid URI value: http://localhost:-1234`. I find this error message slightly better for users to understand what is wrong.