### PR TITLE
[flaky tests] Call `ModuleInitializer.PatchTestNet` before tests run

### DIFF
--- a/WalletWasabi.IntegrationTests/BitcoinCore/Configuration/NetworkTranslator.cs
+++ b/WalletWasabi.IntegrationTests/BitcoinCore/Configuration/NetworkTranslator.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using NBitcoin;
 using WalletWasabi.Exceptions;
-using WalletWasabi.Helpers;
 
 namespace WalletWasabi.IntegrationTests.BitcoinCore.Configuration;
 

--- a/WalletWasabi.IntegrationTests/BitcoinCore/Tests/ConfigTranslatorTests.cs
+++ b/WalletWasabi.IntegrationTests/BitcoinCore/Tests/ConfigTranslatorTests.cs
@@ -15,7 +15,8 @@ public class ConfigTranslatorTests
 		var translatorMain = new CoreConfigTranslator(config, Network.Main);
 		var translatorTest = new CoreConfigTranslator(config, Network.TestNet);
 		var translatorReg = new CoreConfigTranslator(config, Network.RegTest);
-		Assert.Null(translatorMain.TryGetRpcUser());
+
+        Assert.Null(translatorMain.TryGetRpcUser());
 		Assert.Null(translatorTest.TryGetRpcUser());
 		Assert.Null(translatorReg.TryGetRpcUser());
 

--- a/WalletWasabi.IntegrationTests/ModuleInitializer.cs
+++ b/WalletWasabi.IntegrationTests/ModuleInitializer.cs
@@ -1,9 +1,6 @@
-using System.IO;
 using System.Runtime.CompilerServices;
-using WalletWasabi.Logging;
-using WalletWasabi.Tests.Helpers;
 
-namespace WalletWasabi.Tests;
+namespace WalletWasabi.IntegrationTests;
 
 public static class ModuleInitializer
 {
@@ -12,7 +9,5 @@ public static class ModuleInitializer
 	{
 		// Make sure that WalletWasabi.ModuleInitializer is initialized before running the tests.
 		RuntimeHelpers.RunClassConstructor(typeof(WalletWasabi.ModuleInitializer).TypeHandle);
-
-		Logger.Configure(Path.Combine(Common.DataDir, "Logs.txt"), LogLevel.Info, [LogMode.Debug, LogMode.File]);
 	}
 }

--- a/WalletWasabi/ModuleInitializer.cs
+++ b/WalletWasabi/ModuleInitializer.cs
@@ -1,10 +1,10 @@
-namespace WalletWasabi;
 using System.Collections.Concurrent;
 using System.Reflection;
-using NBitcoin;
 using System.Runtime.CompilerServices;
 
-class ModuleInitializer
+namespace WalletWasabi;
+
+public static class ModuleInitializer
 {
 #pragma warning disable CA2255 // The 'ModuleInitializer' attribute should not be used in libraries -- Moving this initializer to the apps did not work (https://github.com/WalletWasabi/WalletWasabi/pull/14364).
 	[ModuleInitializer]
@@ -25,10 +25,10 @@ class ModuleInitializer
 		// Get the internal dictionary
 		var networks = networksField!.GetValue(bitcoinInstance) as ConcurrentDictionary<ChainName, Network>;
 
-		var testnet4 = networks![new ChainName("testnet4")];
+		var testnet4 = networks![Network.TestNet4.ChainName];
 
-		// Replaces testnet by testnet4 network
-		networks[new ChainName("testnet")] = testnet4;
+		// Replaces TestNet by TestNet4 network
+		networks[Network.TestNet.ChainName] = testnet4;
 
 		var otherAliasesField = typeof(Network)
 			.GetField("_OtherAliases", BindingFlags.NonPublic | BindingFlags.Static);


### PR DESCRIPTION
This error

```
failed WalletWasabi.IntegrationTests.BitcoinCore.Tests.ConfigTranslatorTests.TryGetRpcUserTests (50ms)
WalletWasabi> WalletWasabi.Exceptions.NotSupportedNetworkException : Network not supported: TestNet.
WalletWasabi> from /build/garlyvzmk8zsq5glmab6m9mwc1z3bmv0-source/WalletWasabi.IntegrationTests/bin/Release/net10.0/WalletWasabi.IntegrationTests.dll (net10.0|x64)
WalletWasabi> Xunit.MicrosoftTestingPlatform.XunitException: WalletWasabi.Exceptions.NotSupportedNetworkException : Network not supported: TestNet.
```

happens [often](https://github.com/WalletWasabi/WalletWasabi/pull/15018#issuecomment-5510135842) on CI. This PR fixes that.