### PR TITLE
UnitTest: Stabilize blame-round phase timing

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -309,11 +309,11 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 					AllowP2trInputs = true,
 					AllowP2trOutputs = true,
 					MaxInputCountByRound = 2 * inputCount,
-					StandardInputRegistrationTimeout = TimeSpan.FromSeconds(10),
-					BlameInputRegistrationTimeout = TimeSpan.FromSeconds(10),
-					ConnectionConfirmationTimeout = TimeSpan.FromSeconds(10),
-					OutputRegistrationTimeout = TimeSpan.FromSeconds(10),
-					TransactionSigningTimeout = TimeSpan.FromSeconds(4 * inputCount),
+					StandardInputRegistrationTimeout = TimeSpan.FromSeconds(40),
+					BlameInputRegistrationTimeout = TimeSpan.FromSeconds(20),
+					ConnectionConfirmationTimeout = TimeSpan.FromSeconds(40),
+					OutputRegistrationTimeout = TimeSpan.FromSeconds(40),
+					TransactionSigningTimeout = TimeSpan.FromSeconds(20),
 					MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice)
 				})));
 


### PR DESCRIPTION
## Problem

The fork-only matrix soak in molnard/WalletWasabi#74 reproduced `WabiSabiHttpApiIntegrationTests.CoinJoinWithBlameRoundTestAsync` failing on Windows.

The honest client reached input registration after the test's short phase window had already closed, so all four inputs were rejected. The original 10-second phase limits were too narrow for a multi-client integration scenario on a slower hosted runner.

## Fix

Widen only this test's coordinator phase budgets:

- standard input registration: 40 seconds
- blame input registration: 20 seconds
- connection confirmation: 40 seconds
- output registration: 40 seconds
- transaction signing: 20 seconds

These are the proven values used by GingerWallet for the equivalent test. The test's bounded outer cancellation and its strict honest-client and broadcast-transaction assertions remain intact.

## Why this is stable

The fix gives legitimate protocol phases explicit bounded time instead of adding retries, arbitrary sleeps, or weakened success criteria. Production behavior is unchanged.

## Verification

- focused Windows test: 6/6 local repetitions
- the same fix was exercised by the molnard/WalletWasabi#74 matrix soak; the final stabilization state completed ten consecutive fully green runs across Nix/Linux, Linux x64, Windows x64, macOS x64, and macOS ARM64