### PR TITLE
UnitTest: Handle missing Windows startup registry key

### DIFF
--- a/WalletWasabi.Fluent/Helpers/WindowsStartupHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/WindowsStartupHelper.cs
@@ -25,7 +25,19 @@ public static class WindowsStartupHelper
 			throw new InvalidOperationException($"Path: {pathToExeFile} does not exist.");
 		}
 
-		using RegistryKey key = Registry.CurrentUser.OpenSubKey(KeyPath, writable: true) ?? throw new InvalidOperationException("Registry operation failed.");
+		using RegistryKey? key = runOnSystemStartup
+			? Registry.CurrentUser.CreateSubKey(KeyPath, writable: true)
+			: Registry.CurrentUser.OpenSubKey(KeyPath, writable: true);
+
+		if (key is null)
+		{
+			if (runOnSystemStartup)
+			{
+				throw new InvalidOperationException("Registry operation failed.");
+			}
+
+			return;
+		}
 
 		var existingPath = key.GetValue(nameof(WalletWasabi));
 		if (existingPath is null && runOnSystemStartup)

--- a/WalletWasabi.Tests/Helpers/WindowsStartupTestHelper.cs
+++ b/WalletWasabi.Tests/Helpers/WindowsStartupTestHelper.cs
@@ -14,8 +14,8 @@ public class WindowsStartupTestHelper
 
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
-			RegistryKey? registryKey = Registry.CurrentUser.OpenSubKey(PathToRegistyKey, false) ?? throw new InvalidOperationException("Registry operation failed.");
-			result = registryKey.GetValueNames().Contains(nameof(WalletWasabi));
+			using RegistryKey? registryKey = Registry.CurrentUser.OpenSubKey(PathToRegistyKey, false);
+			result = registryKey?.GetValueNames().Contains(nameof(WalletWasabi)) is true;
 		}
 
 		return result;


### PR DESCRIPTION
## Problem

The fork-only matrix soak in #74 reproduced StartWasabiOnSystemStartupTests.ModifyStartupOnDifferentSystemsTestAsync failing on a fresh Windows runner.

WindowsStartupHelper opened HKCU\Software\Microsoft\Windows\CurrentVersion\Run and threw when the key did not exist. The key is not guaranteed to exist in a clean user profile, and disabling an already-disabled startup entry should be a successful no-op.

## Change

- create the Run key when enabling startup
- treat a missing Run key as already disabled when disabling startup
- make the test helper report false when the key is absent

## Why this approach

The behavior follows the intended state transition directly: enabling ensures the storage location exists, while disabling is idempotent. It removes the clean-runner assumption without retries, sleeps, shared fixtures, or platform-specific test suppression.

The production change is limited to Windows startup registration; non-Windows behavior is unchanged.

## Verification

- focused Windows test passed 20/20 local repetitions on current upstream/master
- after the combined fixes were applied in #74, five consecutive complete CI runs passed on Linux x64, Windows x64, macOS x64, and macOS ARM64