### PR TITLE
UnitTest: Accept valid non-success blame result

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -367,7 +367,9 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		var resultBad = await badCoinsTask;
 		var resultOk = await coinJoinTask;
 
-		Assert.IsType<DisruptedCoinJoinResult>(resultBad);
+		// The mock acknowledges signatures without forwarding them to the coordinator.
+		// Its local result can be disrupted or failed, but it must never succeed.
+		Assert.IsNotType<SuccessfulCoinJoinResult>(resultBad);
 		Assert.IsType<SuccessfulCoinJoinResult>(resultOk);
 
 		var broadcastedTx = await broadcastedTxTcs.Task; // wait for the transaction to be broadcasted.


### PR DESCRIPTION
## Problem

The fork-only matrix soak in molnard/WalletWasabi#74 reproduced `WabiSabiHttpApiIntegrationTests.CoinJoinWithBlameRoundTestAsync` failing on Windows because the deliberately non-signing client returned `FailedCoinJoinResult` instead of `DisruptedCoinJoinResult`.

The test mock acknowledges signature requests without forwarding the signatures. Depending on coordinator timing, the non-signing client can therefore legitimately finish as either failed or disrupted. Both outcomes satisfy the behavior under test: that client must not report a successful CoinJoin.

## Fix

Replace the over-specified exact subtype assertion with an assertion that the deliberately non-signing client is not a `SuccessfulCoinJoinResult`.

The important checks remain strict:

- the honest client must return `SuccessfulCoinJoinResult`
- the broadcast transaction's inputs must exactly match the honest client's coins

## Why this is stable

The assertion now expresses the semantic invariant without depending on a race between two valid failure paths. It does not introduce retries, sleeps, broader exception handling, or production changes, and it cannot accept a false success.

## Verification

- focused test passed locally
- the same fix was exercised by the molnard/WalletWasabi#74 matrix soak; the final stabilization state completed ten consecutive fully green runs across Nix/Linux, Linux x64, Windows x64, macOS x64, and macOS ARM64