### PR TITLE
Fix coinjoin stalling when the only non-private coins are banned

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -67,9 +67,9 @@ public class CoinJoinCoinSelectionTests
 	}
 
 	/// <summary>
-	/// This test is to make sure private coins are selected to fund a payment when the user opted in to
-	/// pay in coinjoin regardless of the anonymity score. In that case <see cref="CoinJoinCoinSelector.FromWallet"/>
-	/// lifts the anonymity score target so every private coin becomes selectable.
+	/// This test is to make sure private coins are selected to fund a pending payment when there is
+	/// nothing left to mix. In that case <see cref="CoinJoinCoinSelector.SelectCoinsForRound"/> lifts the
+	/// anonymity score target so every private coin becomes selectable.
 	/// </summary>
 	[Fact]
 	public void SelectPrivateCoinsToPayRegardlessOfAnonScore()
@@ -90,7 +90,7 @@ public class CoinJoinCoinSelectionTests
 		}
 
 		CoinJoinCoinSelectorRandomnessGenerator generator = CreateSelectorGenerator(inputTarget: 5);
-		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: int.MaxValue, semiPrivateThreshold: 0, generator);
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: AnonymitySet, semiPrivateThreshold: 0, generator, arePaymentsPending: () => true);
 
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
 			coins: coinsToSelectFrom,
@@ -99,6 +99,48 @@ public class CoinJoinCoinSelectionTests
 
 		Assert.NotEmpty(coins);
 		Assert.All(coins, coin => Assert.Contains(coin, coinsToSelectFrom));
+	}
+
+	/// <summary>
+	/// Issue #15015: banned coins are subtracted from the candidates by the coinjoin manager, so a wallet
+	/// whose only non-private coins are banned offers nothing but private coins here. A pending payment
+	/// must still be funded instead of aborting the round with NoCoinsEligibleToMix.
+	/// </summary>
+	[Fact]
+	public void SelectPrivateCoinsToPayWhenTheOnlyNonPrivateCoinsAreBanned()
+	{
+		const int AnonymitySet = 10;
+		var km = KeyManager.CreateNew(out _, "", Network.Main);
+
+		// The semi-private coin is banned, hence it is not among the candidates - only private coins are.
+		var coinCandidates = Enumerable
+			.Range(0, 10)
+			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1))
+			.ToList();
+
+		// Make sure the distance from external keys is sufficient.
+		foreach (var sc in coinCandidates)
+		{
+			var sci = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1);
+			sci.Transaction.TryAddWalletInput(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1));
+			sc.Transaction.TryAddWalletInput(sci);
+		}
+
+		CoinJoinCoinSelectorRandomnessGenerator generator = CreateSelectorGenerator(inputTarget: 5);
+		var coinJoinCoinSelector = new CoinJoinCoinSelector(
+			consolidationMode: false,
+			anonScoreTarget: AnonymitySet,
+			semiPrivateThreshold: Constants.SemiPrivateThreshold,
+			generator,
+			arePaymentsPending: () => true);
+
+		var coins = coinJoinCoinSelector.SelectCoinsForRound(
+			coins: coinCandidates,
+			CreateUtxoSelectionParameters(),
+			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
+
+		Assert.NotEmpty(coins);
+		Assert.All(coins, coin => Assert.Contains(coin, coinCandidates));
 	}
 
 	[Fact]

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinClient.cs
@@ -163,6 +163,14 @@ public class CoinJoinClient
 				continue;
 			}
 
+			if (myCoins.IsEmpty)
+			{
+				excludeRound = currentRoundState.Id;
+				Logger.LogInfo(FormatLog("Skipping the round since none of the wallet's coins is suitable for it.", currentRoundState));
+
+				continue;
+			}
+
 			if (roundParameters.MaxSuggestedAmount != default && myCoins.Any(c => c.Amount > roundParameters.MaxSuggestedAmount))
 			{
 				excludeRound = currentRoundState.Id;
@@ -177,7 +185,7 @@ public class CoinJoinClient
 
 		if (myCoins.IsEmpty)
 		{
-			throw new CoinJoinClientException(CoinjoinError.NoCoinsEligibleToMix, $"No coin was selected from '{coinCandidates.Count()}' number of coins. Probably it was not economical, total amount of coins were: {Money.Satoshis(coinCandidates.Sum(c => c.Amount))} BTC.");
+			throw new CoinJoinClientException(CoinjoinError.NoCoinsEligibleToMix, $"Stopped looking for a suitable round. No coin was selected from '{coinCandidates.Count()}' number of coins, total amount of coins were: {Money.Satoshis(coinCandidates.Sum(c => c.Amount))} BTC.");
 		}
 
 		IRoundRestrictions roundRestrictions = UnrestrictedRound.Instance;

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
@@ -12,17 +12,20 @@ public class CoinJoinCoinSelector
 	/// <param name="consolidationMode">If true it attempts to select as many coins as it can.</param>
 	/// <param name="anonScoreTarget">Tries to select few coins over this threshold.</param>
 	/// <param name="semiPrivateThreshold">Minimum anonymity of coins that can be selected together.</param>
+	/// <param name="arePaymentsPending">Tells whether there is a coinjoin payment waiting to be funded.</param>
 	public CoinJoinCoinSelector(
 		bool consolidationMode,
 		int anonScoreTarget,
 		int semiPrivateThreshold,
-		CoinJoinCoinSelectorRandomnessGenerator? generator = null)
+		CoinJoinCoinSelectorRandomnessGenerator? generator = null,
+		Func<bool>? arePaymentsPending = null)
 	{
 		ConsolidationMode = consolidationMode;
 		AnonScoreTarget = anonScoreTarget;
 		SemiPrivateThreshold = semiPrivateThreshold;
 
 		_generator = generator ?? new(MaxInputsRegistrableByWallet, RandomnessProviders.Secure);
+		_arePaymentsPending = arePaymentsPending ?? (() => false);
 	}
 
 	public bool ConsolidationMode { get; }
@@ -30,17 +33,14 @@ public class CoinJoinCoinSelector
 	public int SemiPrivateThreshold { get; }
 	private RandomnessProvider Rnd => _generator.Rnd;
 	private readonly CoinJoinCoinSelectorRandomnessGenerator _generator;
+	private readonly Func<bool> _arePaymentsPending;
 
-	public static CoinJoinCoinSelector FromWallet(Wallet wallet)
-	{
-		var payWithPrivateCoins = wallet.IsWalletPrivate()
-			&& wallet.BatchedPayments.AreTherePendingPayments;
-
-		return new(
+	public static CoinJoinCoinSelector FromWallet(Wallet wallet) =>
+		new(
 			wallet.ConsolidationMode,
-			payWithPrivateCoins ? int.MaxValue : wallet.AnonScoreTarget,
-			wallet.NonPrivateCoinIsolation ? Constants.SemiPrivateThreshold : 0);
-	}
+			wallet.AnonScoreTarget,
+			wallet.NonPrivateCoinIsolation ? Constants.SemiPrivateThreshold : 0,
+			arePaymentsPending: () => wallet.BatchedPayments.AreTherePendingPayments);
 
 	/// <param name="liquidityClue">Weakly prefer not to select inputs over this.</param>
 	public ImmutableList<SmartCoin> SelectCoinsForRound(IEnumerable<SmartCoin> coins, UtxoSelectionParameters parameters, Money liquidityClue)
@@ -62,11 +62,15 @@ public class CoinJoinCoinSelector
 			return ImmutableList<SmartCoin>.Empty;
 		}
 
+		var effectiveAnonScoreTarget = _arePaymentsPending() && filteredCoins.All(x => x.IsPrivate(AnonScoreTarget))
+			? int.MaxValue
+			: AnonScoreTarget;
+
 		var privateCoins = filteredCoins
-			.Where(x => x.IsPrivate(AnonScoreTarget))
+			.Where(x => x.IsPrivate(effectiveAnonScoreTarget))
 			.ToArray();
 		var semiPrivateCoins = filteredCoins
-			.Where(x => x.IsSemiPrivate(AnonScoreTarget, SemiPrivateThreshold))
+			.Where(x => x.IsSemiPrivate(effectiveAnonScoreTarget, SemiPrivateThreshold))
 			.ToArray();
 
 		// redCoins will only fill up if redCoinIsolation is turned on. Otherwise the coin will be in semiPrivateCoins.


### PR DESCRIPTION
Closes https://github.com/WalletWasabi/WalletWasabi/issues/15015.

This is *one* solution to the problem. I'm not crazy about it. 

Code generated with AI.