### PR TITLE
fix: Do not treat lagging block headers as reorg

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Services/SynchronizerReorgTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/SynchronizerReorgTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using WalletWasabi.Backend.Models;
 using WalletWasabi.BitcoinP2p;
+using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -19,6 +20,44 @@ namespace WalletWasabi.Tests.UnitTests.Services;
 /// </summary>
 public class SynchronizerReorgTests(ITestOutputHelper output)
 {
+	[Fact]
+	public async Task P2pProvider_HeaderChainBehindCheckpoint_ReturnsAlreadyOnBestBlock()
+	{
+		var checkpoint = FilterCheckpoints.GetCheckpointForBirthday(700_000u, Network.Main);
+		var blockHeaders = new ConcurrentChain(Network.Main);
+		var filterHeaders = new FilterHeaderChain();
+		filterHeaders.AppendTip(checkpoint.Header);
+		var synchronizationState = new FilterSynchronizationState(blockHeaders, filterHeaders, checkpoint.Header.Height);
+
+		var result = await FilterProviders
+			.CreateBitcoinP2pFilterProvider(filterHeaders, blockHeaders, synchronizationState)
+			(checkpoint.Header.Height, checkpoint.Header.BlockHash, CancellationToken.None);
+
+		Proof($"P2P checkpoint={checkpoint.Header.BlockHash} filterHeight={checkpoint.Header.Height} headerHeight={blockHeaders.Tip.Height} got {Describe(result)} want AlreadyOnBestBlock");
+		Assert.True(result.IsOk);
+		Assert.IsType<FiltersResponse.AlreadyOnBestBlock>(result.Value);
+	}
+
+	[Fact]
+	public void IsReorg_BlockHeadersBehindFilterHeaders_ReturnsFalse()
+	{
+		var blockHeaders = new ConcurrentChain(Network.RegTest);
+		var blockHeader = Network.RegTest.Consensus.ConsensusFactory.CreateBlockHeader();
+		blockHeader.HashPrevBlock = blockHeaders.Tip.HashBlock;
+		blockHeaders.SetTip(new ChainedBlock(blockHeader, blockHeader.GetHash(), blockHeaders.Tip));
+
+		var anchorHeight = (uint)blockHeaders.Tip.Height;
+		var filterHeaders = new FilterHeaderChain();
+		filterHeaders.AppendTip(new SmartHeader(blockHeaders.Tip.HashBlock, new uint256(1u), anchorHeight, DateTimeOffset.UtcNow));
+		filterHeaders.AppendTip(new SmartHeader(new uint256(2u), new uint256(2u), anchorHeight + 1, DateTimeOffset.UtcNow));
+		var synchronizationState = new FilterSynchronizationState(blockHeaders, filterHeaders, anchorHeight);
+
+		var isReorg = synchronizationState.IsReorg(anchorHeight, blockHeaders.Tip.HashBlock);
+
+		Proof($"P2P filterHeight={filterHeaders.Tip!.Height} headerHeight={blockHeaders.Tip.Height} got reorg={isReorg} want false");
+		Assert.False(isReorg);
+	}
+
 	[Fact]
 	public async Task RpcProvider_OrphanedFilterTip_ReturnsBestBlockUnknown()
 	{

--- a/WalletWasabi/BitcoinP2p/FilterSynchronizationState.cs
+++ b/WalletWasabi/BitcoinP2p/FilterSynchronizationState.cs
@@ -411,10 +411,22 @@ public class FilterSynchronizationState
 				return false;
 			}
 
-			var anchorBlock = _blockHeaderChain.GetBlock((int)fromHeight);
-			if (anchorBlock is null || anchorBlock.HashBlock != fromHash)
+			if (_blockHeaderChain.Tip is not { } headerTip || headerTip.Height < fromHeight)
 			{
-				return MarkReorg($"Block {fromHash} at height {fromHeight} not found or mismatched in block header chain. Reorg detected.");
+				// The header chain is behind the stored tip, so it cannot contradict it.
+				return false;
+			}
+
+			var anchorBlock = _blockHeaderChain.GetBlock((int)fromHeight);
+			if (anchorBlock is null)
+			{
+				// A missing header is inconclusive. Wait for the header chain to catch up.
+				return false;
+			}
+
+			if (anchorBlock.HashBlock != fromHash)
+			{
+				return MarkReorg($"Hash mismatch at height {fromHeight}. Filter={fromHash}, Block={anchorBlock.HashBlock}. Reorg detected.");
 			}
 
 			var start = filterTip.Height;
@@ -434,7 +446,8 @@ public class FilterSynchronizationState
 				var block = _blockHeaderChain.GetBlock((int)h);
 				if (block is null)
 				{
-					return MarkReorg($"Missing block header at height {h}. Reorg detected.");
+					// A missing header is inconclusive. Wait for the header chain to catch up.
+					return false;
 				}
 
 				if (filterHeader.BlockHash != block.HashBlock)


### PR DESCRIPTION
fixes #15017

The issue reproduction is missing one prerequisite: the block-header chain must also be absent or behind the seeded checkpoint. (`BlockHeadersMain.dat` needs to be removed to reproduce this manually)

- first commit adds a regression test proving the issue
- second commit is the fix

