### PR TITLE
Sign Windows executables only for MSI packaging

### DIFF
--- a/Contrib/release.sh
+++ b/Contrib/release.sh
@@ -52,6 +52,33 @@ PACKAGES_DIR="$ROOT_DIR/packages"
 # Common name for all packages
 PACKAGE_FILE_NAME_PREFIX="Wasabi-$VERSION"
 
+sign_windows_file() {
+  local file_path="$1"
+
+  # Do not echo credentials passed to AzureSignTool.
+  set +x
+  if ! azuresigntool sign \
+      -kvu "https://wasabiwallet.vault.azure.net/" \
+      -kvc "WasabiCodeSignCert" \
+      -kvi "$AZURE_CLIENT_ID" \
+      -kvs "$AZURE_CLIENT_SECRET" \
+      --azure-key-vault-tenant-id "$AZURE_TENANT_ID" \
+      -tr "http://timestamp.digicert.com" \
+      "$file_path"; then
+    set -x
+    return 1
+  fi
+  set -x
+
+  WINDOWS_SIGNED_FILE="$file_path" powershell.exe -NoProfile -Command '
+    $signature = Get-AuthenticodeSignature -LiteralPath $env:WINDOWS_SIGNED_FILE
+    if ($signature.Status -ne "Valid") {
+      Write-Error "Invalid Authenticode signature for $env:WINDOWS_SIGNED_FILE: $($signature.Status)"
+      exit 1
+    }
+  '
+}
+
 if [[ "$RUNNER_OS" == "Windows" ]]; then
   ZIP="7z.exe a"
 else
@@ -493,6 +520,11 @@ BUILD_INSTALLER_DIR="$BUILD_DIR/win-installer"
 WINDOWS_PACKAGE_BUILD_DIR="$BUILD_DIR"/win-x64
 
 mkdir -p "$BUILD_INSTALLER_DIR"
+
+# Keep the portable ZIP unsigned for reproducibility checks and sign only the MSI payload.
+sign_windows_file "$WINDOWS_PACKAGE_BUILD_DIR/${EXECUTABLE_NAME}.exe"
+sign_windows_file "$WINDOWS_PACKAGE_BUILD_DIR/${EXECUTABLE_NAME}d.exe"
+
 "$HEAT_EXE" dir $WINDOWS_PACKAGE_BUILD_DIR \
     -o $WINDOWS_INSTALLER_DIR/ComponentsGenerated.wxs \
     -cg PublishedComponents \
@@ -519,17 +551,7 @@ mkdir -p "$BUILD_INSTALLER_DIR"
 # Remove unwanted file
 rm $PACKAGES_DIR/*.wixpdb
 
-# Define paths (using your existing variables)
-SIGNTOOL="azuresigntool"
-
-"$SIGNTOOL" sign \
-    -kvu "https://wasabiwallet.vault.azure.net/" \
-    -kvc "WasabiCodeSignCert" \
-    -kvi "$AZURE_CLIENT_ID" \
-    -kvs "$AZURE_CLIENT_SECRET" \
-    --azure-key-vault-tenant-id "$AZURE_TENANT_ID" \
-    -tr "http://timestamp.digicert.com" \
-    "$PACKAGES_DIR/$PACKAGE_FILE_NAME_PREFIX.msi"
+sign_windows_file "$PACKAGES_DIR/$PACKAGE_FILE_NAME_PREFIX.msi"
 fi
 
 #------------------------------------------------------------------------------------#


### PR DESCRIPTION
## Summary

- Keep the portable Windows ZIP unsigned so its executable payload remains available for reproducibility checks.
- After creating the ZIP, Authenticode-sign `wassabee.exe` and `wassabeed.exe` before WiX harvests them into the MSI.
- Keep signing the final MSI, using the same signing and verification helper for all three files.
- Fail the release if Windows does not report each resulting signature as valid.
- Disable shell tracing while Azure signing credentials are passed to AzureSignTool.

## Motivation

The release workflow currently signs only the final MSI. That authenticates the installer package, but it does not add an Authenticode signature to the executables carried inside it. After installation, `wassabee.exe` and `wassabeed.exe` are independent files, so signing them lets Windows and users verify Wasabi as their publisher and detect later modification independently of the installer.

Microsoft recommends signing both an EXE/MSI app and the Portable Executable files inside it. However, Authenticode embeds certificate and timestamp data into each signed PE file. An independent builder cannot reproduce those bytes without Wasabi's signing identity, so the signed MSI payload must not replace Wasabi's unsigned reproducibility artifact.

## Reproducibility

Wasabi publishes a portable `Wasabi-<version>-win-x64.zip`, and WalletScrutiny records reproducibility per artifact rather than applying one artifact's result to every file in a release.

This change deliberately creates the Windows ZIP **before** signing either Wasabi executable. The ZIP therefore retains the same unsigned deterministic build outputs as before this change. Only after the ZIP is closed are the two entry-point executables signed in the staging directory and harvested into the MSI.

Consequently:

- the portable Windows ZIP remains the artifact suitable for byte-level reproducibility checks;
- the MSI and its installed entry-point executables gain Authenticode publisher and integrity information;
- the signed MSI payload is not expected to be byte-for-byte identical to an independently built unsigned executable.

Wasabi's current deterministic-build guide compares an independent build with files installed from the MSI. For releases containing this change, that comparison must instead use the portable Windows ZIP or explicitly normalize Authenticode signatures; otherwise the two signed entry-point executables will differ by design.

## Implementation

- Add a `sign_windows_file` helper around the existing AzureSignTool invocation.
- Create the portable ZIP from the unsigned deterministic outputs.
- Sign the renamed desktop and daemon entry points immediately before WiX harvesting.
- Verify each EXE and the final MSI with `Get-AuthenticodeSignature`; any status other than `Valid` fails the release.
- Keep shell tracing disabled only for the command that receives the Azure credentials.
- Leave bundled third-party executables unchanged.

## Test plan

- [x] `C:\Program Files\Git\bin\bash.exe -n Contrib/release.sh`
- [x] `git diff --check upstream/master...HEAD`
- [x] Confirm ZIP creation precedes both executable-signing calls in `Contrib/release.sh`.
- [ ] Run the complete `wininstaller` signing flow in the release workflow (requires the Azure Key Vault secrets).

## References

- [Wasabi deterministic-build guide](https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md)
- [WalletScrutiny verification model](https://github.com/WalletScrutiny/WalletScrutinyCom/blob/master/docs/verifications.md#artifact-level-verdicts)
- [Microsoft app certification process for MSI/EXE apps](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/msi/app-certification-process)
- [Microsoft Authenticode digital signatures](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/authenticode)
- [Microsoft guidance on timestamping Authenticode signatures](https://learn.microsoft.com/en-us/windows/win32/seccrypto/time-stamping-authenticode-signatures)
