### PR TITLE
Prevent throwing wen reorg'ed chain is shorter

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Services/FilterProvidersTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/FilterProvidersTests.cs
@@ -54,6 +54,43 @@ public class FilterProvidersTests
 		Assert.Equal(100u, newFilters.Filters[^1].Header.Height.Height);
 	}
 
+	[Fact]
+	public async Task BitcoinRpcProviderHandlesPartialBlockHashFailures()
+	{
+		var blockHashes = Enumerable.Range(1, 100)
+			.ToDictionary(x => x, x => new uint256((ulong)x));
+
+		MockRpcClient rpc = new()
+		{
+			Network = Network.Main,
+			OnGetBlockCountAsync = () => Task.FromResult(100),
+			OnGetBlockHashAsync = height =>
+			{
+				// Simulate reorg: blocks 51-100 no longer exist
+				if (height > 50)
+				{
+					return Task.FromException<uint256>(
+						new RPCException(RPCErrorCode.RPC_INVALID_PARAMETER, "Block height out of range", null));
+				}
+				return Task.FromResult(blockHashes[height]);
+			},
+			OnGetBlockFilterAsync = blockHash => Task.FromResult(CreateBlockFilter(blockHash))
+		};
+
+		using CancellationTokenSource testCts = new(TimeSpan.FromMinutes(1));
+
+		var genesisHash = Network.Main.GetGenesis().GetHash();
+		var provider = FilterProviders.CreateBitcoinRpcFilterProvider(rpc, new ConcurrentChain(Network.Main));
+		var result = await provider(fromHeight: 0, fromHash: genesisHash, testCts.Token);
+
+		Assert.True(result.IsOk);
+		var newFilters = Assert.IsType<FiltersResponse.NewFiltersAvailable>(result.Value);
+		// Should only get 50 filters (the ones that succeeded)
+		Assert.Equal(50, newFilters.Filters.Length);
+		Assert.Equal(1u, newFilters.Filters[0].Header.Height.Height);
+		Assert.Equal(50u, newFilters.Filters[^1].Header.Height.Height);
+	}
+
 	private static BlockFilter CreateBlockFilter(uint256 blockHash) =>
 		new(new GolombRiceFilter(DummyFilterData, 20, 1 << 20), blockHash);
 }

--- a/WalletWasabi/Services/Synchronizer.cs
+++ b/WalletWasabi/Services/Synchronizer.cs
@@ -69,7 +69,11 @@ public static class FilterProviders
 			.ToArray();
 		await batchClient.SendBatchAsync(cancellationToken).ConfigureAwait(false);
 
-		var blockHashes = await Task.WhenAll(blockHashTasks).ConfigureAwait(false);
+		var blockHashes = blockHashTasks
+			.Where(t => t.IsCompletedSuccessfully)
+			.Select(t => t.Result)
+			.ToArray();
+
 		return ((uint)currentHeight, blockHashes);
 	}
 


### PR DESCRIPTION
In case there is a deep reorg where the chain with more proof of work is shorter than the losing branch at the moment that the Synchronizer requests the block hashes, prevent it from failing with "Block height out of range". 