### PR TITLE
Mark payments as signed before posting the witnesses

### DIFF
--- a/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
+++ b/WalletWasabi.Client/Rpc/WasabiJsonRpcService.cs
@@ -316,6 +316,14 @@ public class WasabiJsonRpcService : IJsonRpcService
 						});
 						break;
 
+					case SignedUnknownPayment signed:
+						stateHistory.Add(new JsonRpcResult
+						{
+							["status"] = "Signed",
+							["txid"] = signed.TransactionId.ToString()
+						});
+						break;
+
 					case FinishedPayment finished:
 						stateHistory.Add(new JsonRpcResult
 						{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinPayment/CoinJoinPaymentViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/CoinJoinPayment/CoinJoinPaymentViewModel.cs
@@ -31,7 +31,7 @@ public partial class CoinJoinPaymentViewModel : ViewModelBase
 
 	public bool IsPending => _payment.State is PendingPayment;
 
-	public bool IsInProgress => _payment.State is InProgressPayment;
+	public bool IsInProgress => _payment.State is InProgressPayment or SignedUnknownPayment;
 
 	public bool IsFinished => _payment.State is FinishedPayment;
 
@@ -48,7 +48,7 @@ public partial class CoinJoinPaymentViewModel : ViewModelBase
 		return _payment.State switch
 		{
 			PendingPayment => "Pending",
-			InProgressPayment => "In Progress",
+			InProgressPayment or SignedUnknownPayment => "In Progress",
 			FinishedPayment => "Completed",
 			_ => "Unknown"
 		};

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -350,9 +350,6 @@ public class CoinJoinClient
 
 			var (unsignedCoinJoin, aliceClientsThatSigned) = await ProceedWithSigningStateAsync(roundId, registeredAliceClients, outputTxOuts, cancellationToken).ConfigureAwait(false);
 
-			// Notify that we've signed the transaction - payments should now be tracked with the txId
-			CoinJoinClientProgress.SafeInvoke(this, new TransactionSigned(unsignedCoinJoin.GetHash()));
-
 			LogCoinJoinSummary(registeredAliceClients, outputTxOuts, roundState);
 
 			_liquidityClueProvider.UpdateLiquidityClue(roundState.CoinjoinState.Parameters.MaxSuggestedAmount, unsignedCoinJoin, outputTxOuts);
@@ -847,6 +844,15 @@ public class CoinJoinClient
 
 		var delayBeforeSigning = TimeSpan.FromSeconds(roundState.CoinjoinState.Parameters.DelayTransactionSigning ? 50 : 0);
 		var signingStateStartTime = DateTimeOffset.UtcNow + delayBeforeSigning;
+
+		// Once our last witness reaches the coordinator it can broadcast the transaction, whether or not
+		// we get to know it: the response can be lost, the round can be cancelled, the app can be closed.
+		// So the payments have to leave the in-progress state.
+		if (mustSignAllInputs)
+		{
+			CoinJoinClientProgress.SafeInvoke(this, new TransactionSigned(unsignedCoinJoin.Transaction.GetHash()));
+		}
+
 		await SignTransactionAsync(alicesToSign, unsignedCoinJoin, signingStateStartTime, signingStateEndTime, combinedToken).ConfigureAwait(false);
 		Logger.LogInfo(FormatLog($"{alicesToSign.Length} out of {registeredAliceClients.Length} of your Alices have signed the coinjoin transaction.", roundState));
 


### PR DESCRIPTION
A coinjoin payment can still be paid twice after #14998, because the protection is keyed on our bookkeeping rather than on the act of signing.

Example:

1. Alice posts her payment witness, the coordinator stores it.
2. The response is lost (i.e., dead circus or timeout)
3. TransactionSigned never fires, so the payment is still InProgressPayment.

The fix is to fire `TransactionSigned` immediately before the first witness is posted instead of after the last one is acknowledged.

Tradeoff: A round that fails after we start signing strands the payment in the signed state. A recovery path for stranded payments is left for a separate PR.

Disclaimer: Code written with AI.