### PR TITLE
UnitTest: Stabilize WabiSabi idempotency integration test

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -78,8 +78,19 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 
 	public async Task<ArenaClient> CreateArenaClientAsync(WabiSabiHttpApiClient wabiSabiHttpApiClient)
 	{
-		var rounds = (await wabiSabiHttpApiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None)).RoundStates;
-		var round = rounds.First(x => x.CoinjoinState is ConstructionState);
+		using CancellationTokenSource timeout = new(TimeSpan.FromSeconds(30));
+		RoundState? round;
+		do
+		{
+			var rounds = (await wabiSabiHttpApiClient.GetStatusAsync(RoundStateRequest.Empty, timeout.Token)).RoundStates;
+			round = rounds.FirstOrDefault(x => x.CoinjoinState is ConstructionState);
+			if (round is null)
+			{
+				await Task.Delay(50, timeout.Token);
+			}
+		}
+		while (round is null);
+
 		var arenaClient = new ArenaClient(
 			round.CreateAmountCredentialClient(InsecureRandom.Instance),
 			round.CreateVsizeCredentialClient(InsecureRandom.Instance),

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -11,6 +11,7 @@ using WalletWasabi.BitcoinRpc;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.WabiSabi.Client.CoinJoin.Client;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
@@ -541,13 +542,18 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				services.AddSingleton<IRPCClient>(s => rpc);
 			})).CreateClient();
 
-		using var stutteredHttpClient = new StuttererHttpClient(httpClient);
-		var apiClient = await _apiApplicationFactory.CreateArenaClientAsync(stutteredHttpClient);
+		var apiClient = await _apiApplicationFactory.CreateArenaClientAsync(httpClient);
 		var rounds = (await apiClient.GetStatusAsync(RoundStateRequest.Empty, CancellationToken.None)).RoundStates;
 		var round = rounds.First(x => x.CoinjoinState is ConstructionState);
+		using var stutteredHttpClient = new StuttererHttpClient(httpClient);
+		var stutteredApiClient = new ArenaClient(
+			apiClient.AmountCredentialClient,
+			apiClient.VsizeCredentialClient,
+			apiClient.CoordinatorIdentifier,
+			_apiApplicationFactory.CreateWabiSabiHttpApiClient(stutteredHttpClient));
 
 		var ownershipProof = WabiSabiFactory.CreateOwnershipProof(signingKey, round.Id);
-		var response = await apiClient.RegisterInputAsync(round.Id, coinToRegister.Outpoint, ownershipProof, CancellationToken.None);
+		var response = await stutteredApiClient.RegisterInputAsync(round.Id, coinToRegister.Outpoint, ownershipProof, CancellationToken.None);
 
 		Assert.NotEqual(Guid.Empty, response.Value);
 	}


### PR DESCRIPTION
## Problem

The fork-only matrix soak in #74 reproduced two failures of WabiSabiHttpApiIntegrationTests.RegisterCoinIdempotencyAsync on macOS ARM64:

- the fixture sometimes queried status before the Arena had published a construction round, so First(...) threw
- StuttererHttpClient duplicated every request used during setup, including status requests whose round-state response can legitimately change between calls

The test is meant to verify that duplicate input registration is idempotent. Duplicating changing setup/status requests adds an unrelated timing dependency.

## Change

- wait up to 30 seconds for the fixture to observe a construction round
- create the normal Arena client and query status through the normal HTTP client
- apply StuttererHttpClient only to the input-registration client used by the idempotency assertion

## Why this approach

The fixture now waits for the state it requires with a bounded timeout instead of assuming Arena scheduling. Fault injection is limited to the operation under test, so the test still exercises a genuinely duplicated registration request without requiring two dynamic status responses to be identical.

This changes test infrastructure only; production behavior is untouched.

## Verification

- focused test passed 20/20 local repetitions on current upstream/master
- after the combined fixes were applied in #74, five consecutive complete CI runs passed on Linux x64, Windows x64, macOS x64, and macOS ARM64