### PR TITLE
BrandAndBound: Allow user-selected BnB tolerance

### DIFF
--- a/WalletWasabi.Fluent/Helpers/CoinPocketHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/CoinPocketHelper.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Fluent.Models;
 using WalletWasabi.Helpers;
 using WalletWasabi.Wallets;
 

--- a/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/PrivacySuggestionsModel.cs
@@ -1,4 +1,3 @@
-using DynamicData;
 using NBitcoin;
 using Nito.AsyncEx;
 using System.Collections.Generic;
@@ -51,9 +50,13 @@ public partial class PrivacySuggestionsModel
 	}
 
 	/// <remarks>Method supports being called multiple times. In that case the last call cancels the previous one.</remarks>
-	public async IAsyncEnumerable<PrivacyItem> BuildPrivacySuggestionsAsync(TransactionInfo transactionInfo, BuildTransactionResult transactionResult, [EnumeratorCancellation] CancellationToken cancellationToken, bool includeSuggestions)
+	public async IAsyncEnumerable<PrivacyItem> BuildPrivacySuggestionsAsync(
+		TransactionInfo transactionInfo,
+		BuildTransactionResult transactionResult,
+		SuggestionParameters? suggestionParameters,
+		[EnumeratorCancellation] CancellationToken cancellationToken)
 	{
-		var parameters = new Parameters(transactionInfo, transactionResult, includeSuggestions);
+		var parameters = new Parameters(transactionInfo, transactionResult, suggestionParameters);
 		var result = new List<PrivacyItem>();
 
 		using CancellationTokenSource singleRunCts = new();
@@ -98,7 +101,7 @@ public partial class PrivacySuggestionsModel
 		{
 			yield return warning;
 
-			if (parameters.IncludeSuggestions && parameters.TransactionInfo.IsOtherPocketSelectionPossible)
+			if (parameters.SuggestionParameters is not null && parameters.TransactionInfo.IsOtherPocketSelectionPossible)
 			{
 				yield return new LabelManagementSuggestion();
 			}
@@ -153,7 +156,7 @@ public partial class PrivacySuggestionsModel
 			yield return new SemiPrivateFundsWarning();
 		}
 
-		if (!parameters.IncludeSuggestions)
+		if (parameters.SuggestionParameters is null)
 		{
 			// Return early, to avoid needless compute.
 			yield break;
@@ -270,9 +273,14 @@ public partial class PrivacySuggestionsModel
 		{
 			yield return new CreatesChangeWarning();
 
-			if (parameters.IncludeSuggestions && !parameters.TransactionInfo.IsFixedAmount && !parameters.TransactionInfo.IsPayJoin && !parameters.TransactionInfo.IsPayToMany)
+			if (parameters.SuggestionParameters is not null && !parameters.TransactionInfo.IsFixedAmount && !parameters.TransactionInfo.IsPayJoin && !parameters.TransactionInfo.IsPayToMany)
 			{
-				var suggestions = await CreateChangeAvoidanceSuggestionsAsync(parameters.TransactionInfo, parameters.Transaction, linkedCts).ConfigureAwait(false);
+				var suggestions = await CreateChangeAvoidanceSuggestionsAsync(
+					parameters.SuggestionParameters.MaxAdditionalCoins,
+					parameters.TransactionInfo,
+					parameters.Transaction,
+					linkedCts).ConfigureAwait(false);
+
 				foreach (var suggestion in suggestions)
 				{
 					yield return suggestion;
@@ -281,7 +289,11 @@ public partial class PrivacySuggestionsModel
 		}
 	}
 
-	private async Task<List<ChangeAvoidanceSuggestion>> CreateChangeAvoidanceSuggestionsAsync(TransactionInfo info, BuildTransactionResult transaction, CancellationTokenSource linkedCts)
+	private async Task<List<ChangeAvoidanceSuggestion>> CreateChangeAvoidanceSuggestionsAsync(
+		int maxAdditionalCoins,
+		TransactionInfo info,
+		BuildTransactionResult transaction,
+		CancellationTokenSource linkedCts)
 	{
 		var result = new List<ChangeAvoidanceSuggestion>();
 
@@ -289,8 +301,7 @@ public partial class PrivacySuggestionsModel
 		// Reporting up-to-date exchange rates would just confuse users.
 		decimal usdExchangeRate = _exchangeRate;
 
-		// Only allow to create 2 more inputs with BnB.
-		int maxInputCount = transaction.SpentCoins.Count() + 2;
+		int maxInputCount = transaction.SpentCoins.Count() + maxAdditionalCoins;
 
 		var pockets = _sendFlow.GetPockets();
 		var spentCoins = transaction.SpentCoins;
@@ -307,7 +318,8 @@ public partial class PrivacySuggestionsModel
 			coinsToUse = coinsToUse.Where(x => x.Confirmed).ToImmutableArray();
 		}
 
-		var suggestions = CreateChangeAvoidanceSuggestionsAsync(info, coinsToUse, maxInputCount, usdExchangeRate, linkedCts.Token).ConfigureAwait(false);
+		var suggestions = CreateChangeAvoidanceSuggestionsAsync(info, coinsToUse, maxInputCount, usdExchangeRate, linkedCts.Token)
+			.ConfigureAwait(false);
 
 		await foreach (var suggestion in suggestions)
 		{
@@ -467,5 +479,7 @@ public partial class PrivacySuggestionsModel
 				: "");
 	}
 
-	private record Parameters(TransactionInfo TransactionInfo, BuildTransactionResult Transaction, bool IncludeSuggestions);
+	private record Parameters(TransactionInfo TransactionInfo, BuildTransactionResult Transaction, SuggestionParameters? SuggestionParameters);
+
+	public record SuggestionParameters(int MaxAdditionalCoins);
 }

--- a/WalletWasabi.Fluent/Models/Transactions/SendFlowModel.cs
+++ b/WalletWasabi.Fluent/Models/Transactions/SendFlowModel.cs
@@ -49,6 +49,6 @@ public record SendFlowModel
 
 	public Pocket[] GetPockets() =>
 		AvailableCoins.GetPockets(Wallet.AnonScoreTarget)
-					  .Select(x => new Pocket(x))
-		              .ToArray();
+			.Select(x => new Pocket(x))
+			.ToArray();
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/PrivacySuggestionsFlyoutViewModel.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Fluent.Models.Transactions;
 using WalletWasabi.Fluent.Models.Wallets;
-using WalletWasabi.Wallets;
+using static WalletWasabi.Fluent.Models.Transactions.PrivacySuggestionsModel;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;
 
@@ -24,6 +24,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 	[AutoNotify] private bool _badPrivacy;
 	[AutoNotify] private bool _goodPrivacy;
 	[AutoNotify] private bool _maxPrivacy;
+	[AutoNotify] private int _maxAdditionalCoins;
 
 	public PrivacySuggestionsFlyoutViewModel(UiContext uiContext, IWalletModel wallet, SendFlowModel sendParameters) : base(uiContext)
 	{
@@ -38,7 +39,7 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 	{
 		var previewWarningList = new List<PrivacyWarning>();
 
-		await foreach (var item in _privacySuggestionsModel.BuildPrivacySuggestionsAsync(info, transaction, cancellationToken, includeSuggestions: false))
+		await foreach (var item in _privacySuggestionsModel.BuildPrivacySuggestionsAsync(info, transaction, suggestionParameters: null, cancellationToken))
 		{
 			if (item is PrivacyWarning warning)
 			{
@@ -67,7 +68,9 @@ public partial class PrivacySuggestionsFlyoutViewModel : ViewModelBase
 
 		IsBusy = true;
 
-		await foreach (var item in _privacySuggestionsModel.BuildPrivacySuggestionsAsync(info, transaction, cancellationToken, includeSuggestions: true))
+		var suggestionParameters = new SuggestionParameters(_maxAdditionalCoins);
+
+		await foreach (var item in _privacySuggestionsModel.BuildPrivacySuggestionsAsync(info, transaction, suggestionParameters, cancellationToken))
 		{
 			if (item is PrivacyWarning warning)
 			{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionInfo.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using NBitcoin;
-using ReactiveUI;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.TransactionOutputs;
@@ -14,7 +12,7 @@ namespace WalletWasabi.Fluent.ViewModels.Wallets.Send;
 public partial class TransactionInfo
 {
 	[AutoNotify] private FeeRate _feeRate = FeeRate.Zero;
-	[AutoNotify] private IEnumerable<SmartCoin> _coins = Enumerable.Empty<SmartCoin>();
+	[AutoNotify] private IEnumerable<SmartCoin> _coins = [];
 
 	public TransactionInfo(Destination destination, int anonScoreTarget)
 	{
@@ -40,7 +38,7 @@ public partial class TransactionInfo
 
 	public TimeSpan ConfirmationTimeSpan { get; set; }
 
-	public IEnumerable<SmartCoin> ChangelessCoins { get; set; } = Enumerable.Empty<SmartCoin>();
+	public IEnumerable<SmartCoin> ChangelessCoins { get; set; } = [];
 
 	public IPayjoinClient? PayJoinClient { get; set; }
 
@@ -58,7 +56,7 @@ public partial class TransactionInfo
 
 	public bool IsFixedAmount { get; init; }
 
-	public IReadOnlyList<RecipientInfo> AdditionalRecipients { get; init; } = ImmutableList<RecipientInfo>.Empty;
+	public IReadOnlyList<RecipientInfo> AdditionalRecipients { get; init; } = [];
 
 	public bool IsPayToMany => AdditionalRecipients.Count > 0;
 
@@ -78,13 +76,13 @@ public partial class TransactionInfo
 
 	private void OnFeeChanged()
 	{
-		ChangelessCoins = Enumerable.Empty<SmartCoin>();
+		ChangelessCoins = [];
 	}
 
 	private void OnCoinsChanged()
 	{
 		MaximumPossibleFeeRate = null;
-		ChangelessCoins = Enumerable.Empty<SmartCoin>(); // Clear ChangelessCoins on pocket change, so we calculate the suggestions with the new pocket.
+		ChangelessCoins = []; // Clear ChangelessCoins on pocket change, so we calculate the suggestions with the new pocket.
 	}
 
 	public TransactionInfo Clone()

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/TransactionPreviewViewModel.cs
@@ -390,7 +390,10 @@ public partial class TransactionPreviewViewModel : RoutableViewModel
 				})
 			.DisposeWith(disposables);
 
-		this.WhenAnyValue(x => x.Transaction)
+		this.WhenAnyValue(
+			x => x.Transaction,
+			x => x.PrivacySuggestions.MaxAdditionalCoins,
+			(transaction, maxAdditionalCoins) => transaction)
 			.WhereNotNull()
 			.Throttle(TimeSpan.FromMilliseconds(100))
 			.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/PrivacyWarningsView.axaml
@@ -219,9 +219,15 @@
         </DataTemplate>
       </ItemsControl.DataTemplates>
     </ItemsControl>
-    <TextBlock Text="Improve this transaction:" HorizontalAlignment="Center"
+
+    <TextBlock Text="Allowed number of additional coins:" HorizontalAlignment="Center"
                Margin="0 10 0 5"
                IsVisible="{Binding !!Suggestions.Count}" />
+
+    <Slider Width="150" Minimum="1" Maximum="5" TickFrequency="1" IsSnapToTickEnabled="True"
+            Value="{Binding MaxAdditionalCoins, Mode=TwoWay}" />
+    <TextBlock Text="{Binding MaxAdditionalCoins}" VerticalAlignment="Center" Width="15" />
+
     <ListBox ItemsSource="{Binding Suggestions}" SelectedItem="{Binding SelectedSuggestion}">
       <Interaction.Behaviors>
         <ListBoxPreviewBehavior PreviewItem="{Binding PreviewSuggestion, Mode=TwoWay}" />

--- a/WalletWasabi/Blockchain/TransactionBuilding/BnB/LessSelectionStrategy.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BnB/LessSelectionStrategy.cs
@@ -1,5 +1,3 @@
-using WalletWasabi.Helpers;
-
 namespace WalletWasabi.Blockchain.TransactionBuilding.BnB;
 
 /// <summary>

--- a/WalletWasabi/Blockchain/TransactionBuilding/BnB/SelectionStrategy.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BnB/SelectionStrategy.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace WalletWasabi.Blockchain.TransactionBuilding.BnB;
 
 public abstract class SelectionStrategy

--- a/WalletWasabi/Blockchain/TransactionBuilding/BranchAndBound.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/BranchAndBound.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 using WalletWasabi.Blockchain.TransactionBuilding.BnB;
 
 namespace WalletWasabi.Blockchain.TransactionBuilding;

--- a/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
+++ b/WalletWasabi/Blockchain/TransactionBuilding/ChangelessTransactionCoinSelector.cs
@@ -1,14 +1,6 @@
-using NBitcoin;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using WalletWasabi.Blockchain.TransactionBuilding.BnB;
-using WalletWasabi.Blockchain.TransactionOutputs;
-using WalletWasabi.Extensions;
-using WalletWasabi.Logging;
 
 namespace WalletWasabi.Blockchain.TransactionBuilding;
 
@@ -40,11 +32,10 @@ public static class ChangelessTransactionCoinSelector
 
 		StrategyParameters parameters = new(target, inputValues, inputCosts, maxInputCount);
 
-		SelectionStrategy[] strategies = new SelectionStrategy[]
-		{
+		SelectionStrategy[] strategies = [
 			new MoreSelectionStrategy(parameters),
 			new LessSelectionStrategy(parameters)
-		};
+		];
 
 		var tasks = strategies
 			.Select(strategy => Task.Run(
@@ -79,7 +70,11 @@ public static class ChangelessTransactionCoinSelector
 	/// <param name="inputEffectiveValues">Dictionary to map back the effective values to their original SmartCoin. </param>
 	/// <param name="selectedCoins">Out parameter that returns (non-grouped!) coins back.</param>
 	/// <returns><c>true</c> if a solution was found, <c>false</c> otherwise.</returns>
-	internal static bool TryGetCoins(SelectionStrategy strategy, Dictionary<SmartCoin[], long> inputEffectiveValues, [NotNullWhen(true)] out IReadOnlyList<SmartCoin>? selectedCoins, CancellationToken cancellationToken)
+	internal static bool TryGetCoins(
+		SelectionStrategy strategy,
+		Dictionary<SmartCoin[], long> inputEffectiveValues,
+		[NotNullWhen(true)] out IReadOnlyList<SmartCoin>? selectedCoins,
+		CancellationToken cancellationToken)
 	{
 		selectedCoins = null;
 

--- a/WalletWasabi/Helpers/SmartCoinExtensions.cs
+++ b/WalletWasabi/Helpers/SmartCoinExtensions.cs
@@ -1,5 +1,3 @@
-using WalletWasabi.Blockchain.TransactionOutputs;
-
 namespace WalletWasabi.Helpers;
 
 public static class SmartCoinExtensions


### PR DESCRIPTION
close #14914

## Testing

1. Start Wasabi
2. Open the "Send dialog", enter `To` and an `Amount` and press `Continue`
3. Hover over the shield icon in the Preview Transaction dialog.

Then you should see:

<img width="977" height="604" alt="image" src="https://github.com/user-attachments/assets/29435291-206a-424a-a2f1-aea7db385c65" />


This is just a draft for now. It seems to do something. However, it's unclear if the design is OK, etc.