### PR TITLE
Rename toggle to "Display control box at 100% privacy"

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinStateViewModel.cs
@@ -118,7 +118,7 @@ public partial class CoinJoinStateViewModel : ViewModelBase
 			.Do(_ => _stateMachine.Fire(Trigger.PendingPaymentsChanged))
 			.Subscribe();
 
-		// Same refresh when the "pay in coinjoin regardless of anonymity score" toggle flips.
+		// Same refresh when the "display control box at 100%" toggle flips.
 		wallet.Settings.WhenAnyValue(x => x.AllowPaymentsRegardlessOfAnonScore)
 			.Skip(1)
 			.ObserveOn(RxApp.MainThreadScheduler)

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
@@ -53,8 +53,8 @@
       <ToggleSwitch IsChecked="{Binding NonPrivateCoinIsolation}" Command="{Binding SetNonPrivateCoinIsolationCommand}" />
     </DockPanel>
 
-    <DockPanel ToolTip.Tip="When enabled, payments in coinjoin can be funded with private coins, so you can pay without mixing non-private coins first. Disable it to save fees.">
-      <TextBlock Text="Pay in coinjoin regardless of anonymity score" />
+    <DockPanel ToolTip.Tip="When enabled, the control box will be displayed even if you reach 100% privacy.">
+      <TextBlock Text="Display control box at 100% privacy" />
       <ToggleSwitch IsChecked="{Binding AllowPaymentsRegardlessOfAnonScore}" Command="{Binding SetAllowPaymentsRegardlessOfAnonScoreCommand}" />
     </DockPanel>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletCoinJoinSettingsView.axaml
@@ -53,11 +53,6 @@
       <ToggleSwitch IsChecked="{Binding NonPrivateCoinIsolation}" Command="{Binding SetNonPrivateCoinIsolationCommand}" />
     </DockPanel>
 
-    <DockPanel ToolTip.Tip="When enabled, the control box will be displayed even if you reach 100% privacy.">
-      <TextBlock Text="Display control box at 100% privacy" />
-      <ToggleSwitch IsChecked="{Binding AllowPaymentsRegardlessOfAnonScore}" Command="{Binding SetAllowPaymentsRegardlessOfAnonScoreCommand}" />
-    </DockPanel>
-
     <DockPanel>
       <TextBlock Text="Anonymity score target" ToolTip.Tip="Minimum anonymity score to consider a coin private." />
       <TextBox Classes="standalone" Name="AnonScoreTargetTextBox" Text="{Binding AnonScoreTarget}" DockPanel.Dock="Right" Watermark="Choose between 2 and 300." MaxLength="3" />
@@ -68,6 +63,11 @@
     <DockPanel>
       <TextBlock Text="Automatically start coinjoin" />
       <ToggleSwitch IsChecked="{Binding AutoCoinJoin}" Command="{Binding SetAutoCoinJoin}" />
+    </DockPanel>
+
+    <DockPanel ToolTip.Tip="When enabled, the control box will be displayed even if you reach 100% privacy.">
+      <TextBlock Text="Display control box at 100% privacy" />
+      <ToggleSwitch IsChecked="{Binding AllowPaymentsRegardlessOfAnonScore}" Command="{Binding SetAllowPaymentsRegardlessOfAnonScoreCommand}" />
     </DockPanel>
 
     <DockPanel>


### PR DESCRIPTION
Currently, if you disable the "Pay in coinjoin regardless of anonymity score", it does not really prohibit non-private coins from joining a round, as said in here: https://github.com/WalletWasabi/WalletWasabi/issues/14970#issuecomment-5389717827. 

I propose this temporary modification since v2.8.2 is soon to be released. This will not trick any whale into believing that payments will not be funded using non-private coins. 

In the future (v2.9.0), the protection is ensured by https://github.com/WalletWasabi/WalletWasabi/pull/14983.