### PR TITLE
UnitTest: Allow multi-client CoinJoin phase budget

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -385,8 +385,8 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		double faultInjectorMonkeyAggressiveness,
 		double delayInjectorMonkeyAggressiveness)
 	{
-		// Total test timeout.
-		using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+		// Allow the coordinator to complete all configured phases on slower CI runners.
+		using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 
 		const int NumberOfParticipants = 10;
 		const int NumberOfCoinsPerParticipant = 2;


### PR DESCRIPTION
## Problem

The fork-only matrix soak in molnard/WalletWasabi#74 reproduced `WabiSabiHttpApiIntegrationTests.MultiClientsCoinJoinTestAsync` failing on macOS ARM64 with `TaskCanceledException` at exactly two minutes.

The test's two-minute outer deadline was shorter than the legitimate combined coordinator phase budget and raced the clients' own timeout margin on the slower ARM runner.

## Fix

Increase only this integration test's outer cancellation deadline from two minutes to five minutes.

GingerWallet uses a ten-minute deadline for the equivalent scenario. Five minutes is deliberately narrower: it covers Wasabi's configured protocol phases while preserving a finite detector for genuine hangs.

## Why this is stable

The fix aligns the test-level deadline with the protocol time it permits. It does not retry a failed CoinJoin, suppress an assertion, or change production behavior.

## Verification

- focused test: 4/4 local repetitions
- the next macOS ARM64 matrix run passed
- the final stabilization state completed ten consecutive fully green runs across Nix/Linux, Linux x64, Windows x64, macOS x64, and macOS ARM64