### PR TITLE
UnitTest: Stabilize CPFP provider scheduling

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Services/CpfpInfoProviderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/CpfpInfoProviderTests.cs
@@ -340,33 +340,21 @@ public class CpfpInfoProviderTests
 	{
 		// Arrange
 		using var cts = new CancellationTokenSource();
-		var cpfpJson = """{"effectiveFeePerVsize": 10.5, "fee": 1.0, "adjustedVsize": 100, "ancestors": []}""";
-		var requestReceived = false;
-
-		using var mockHttpClient = new MockHttpClient();
-		mockHttpClient.OnSendAsync = _ =>
+		var messageReceived = new TaskCompletionSource<CpfpInfoMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+		using var mailbox = CreateAndStartMailboxProcessor((message, _, _) =>
 		{
-			requestReceived = true;
-			return Task.FromResult(HttpResponseMessageEx.Ok(cpfpJson));
-		};
-
-		var httpClientFactory = new MockHttpClientFactory { OnCreateClient = _ => mockHttpClient };
-		var eventBus = new EventBus();
-		var handler = CpfpInfoUpdater.Create(httpClientFactory, Network.Main, eventBus);
-
-		using var mailbox = CreateAndStartMailboxProcessor(handler, cts.Token);
+			messageReceived.TrySetResult(message);
+			return Task.FromResult(Unit.Instance);
+		}, cts.Token);
 		var provider = new CpfpInfoProvider(mailbox);
 		var tx = BitcoinFactory.CreateSmartTransaction(height: Height.Mempool);
 
 		// Act
 		provider.ScheduleRequest(tx);
+		var message = await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-		// Wait for async processing (prefetch has random delay up to 10 seconds, but we can check cache)
-		await Task.Delay(100);
-
-		// Assert - message was posted (we can't easily verify prefetch completed due to random delay)
-		// But we can verify the provider doesn't throw
-		Assert.False(requestReceived);
+		// Assert
+		Assert.Same(tx, Assert.IsType<CpfpInfoMessage.PreFetchInfoForTransaction>(message).SmartTransaction);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Problem

The fork-only matrix soak in molnard/WalletWasabi#74 reproduced `CpfpInfoProviderTests.ScheduleRequest_PostsPreFetchMessage_AndProcessesItAsync` failing in the Nix/Linux test run.

The test scheduled a real randomized prefetch, waited 100 ms, and asserted that the HTTP request had not started. A legitimate random delay can be shorter than 100 ms, so the negative timing assertion could fail even when production behavior was correct.

## Fix

- replace the randomized updater/HTTP path with a mailbox handler that acknowledges receipt of `PreFetchInfoForTransaction`
- wait with a bounded timeout for that acknowledgement
- assert that the message contains the exact `SmartTransaction` passed to `ScheduleRequest`

## Why the JSON fixture was removed

The `cpfpJson` variable was deleted, not moved. It supplied the fake HTTP response returned by `MockHttpClient`. This test now observes the mailbox message directly instead of running the HTTP updater, so both the JSON fixture and the HTTP mock setup are no longer needed.

The coverage boundary is explicit:

- this test verifies that `ScheduleRequest(tx)` posts a `PreFetchInfoForTransaction` message containing the exact transaction
- existing updater/provider tests continue to exercise HTTP fetching, JSON parsing, and caching

The original test asserted that no HTTP request had started after 100 ms. It therefore did not verify that the JSON response was consumed or parsed. The revised test checks the scheduling contract directly; it does not claim to test the complete prefetch/HTTP path.

## Why this is stable

The test now verifies the actual scheduling contract through an observable synchronization point. It no longer depends on a sleep, random timing, retries, or runner speed. Production code is unchanged.

## Verification

- the initial mailbox-acknowledgement version passed 20/20 focused local repetitions and all 8 tests in the complete `CpfpInfoProviderTests` class
- that version was included in the molnard/WalletWasabi#74 stabilization soak, whose final state completed ten consecutive fully green runs across Nix/Linux, Linux x64, Windows x64, macOS x64, and macOS ARM64
- the subsequently minimized version in this PR passed the fork's [Build workflow](https://github.com/molnard/WalletWasabi/actions/runs/33507984290) at commit `4918aa49ccefeaefa069628bd2b0a02f5f1052c3`