### PR TITLE
PaymentBatch: Never requeue a signed coinjoin payment

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/PaymentBatchTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/PaymentBatchTests.cs
@@ -121,33 +121,23 @@ public class PaymentBatchTests
 		Assert.True(paymentBatch.AreThereUncertainPayments);
 	}
 
-	/// <summary>
-	/// Verifies that uncertain payments timeout and move back to pending after the timeout period.
-	/// </summary>
 	[Fact]
-	public void UncertainPaymentsTimeoutAfterWaiting()
+	public void SignedPaymentsAreNotMovedBackToPending()
 	{
 		var paymentBatch = new PaymentBatch();
+		var roundParameters = WabiSabiFactory.CreateRoundParameters(new WabiSabiConfig());
 		var destination = GetNewSegwitAddress();
 		var amount = Money.Coins(0.1m);
 
-		// Add payment and move to uncertain state
 		paymentBatch.AddPayment(destination, amount);
-		var payments = paymentBatch.GetPayments().ToArray();
-		paymentBatch.MovePaymentsToInProgress(payments, uint256.One);
-		var signedTxId = CreateTransactionWithOutput(destination.ScriptPubKey, amount).GetHash();
-		paymentBatch.MovePaymentsToSigned(signedTxId);
+		paymentBatch.MovePaymentsToInProgress(paymentBatch.GetPayments().ToArray(), uint256.One);
+		paymentBatch.MovePaymentsToSigned(CreateTransactionWithOutput(destination.ScriptPubKey, amount).GetHash());
 
-		Assert.True(paymentBatch.AreThereUncertainPayments);
+		paymentBatch.MovePaymentsToPending();
+
 		Assert.False(paymentBatch.AreTherePendingPayments);
-
-		// Timeout should not move payments back immediately (timeout is 3 minutes)
-		paymentBatch.TimeoutUncertainPayments();
 		Assert.True(paymentBatch.AreThereUncertainPayments);
-
-		// Note: To fully test the timeout, we would need to mock DateTimeOffset.UtcNow
-		// or wait 3 minutes. For now, we verify the method doesn't crash and
-		// doesn't immediately move payments back.
+		Assert.Equal(0, paymentBatch.GetBestPaymentSet(Money.Coins(1m), 1000, roundParameters).PaymentCount);
 	}
 
 	/// <summary>

--- a/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
+++ b/WalletWasabi/WabiSabi/Client/Batching/PaymentBatch.cs
@@ -14,10 +14,6 @@ namespace WalletWasabi.WabiSabi.Client.Batching;
 // payments are moved to finished or back to pending state.
 public class PaymentBatch
 {
-	/// Time to wait before considering an uncertain payment as failed.
-	/// This should be longer than CoinRefrigerator's freeze time
-	private static readonly TimeSpan UncertainPaymentTimeout = TimeSpan.FromMinutes(3);
-
 	private readonly List<Payment> _payments = new();
 	private readonly Lock _syncObj = new();
 	private IEnumerable<Payment> PendingPayments => GetPayments().Where(p => p.State is PendingPayment);
@@ -96,13 +92,8 @@ public class PaymentBatch
 	public void MovePaymentsToFinished(uint256 txId) =>
 		MovePaymentsTo(InProgressPayments, payment => payment with { State = new FinishedPayment(payment.State, txId) });
 
-	public void MovePaymentsToPending()
-	{
-		// Move both in-progress and signed payments back to pending.
-		// This handles both: round failure before signing, and round failure after signing.
+	public void MovePaymentsToPending() =>
 		MovePaymentsTo(InProgressPayments, payment => payment with { State = new PendingPayment(payment.State) });
-		MovePaymentsTo(SignedPayments, payment => payment with { State = new PendingPayment(payment.State) });
-	}
 
 	public void MovePaymentsToSigned(uint256 transactionId) =>
 		MovePaymentsTo(InProgressPayments, payment => payment with
@@ -133,34 +124,6 @@ public class PaymentBatch
 		}
 
 		return resolved;
-	}
-
-	/// <summary>
-	/// Moves uncertain payments back to pending state if they have timed out.
-	/// This should be called periodically to handle cases where the coinjoin failed
-	/// but no matching transaction was ever found.
-	/// </summary>
-	public void TimeoutUncertainPayments()
-	{
-		var uncertainPayments = SignedPayments.ToArray();
-		foreach (var payment in uncertainPayments)
-		{
-			if (payment.State is not SignedUnknownPayment uncertainState)
-			{
-				continue;
-			}
-
-			var elapsed = DateTimeOffset.UtcNow - uncertainState.Timestamp;
-			if (elapsed >= UncertainPaymentTimeout)
-			{
-				Logger.LogInfo($"Payment {payment.Id} timed out after {elapsed.TotalSeconds:F0}s - no matching transaction found, moving back to pending.");
-				lock (_syncObj)
-				{
-					_payments.Remove(payment);
-					_payments.Add(payment with { State = new PendingPayment(uncertainState) });
-				}
-			}
-		}
 	}
 
 	public bool AreTherePendingPayments => PendingPayments.Any();

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Manager/CoinJoinManager.cs
@@ -436,13 +436,6 @@ public class CoinJoinManager : BackgroundService
 			// Updates coinjoin client states.
 			var wallets = await _getWalletsAsync().ConfigureAwait(false);
 
-			// Timeout any uncertain payments that have been waiting too long.
-			// This moves payments back to pending if no matching transaction was found.
-			foreach (var wallet in wallets)
-			{
-				wallet.BatchedPayments.TimeoutUncertainPayments();
-			}
-
 			_state.CoinJoinClientStates = GetCoinJoinClientStates(wallets);
 			_state.CoinsInCriticalPhase = GetCoinsInCriticalPhase(wallets);
 


### PR DESCRIPTION
Once a payment is signed it must not go back to pending, even if the round ending is unknown or Bitcoin is unreachable. Otherwise the next coinjoin pays it again with other coins.