### PR TITLE
Fix flaky Arena client coinjoin tests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -170,7 +170,6 @@ public class ArenaClientTests
 			Task.FromResult(BitcoinFactory.CreateTransaction());
 
 		using Arena arena = await ArenaBuilder.From(config).With(mockRpc).CreateAndStartAsync(round);
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 
 		using var memoryCache = new MemoryCache(new MemoryCacheOptions());
 		var idempotencyRequestCache = new IdempotencyRequestCache(memoryCache);
@@ -204,7 +203,7 @@ public class ArenaClientTests
 
 		var inputRegistrationResponse = await inputRegistrationResponseTask;
 		var aliceId = inputRegistrationResponse.Value;
-		var connectionConfirmationResponse1Task = aliceArenaClient.ConfirmConnectionAsync(
+		var connectionConfirmationResponse1 = await aliceArenaClient.ConfirmConnectionAsync(
 			round.Id,
 			aliceId,
 			amountsToRequest,
@@ -212,13 +211,13 @@ public class ArenaClientTests
 			inputRegistrationResponse.IssuedAmountCredentials,
 			inputRegistrationResponse.IssuedVsizeCredentials,
 			CancellationToken.None);
+		Assert.False(connectionConfirmationResponse1.Value);
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 		Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
 
 		// Phase: Connection Confirmation
-		var connectionConfirmationResponse1 = await connectionConfirmationResponse1Task;
-		var connectionConfirmationResponse2Task = aliceArenaClient.ConfirmConnectionAsync(
+		var connectionConfirmationResponse2 = await aliceArenaClient.ConfirmConnectionAsync(
 			round.Id,
 			aliceId,
 			amountsToRequest,
@@ -226,6 +225,7 @@ public class ArenaClientTests
 			connectionConfirmationResponse1.IssuedAmountCredentials,
 			connectionConfirmationResponse1.IssuedVsizeCredentials,
 			CancellationToken.None);
+		Assert.True(connectionConfirmationResponse2.Value);
 
 		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
 
@@ -238,7 +238,6 @@ public class ArenaClientTests
 			config.CoordinatorIdentifier,
 			wabiSabiApi);
 
-		var connectionConfirmationResponse2 = await connectionConfirmationResponse2Task;
 		var reissuanceResponse = await bobArenaClient.ReissueCredentialAsync(
 			round.Id,
 			amountsToRequest,


### PR DESCRIPTION
## Summary

- remove the redundant Arena trigger immediately after startup
- await each connection-confirmation request before advancing the Arena
- assert the expected two-step confirmation responses

## Root cause

The test triggered the Arena while its startup pass could still be active, which could queue an additional pass. At the same time, both connection-confirmation requests were started without being awaited.

Depending on scheduling, the first request could be processed after the round entered connection confirmation. The queued Arena pass would then observe the only Alice as confirmed and advance directly to output registration before the test asserted the intermediate phase.

The same race affects both the P2WPKH and P2TR variants, although P2TR was the variant repeatedly observed failing in CI.

## Testing

- reproduced the original P2TR failure locally: expected ConnectionConfirmation, actual OutputRegistration
- ran both full-coinjoin variants 20 consecutive times: 40/40 passed
- ran the complete ArenaClientTests class: 4/4 passed