### PR TITLE
Fix remaining Arena client startup race

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -169,7 +169,7 @@ public class ArenaClientTests
 		mockRpc.OnGetRawTransactionAsync = (_, _) =>
 			Task.FromResult(BitcoinFactory.CreateTransaction());
 
-		using Arena arena = await ArenaBuilder.From(config).With(mockRpc).CreateAndStartAsync(round);
+		using Arena arena = ArenaBuilder.From(config).With(mockRpc).Create(round);
 
 		using var memoryCache = new MemoryCache(new MemoryCacheOptions());
 		var idempotencyRequestCache = new IdempotencyRequestCache(memoryCache);
@@ -213,7 +213,12 @@ public class ArenaClientTests
 			CancellationToken.None);
 		Assert.False(connectionConfirmationResponse1.Value);
 
-		await arena.TriggerAndWaitRoundAsync(TimeSpan.FromMinutes(1));
+		EventAwaiter<TimeSpan> initialArenaRound = new(
+			h => arena.Tick += h,
+			h => arena.Tick -= h);
+		using var initialArenaRoundTimeout = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+		await arena.StartAsync(initialArenaRoundTimeout.Token);
+		await initialArenaRound.WaitAsync(initialArenaRoundTimeout.Token);
 		Assert.Equal(Phase.ConnectionConfirmation, round.Phase);
 
 		// Phase: Connection Confirmation


### PR DESCRIPTION
## Summary

- construct the test Arena without starting its background runner
- perform the initial connection confirmation deterministically during input registration
- subscribe before startup and await the automatic initial Arena pass instead of triggering an additional pass

## Root cause

The previous fix in #14979 removed the manually queued startup pass and awaited both confirmation requests, but the automatic BackgroundService startup pass could still race with input registration. Because the test round accepts only one input, that pass can advance the round to connection confirmation before the first confirmation request. The request then correctly returns true while the test expects false.

This change establishes explicit ordering without delays or retries: the first request completes before Arena starts, and the test observes the startup Tick before checking the next phase.

## Testing

- Release build succeeded with zero warnings and zero errors
- ArenaClientTests passed 20 consecutive class runs: 80/80 test executions
- broader unit run excluding the unrelated ReleaseDownloaderTests issue: 998 passed; three local HWI enumeration cases failed because the local bridge returned entries without a model token