### PR TITLE
UnitTest: Automatically update round state in tests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Services/UpdateManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Services/UpdateManagerTests.cs
@@ -244,7 +244,21 @@ public class TesteabletNostrClient : INostrClient
 public class RoundStateUpdaterForTesting
 {
 	public static MailboxProcessor<RoundUpdateMessage> Create(IWabiSabiApiRequestHandler api, CancellationToken? cancellationToken = null) =>
-		Spawn($"RoundStateUpdater-{Random.Shared.Next()}", EventDriven(
-			new RoundsState(DateTime.UtcNow, TimeSpan.FromSeconds(0), new Dictionary<uint256, RoundState>(), ImmutableList<RoundStateAwaiter>.Empty),
-			RoundStateUpdater.Create(api)), cancellationToken);
+		Create(api, cancellationToken, autoUpdate: true);
+
+	public static MailboxProcessor<RoundUpdateMessage> CreateManual(IWabiSabiApiRequestHandler api, CancellationToken? cancellationToken = null) =>
+		Create(api, cancellationToken, autoUpdate: false);
+
+	private static MailboxProcessor<RoundUpdateMessage> Create(IWabiSabiApiRequestHandler api, CancellationToken? cancellationToken, bool autoUpdate) =>
+		Spawn<RoundUpdateMessage>($"RoundStateUpdater-{Random.Shared.Next()}", async (mailbox, token) =>
+		{
+			// Stop the ticker when cancellation or disposal ends the worker.
+			await using var ticker = autoUpdate
+				? new Timer(_ => mailbox.Post(new RoundUpdateMessage.UpdateMessage(DateTime.UtcNow)), null, TimeSpan.Zero, TimeSpan.FromSeconds(1))
+				: null;
+			var process = EventDriven(
+				new RoundsState(DateTime.UtcNow, TimeSpan.Zero, new Dictionary<uint256, RoundState>(), ImmutableList<RoundStateAwaiter>.Empty),
+				RoundStateUpdater.Create(api));
+			await process(mailbox, token).ConfigureAwait(false);
+		}, cancellationToken);
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -7,7 +7,6 @@ using WalletWasabi.Coordinator.WabiSabi;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.Tests.UnitTests.Services;
-using WalletWasabi.Tests.UnitTests.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.CoinJoin.Client;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
@@ -282,15 +281,12 @@ public class StepOutputRegistrationTests
 		var task1a = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round1), arenaClient1, coin1a, keyChain1, roundStateProvider, token, token, token);
 		var task1b = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round1), arenaClient1, coin1b, keyChain1, roundStateProvider, token, token, token);
 
-		roundStateUpdater.Update();
 		while (Phase.ConnectionConfirmation != round1.Phase)
 		{
 			await arena.TriggerAndWaitRoundAsync(token);
 		}
 
-		void Update(Task _) => roundStateUpdater.Update();
-		Task updateTask = Task.Delay(TimeSpan.FromMilliseconds(100)).ContinueWith(Update);
-		await Task.WhenAll(task1a, task1b, updateTask);
+		await Task.WhenAll(task1a, task1b);
 		var aliceClient1a = await task1a;
 		var aliceClient1b = await task1b;
 
@@ -307,8 +303,7 @@ public class StepOutputRegistrationTests
 			await arena.TriggerAndWaitRoundAsync(token);
 		}
 
-		Task updateTask2 = Task.Delay(TimeSpan.FromMilliseconds(100)).ContinueWith(Update);
-		await Task.WhenAll(task2a, task2b, updateTask2);
+		await Task.WhenAll(task2a, task2b);
 		var aliceClient2a = await task2a;
 		var aliceClient2b = await task2b;
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -12,7 +12,6 @@ using WalletWasabi.Extensions;
 using WalletWasabi.Models;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.Tests.UnitTests.Services;
-using WalletWasabi.Tests.UnitTests.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Client;
 using WalletWasabi.WabiSabi.Client.RoundStateAwaiters;
 using WalletWasabi.WabiSabi.Coordinator.PostRequests;
@@ -77,7 +76,6 @@ internal class Participant
 
 		var apiClient = HttpClientFactory;
 		using var roundStateUpdater = RoundStateUpdaterForTesting.Create(apiClient("satoshi"));
-		await using var ticker = new Timer(_ => roundStateUpdater.Update(), 0, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
 		var roundStateProvider = new RoundStateProvider(roundStateUpdater);
 
 		var outputProvider = new OutputProvider(Wallet, RandomnessProviders.Insecure);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -17,7 +17,6 @@ using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using Xunit;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Tests.UnitTests.Services;
-using WalletWasabi.Tests.UnitTests.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Coordinator;
 using WalletWasabi.WabiSabi.Coordinator.Models;
 using WalletWasabi.WabiSabi.Coordinator.Rounds;
@@ -161,7 +160,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
 		using var roundStateUpdater = RoundStateUpdaterForTesting.Create(apiClient);
-		await using var ticker = new Timer(_ => roundStateUpdater.Update(), 0, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
 		var roundStateProvider = new RoundStateProvider(roundStateUpdater);
 
 		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(_ => apiClient, keyManager, roundStateProvider);
@@ -229,7 +227,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
 		using var roundStateUpdater = RoundStateUpdaterForTesting.Create(apiClient, cts.Token);
-		await using var ticker = new Timer(_ => roundStateUpdater.Update(), 0, TimeSpan.Zero, TimeSpan.FromSeconds(1));
 		var roundStateProvider = new RoundStateProvider(roundStateUpdater);
 
 		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(_=> apiClient, keyManager, roundStateProvider);
@@ -330,7 +327,6 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		var apiClient = _apiApplicationFactory.CreateWabiSabiHttpApiClient(coordinatorApp.CreateClient());
 
 		using var roundStateUpdater = RoundStateUpdaterForTesting.Create(apiClient, cts.Token);
-		using var ticker = new Timer(_ => roundStateUpdater.Update(), 0, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
 		var roundStateProvider = new RoundStateProvider(roundStateUpdater);
 
 		var roundState = await roundStateProvider.CreateRoundAwaiterAsync(roundState => roundState.Phase == Phase.InputRegistration, cts.Token);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -261,6 +261,8 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		}
 		else
 		{
+			// Task.WhenAny does not propagate cancellation or failures from the winning task.
+			// Await it so a timeout fails the test instead of passing without a blame round.
 			await blameRoundWaiterTask;
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -229,6 +229,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
 		using var roundStateUpdater = RoundStateUpdaterForTesting.Create(apiClient, cts.Token);
+		await using var ticker = new Timer(_ => roundStateUpdater.Update(), 0, TimeSpan.Zero, TimeSpan.FromSeconds(1));
 		var roundStateProvider = new RoundStateProvider(roundStateUpdater);
 
 		var coinJoinClient = WabiSabiFactory.CreateTestCoinJoinClient(_=> apiClient, keyManager, roundStateProvider);
@@ -257,6 +258,10 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			{
 				// ignore. There is a rare case for this
 			}
+		}
+		else
+		{
+			await blameRoundWaiterTask;
 		}
 	}
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/RoundStateUpdaterTests.cs
@@ -23,6 +23,23 @@ public class RoundStateUpdaterTests
 	private static readonly TimeSpan TestTimeOut = TimeSpan.FromMinutes(10);
 
 	[Fact]
+	public async Task UpdatesAutomaticallyAsync()
+	{
+		var roundState = RoundState.FromRound(WabiSabiFactory.CreateRound(cfg: new()));
+		var mockHttpClientFactory = MockHttpClientFactory.Create([
+			RoundStateResponseBuilder(roundState with { Phase = Phase.InputRegistration }),
+			RoundStateResponseBuilder(roundState with { Phase = Phase.OutputRegistration, CoinjoinState = roundState.CoinjoinState.GetStateFrom(1) })
+		]);
+		var apiClient = new WabiSabiHttpApiClient("identity", mockHttpClientFactory);
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+		using var roundStatusUpdater = RoundStateUpdaterForTesting.Create(apiClient, cts.Token);
+		var roundStatusProvider = new RoundStateProvider(roundStatusUpdater);
+
+		await roundStatusProvider.CreateRoundAwaiterAsync(roundState.Id, Phase.InputRegistration, cts.Token);
+		await roundStatusProvider.CreateRoundAwaiterAsync(roundState.Id, Phase.OutputRegistration, cts.Token);
+	}
+
+	[Fact]
 	public async Task RoundStateUpdaterTestsAsync()
 	{
 		var roundState1 = RoundState.FromRound(WabiSabiFactory.CreateRound(cfg: new()));
@@ -43,7 +60,7 @@ public class RoundStateUpdaterTests
 		var apiClient = new WabiSabiHttpApiClient("identity", mockHttpClientFactory);
 
 		using var roundStatusUpdaterCancellation = new CancellationTokenSource();
-		using var roundStatusUpdater = RoundStateUpdaterForTesting.Create(apiClient, roundStatusUpdaterCancellation.Token);
+		using var roundStatusUpdater = RoundStateUpdaterForTesting.CreateManual(apiClient, roundStatusUpdaterCancellation.Token);
 		var roundStatusProvider = new RoundStateProvider(roundStatusUpdater);
 
 		// At this point in time the RoundStateUpdater only knows about `round1` and then we can subscribe to
@@ -122,7 +139,7 @@ public class RoundStateUpdaterTests
 		]);
 		var apiClient = new WabiSabiHttpApiClient("identity", mockHttpClientFactory);
 
-		using var roundStatusUpdater = RoundStateUpdaterForTesting.Create(apiClient);
+		using var roundStatusUpdater = RoundStateUpdaterForTesting.CreateManual(apiClient);
 		var roundStatusProvider = new RoundStateProvider(roundStatusUpdater);
 
 		// At this point in time the RoundStateUpdater only knows about `round1` and then we can subscribe to
@@ -172,7 +189,7 @@ public class RoundStateUpdaterTests
 		]);
 		var apiClient = new WabiSabiHttpApiClient("identity", mockHttpClientFactory);
 
-		using var roundStatusUpdater = RoundStateUpdaterForTesting.Create(apiClient);
+		using var roundStatusUpdater = RoundStateUpdaterForTesting.CreateManual(apiClient);
 		var roundStatusProvider = new RoundStateProvider(roundStatusUpdater);
 
 		// At this point in time the RoundStateUpdater only knows about `round1` and then we can subscribe to
@@ -209,7 +226,7 @@ public class RoundStateUpdaterTests
 		]);
 		var apiClient = new WabiSabiHttpApiClient("identity", mockHttpClientFactory);
 
-		using var roundStatusUpdater = RoundStateUpdaterForTesting.Create(apiClient);
+		using var roundStatusUpdater = RoundStateUpdaterForTesting.CreateManual(apiClient);
 		var roundStatusProvider = new RoundStateProvider(roundStatusUpdater);
 		using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
 


### PR DESCRIPTION
`RoundStateUpdaterForTesting` created the worker but did not send update messages. Each test had to provide a timer or call `Update()` itself. Without this, some tests waited 30 seconds for the client's connection-confirmation fallback. The output-rejection test could also time out and still pass because it did not await the completed blame-round waiter.

Make the shared helper own a one-second timer and stop it when the worker exits. Remove the separate timers and delayed update calls, while keeping `CreateManual` for tests that control updates explicitly. Await the winning blame-round waiter so cancellation fails the output-rejection test.

Found while investigating the failures discussed in closed #15023, where [Lucas NACKed the timeout increase](https://github.com/WalletWasabi/WalletWasabi/pull/15023#issuecomment-5519659989).

- Same 29 tests, same machine: 6m30s → 2m44s (58% faster).
- Twelve affected tests, combined durations: 388s → 30s.
- Output-rejection test: 90s → 31s. Address-reuse test: 1.5s slower.
- GitHub Test steps: 1m35s–2m42s faster across four platforms. Single before/after comparison; runner variation applies.

