### PR TITLE
Sync bug

### DIFF
--- a/WalletWasabi/BitcoinP2p/CompactFilterBehavior.cs
+++ b/WalletWasabi/BitcoinP2p/CompactFilterBehavior.cs
@@ -161,16 +161,14 @@ public partial class CompactFilterBehavior(
 
 		switch (validationResult)
 		{
-			case HeaderValidationResult.Success success:
+			case HeaderValidationResult.Success:
 				Logger.LogInfo($"Successfully validated filter header range {assignment}");
-				synchronizationState.OnHeaderCompleted(assignment.StartHeight, success.Headers);
 				_assignedHeaderRange = null;
 				TrySyncNoLock(node);
 				break;
 
 			case HeaderValidationResult.NotReadyYet:
 				Logger.LogDebug($"Buffering filter header range {assignment} for later validation");
-				synchronizationState.BufferUnvalidatedHeaders(assignment, filterHashArray, cfHeaders.PreviousFilterHeader, node.Network);
 				_assignedHeaderRange = null;
 				TrySyncNoLock(node);
 				break;

--- a/WalletWasabi/BitcoinP2p/FilterSynchronizationState.cs
+++ b/WalletWasabi/BitcoinP2p/FilterSynchronizationState.cs
@@ -102,10 +102,10 @@ public class FilterSynchronizationState
 			}
 
 			// Process any ranges that are now ready
-			ProcessPendingHeaderRanges();
+			ProcessPendingHeaderRangesNoLock();
 
 			// Try to validate and process any buffered responses that may now be ready
-			TryProcessBufferedHeaders();
+			TryProcessBufferedHeadersNoLock();
 		}
 	}
 
@@ -196,7 +196,7 @@ public class FilterSynchronizationState
 	/// Attempts to validate and process any buffered header responses that are now ready.
 	/// Called after a range completes, since the previous filter header may now be available.
 	/// </summary>
-	private void TryProcessBufferedHeaders()
+	private void TryProcessBufferedHeadersNoLock()
 	{
 		// Process buffered responses in order
 		while (true)
@@ -251,7 +251,7 @@ public class FilterSynchronizationState
 		}
 	}
 
-	private void ProcessPendingHeaderRanges()
+	private void ProcessPendingHeaderRangesNoLock()
 	{
 		// Process ranges in order
 		while (true)

--- a/WalletWasabi/BitcoinP2p/FilterSynchronizationState.cs
+++ b/WalletWasabi/BitcoinP2p/FilterSynchronizationState.cs
@@ -89,24 +89,20 @@ public class FilterSynchronizationState
 		}
 	}
 
-	public void OnHeaderCompleted(uint rangeStartHeight, SmartHeader[] headers)
+	private void OnHeaderCompletedNoLock(uint rangeStartHeight, SmartHeader[] headers)
 	{
-		lock (_lock)
+		var response = new HeaderResponse(rangeStartHeight, headers);
+		if (!_headerTracker.TryMoveActiveToPending(rangeStartHeight, response))
 		{
-			var response = new HeaderResponse(rangeStartHeight, headers);
-			if (!_headerTracker.TryMoveActiveToPending(rangeStartHeight, response))
-			{
-				Logger.LogDebug(
-					$"Ignoring stale filter header range {rangeStartHeight}-{response.EndHeight} (already processed up to {_headerTracker.LastHeight})");
-				return;
-			}
-
-			// Process any ranges that are now ready
-			ProcessPendingHeaderRangesNoLock();
-
-			// Try to validate and process any buffered responses that may now be ready
-			TryProcessBufferedHeadersNoLock();
+			Logger.LogDebug($"Ignoring stale filter header range {rangeStartHeight}-{response.EndHeight} (already processed up to {_headerTracker.LastHeight})");
+			return;
 		}
+
+		// Process any ranges that are now ready
+		ProcessPendingHeaderRangesNoLock();
+
+		// Try to validate and process any buffered responses that may now be ready
+		TryProcessBufferedHeadersNoLock();
 	}
 
 	internal void OnHeaderNodeDisconnected(RangeRequest assignment)
@@ -126,70 +122,72 @@ public class FilterSynchronizationState
 		uint256 declaredPreviousFilterHeader,
 		Network network)
 	{
-		// Recalculate the expected previous filter header from the chain
-		if (!TryGetPreviousFilterHeader(assignment.StartHeight, network, out var expectedPreviousFilterHeader))
+		lock (_lock)
 		{
-			Logger.LogDebug(
-				$"Previous filter header not yet available for range {assignment.StartHeight}, will retry later");
-			return new HeaderValidationResult.NotReadyYet();
-		}
-
-		// Validate against the expected previous filter header
-		if (declaredPreviousFilterHeader != expectedPreviousFilterHeader)
-		{
-			var reason = $"Previous filter header mismatch for range {assignment.StartHeight} - expected {expectedPreviousFilterHeader}, received {declaredPreviousFilterHeader}";
-			Logger.LogWarning(reason);
-			return new HeaderValidationResult.Invalid(reason);
-		}
-
-		var result = new SmartHeader[filterHashes.Length];
-		var prevFilterHeader = declaredPreviousFilterHeader;
-
-		for (var i = 0; i < filterHashes.Length; i++)
-		{
-			var height = assignment.StartHeight + (uint) i;
-			var block = _blockHeaderChain.GetBlock((int) height);
-			if (block == null)
+			// Recalculate the expected previous filter header from the chain
+			if (!TryGetPreviousFilterHeader(assignment.StartHeight, network, out var expectedPreviousFilterHeader))
 			{
-				var reason = $"Block header not found at height {height}, aborting batch validation";
-				Logger.LogWarning(reason);
+				Logger.LogDebug($"Previous filter header not yet available for range {assignment.StartHeight}, will retry later");
+				BufferUnvalidatedHeadersNoLock(assignment, filterHashes, declaredPreviousFilterHeader, network);
+				return new HeaderValidationResult.NotReadyYet();
+			}
 
+			// Validate against the expected previous filter header
+			if (declaredPreviousFilterHeader != expectedPreviousFilterHeader)
+			{
+				var reason = $"Previous filter header mismatch for range {assignment.StartHeight} - expected {expectedPreviousFilterHeader}, received {declaredPreviousFilterHeader}";
+				Logger.LogWarning(reason);
 				return new HeaderValidationResult.Invalid(reason);
 			}
 
-			var filterHash = filterHashes[i];
-			var filterHeader = ComputeFilterHeader(filterHash, prevFilterHeader);
+			var result = new SmartHeader[filterHashes.Length];
+			var prevFilterHeader = declaredPreviousFilterHeader;
 
-			result[i] = new SmartHeader(
-				block.HashBlock,
-				filterHeader,
-				height,
-				block.Header.BlockTime);
+			for (var i = 0; i < filterHashes.Length; i++)
+			{
+				var height = assignment.StartHeight + (uint)i;
+				var block = _blockHeaderChain.GetBlock((int)height);
+				if (block == null)
+				{
+					var reason = $"Block header not found at height {height}, aborting batch validation";
+					Logger.LogWarning(reason);
 
-			prevFilterHeader = filterHeader;
+					return new HeaderValidationResult.Invalid(reason);
+				}
+
+				var filterHash = filterHashes[i];
+				var filterHeader = ComputeFilterHeader(filterHash, prevFilterHeader);
+
+				result[i] = new SmartHeader(
+					block.HashBlock,
+					filterHeader,
+					height,
+					block.Header.BlockTime);
+
+				prevFilterHeader = filterHeader;
+			}
+
+			OnHeaderCompletedNoLock(assignment.StartHeight, result);
+
+			return new HeaderValidationResult.Success(result);
 		}
-
-		return new HeaderValidationResult.Success(result);
 	}
 
 	/// <summary>
 	/// Buffers a header response that arrived before we could validate it.
 	/// Removes the assignment from active tracking since we have the data.
 	/// </summary>
-	internal void BufferUnvalidatedHeaders(RangeRequest assignment, uint256[] filterHashes, uint256 declaredPreviousFilterHeader, Network network)
+	private void BufferUnvalidatedHeadersNoLock(RangeRequest assignment, uint256[] filterHashes, uint256 declaredPreviousFilterHeader, Network network)
 	{
-		lock (_lock)
-		{
-			// Remove from active assignments - we have the data, just can't validate yet
-			_headerTracker.RemoveActiveAssignment(assignment.StartHeight);
+		// Remove from active assignments - we have the data, just can't validate yet
+		_headerTracker.RemoveActiveAssignment(assignment.StartHeight);
 
-			_bufferedHeaderResponses[assignment.StartHeight] = new UnvalidatedHeaderResponse(
-				assignment, filterHashes, declaredPreviousFilterHeader, network);
+		_bufferedHeaderResponses[assignment.StartHeight] = new UnvalidatedHeaderResponse(
+			assignment, filterHashes, declaredPreviousFilterHeader, network);
 
-			Logger.LogDebug(
-				$"Buffered filter header range {assignment.StartHeight}-{assignment.StopHeight} for later validation. " +
-				$"Total buffered: {_bufferedHeaderResponses.Count}");
-		}
+		Logger.LogDebug(
+			$"Buffered filter header range {assignment.StartHeight}-{assignment.StopHeight} for later validation. " +
+			$"Total buffered: {_bufferedHeaderResponses.Count}");
 	}
 
 	/// <summary>


### PR DESCRIPTION
This PR is based on digging into the log here: https://github.com/WalletWasabi/WalletWasabi/pull/14966#pullrequestreview-5002113771

The bug can be seen from this excerpt:

```
2026-08-23 05:13:56.836 [58] DBG | CompactFilterBehavior.cs:119   | Received 2000 filter headers from [::ffff:194.132.173.89]:8333 for range 539825-541824
...
2026-08-23 05:13:56.838 [58] INF | CompactFilterBehavior.cs:165   | Successfully validated filter header range 539825-541824    <------- SUCCESSFULLY VALIDATED
2026-08-23 05:13:56.838 [62] DBG | CompactFilterBehavior.cs:119   | Received 2000 filter headers from [::ffff:189.140.117.103]:8333 for range 541825-543824
2026-08-23 05:13:56.838 [62] DBG | ..rSynchronizationState.cs:130 | Previous filter header not yet available for range 541825, will retry later
2026-08-23 05:13:56.838 [62] DBG | CompactFilterBehavior.cs:172   | Buffering filter header range 541825-543824 for later validation    <------- BUFFERING AFTER SUCESSFULLY VALIDATED RANGE
2026-08-23 05:13:56.838 [58] INF | ..rSynchronizationState.cs:283 | Successfully processed filter header range 539825, new tip at height 541824
2026-08-23 05:13:56.838 [58] DBG | CompactFilterBehavior.cs:361   | Assigned filter header range 543825-545824 to node [::ffff:194.132.173.89]:8333
2026-08-23 05:13:56.838 [62] DBG | ..rSynchronizationState.cs:187 | Buffered filter header range 541825-543824 for later validation. Total buffered: 1
2026-08-23 05:13:56.838 [62] DBG | CompactFilterBehavior.cs:361   | Assigned filter header range 545825-547824 to node [::ffff:189.140.117.103]:8333
...
2026-08-23 05:13:58.653 [58] DBG | ..rSynchronizationState.cs:130 | Previous filter header not yet available for range 543825, will retry later
2026-08-23 05:13:58.653 [58] DBG | CompactFilterBehavior.cs:172   | Buffering filter header range 543825-545824 for later validation
2026-08-23 05:13:58.654 [58] DBG | ..rSynchronizationState.cs:187 | Buffered filter header range 543825-545824 for later validation. Total buffered: 2
...
2026-08-23 05:13:58.855 [62] DBG | CompactFilterBehavior.cs:172   | Buffering filter header range 545825-547824 for later validation
2026-08-23 05:13:58.856 [62] DBG | ..rSynchronizationState.cs:187 | Buffered filter header range 545825-547824 for later validation. Total buffered: 3
```
(Note that the log messages do not necessarily need to be sorted in the order operations happened in the real life when the operations happen concurrently. The timestamp `05:13:56.838` was full of events.)

Basically the range of headers `539825-541824` was successfully processed but the following range `541825-543824` was _buffered_. Then you can see that even newer and newer header ranges gets buffered. Importantly, the buffering continues but there is no processing of that buffered data. It keeps buffering but there is no attempt to process buffered data.

Here is the relevant code section:

https://github.com/WalletWasabi/WalletWasabi/blob/db40ff88b7f7a0a50d9edb181ff5f6e0c02776e6/WalletWasabi/BitcoinP2p/CompactFilterBehavior.cs#L154-L176

Now `synchronizationState` is not locked between

https://github.com/WalletWasabi/WalletWasabi/blob/db40ff88b7f7a0a50d9edb181ff5f6e0c02776e6/WalletWasabi/BitcoinP2p/CompactFilterBehavior.cs#L156-L160

and

https://github.com/WalletWasabi/WalletWasabi/blob/db40ff88b7f7a0a50d9edb181ff5f6e0c02776e6/WalletWasabi/BitcoinP2p/CompactFilterBehavior.cs#L166 [^1].

So it happened that a header range was successfully added to the chain and _then_ the following header range was _buffered_ (i.e `OnHeaderCompleted` is never called from this point on). That's what this PR fixes.

[^1]: Also https://github.com/WalletWasabi/WalletWasabi/blob/db40ff88b7f7a0a50d9edb181ff5f6e0c02776e6/WalletWasabi/BitcoinP2p/CompactFilterBehavior.cs#L173.